### PR TITLE
Field report authorization

### DIFF
--- a/api/authorization.py
+++ b/api/authorization.py
@@ -1,0 +1,7 @@
+from tastypie.authorization import DjangoAuthorization
+
+# Overwrite Django authorization to allow
+# anyone to create a field report
+class FieldReportAuthorization(DjangoAuthorization):
+    def create_detail(self, object_list, bundle):
+        return True

--- a/api/authorization.py
+++ b/api/authorization.py
@@ -1,7 +1,13 @@
 from tastypie.authorization import DjangoAuthorization
 
 # Overwrite Django authorization to allow
-# anyone to create a field report
+# anyone to read or create a field report
 class FieldReportAuthorization(DjangoAuthorization):
+    def read_list(self, object_list, bundle):
+        return True
+
+    def read_detail(self, object_list, bundle):
+        return True
+
     def create_detail(self, object_list, bundle):
         return True

--- a/api/resources.py
+++ b/api/resources.py
@@ -1,6 +1,6 @@
 from tastypie import fields
 from tastypie.resources import ModelResource, ALL_WITH_RELATIONS
-from tastypie.authorization import DjangoAuthorization
+from tastypie.authorization import Authorization, DjangoAuthorization
 from django.contrib.auth.models import User
 from .models import DisasterType, Event, Country, FieldReport, Profile
 from .authentication import ExpiringApiKeyAuthentication
@@ -11,6 +11,8 @@ class DisasterTypeResource(ModelResource):
     class Meta:
         queryset = DisasterType.objects.all()
         resource_name = 'disaster_type'
+        allowed_methods = ['get']
+        authorization = Authorization()
 
 
 class EventResource(ModelResource):
@@ -23,12 +25,17 @@ class CountryResource(ModelResource):
     class Meta:
         queryset = Country.objects.all()
         resource_name = 'country'
+        allowed_methods = ['get']
+        authorization = Authorization()
 
 
 class FieldReportResource(ModelResource):
+    dtype = fields.ForeignKey(DisasterTypeResource, 'dtype', full=True)
+    countries = fields.ToManyField(CountryResource, 'countries', full=True)
     class Meta:
         queryset = FieldReport.objects.all()
         resource_name = 'field_report'
+        always_return_data = True
         authentication = ExpiringApiKeyAuthentication()
         authorization = FieldReportAuthorization()
 
@@ -52,7 +59,7 @@ class ProfileResource(ModelResource):
     class Meta:
         queryset = Profile.objects.all()
         list_allowed_methods = ['get']
-        detail_allowed_methods = ['get', 'post', 'put', 'patch']
+        detail_allowed_methods = ['get']
         resource_name = 'profile'
         filtering = {
             'user': ALL_WITH_RELATIONS,

--- a/api/resources.py
+++ b/api/resources.py
@@ -4,6 +4,7 @@ from tastypie.authorization import DjangoAuthorization
 from django.contrib.auth.models import User
 from .models import DisasterType, Event, Country, FieldReport, Profile
 from .authentication import ExpiringApiKeyAuthentication
+from .authorization import FieldReportAuthorization
 
 
 class DisasterTypeResource(ModelResource):
@@ -29,6 +30,7 @@ class FieldReportResource(ModelResource):
         queryset = FieldReport.objects.all()
         resource_name = 'field_report'
         authentication = ExpiringApiKeyAuthentication()
+        authorization = FieldReportAuthorization()
 
 
 class UserResource(ModelResource):
@@ -42,6 +44,7 @@ class UserResource(ModelResource):
             'username': ('exact'),
         }
         authentication = ExpiringApiKeyAuthentication()
+        authorization = DjangoAuthorization()
 
 
 class ProfileResource(ModelResource):
@@ -55,3 +58,4 @@ class ProfileResource(ModelResource):
             'user': ALL_WITH_RELATIONS,
         }
         authentication = ExpiringApiKeyAuthentication()
+        authorization = DjangoAuthorization()


### PR DESCRIPTION
@matthewhanson For some reason, applying a default user group to every user made the ingest process a heckuva lot longer.

Plus, if every user is part of this user group than user groups probably aren't the right tool for it anyway. So I used an authorization class instead. Some notes:

1. The base `Authorization` class authorizes everything. In order for me to `POST` anything to the field report resource, I had to set the countries and disaster types (related fields) to `Authorization`. Not sure why this is the case, but I restricted those resources to `GET` only so I think we're ok there.

1. The `DjangoAuthorization` class but is actually quite restrictive. For example, `read_list` isn't granted by default. This is pretty easy to extend, fortunately. Also I think it's the right class for the `UserResource`.