### PR TITLE
Turn off debug for json error messages

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -27,7 +27,7 @@ class es_keyword_search(PublicJsonRequestView):
         if keyword is None:
             return JsonResponse({
                 'statusCode': 400,
-                'message': 'Must include a `keyword`'
+                'error_message': 'Must include a `keyword`'
             }, status=400)
 
         query = {
@@ -53,13 +53,13 @@ def get_auth_token(request):
     if request.META.get('CONTENT_TYPE') != 'application/json':
         return JsonResponse({
             'statusCode': 400,
-            'message': 'Content-type must be `application/json`'
+            'error_message': 'Content-type must be `application/json`'
         }, status=400)
 
     elif request.method != 'POST':
         return JsonResponse({
             'statusCode': 400,
-            'message': 'HTTP method must be `POST`'
+            'error_message': 'HTTP method must be `POST`'
         }, status=400)
 
     else:
@@ -69,7 +69,7 @@ def get_auth_token(request):
         if not username or not password:
             return JsonResponse({
                 'statusCode': 400,
-                'message': 'Body must contain `username` and `password`'
+                'error_message': 'Body must contain `username` and `password`'
             }, status=400)
 
         user = authenticate(username=username, password=password)
@@ -85,5 +85,5 @@ def get_auth_token(request):
         else:
             return JsonResponse({
                 'statusCode': 400,
-                'message': 'Could not authenticate'
+                'error_message': 'Could not authenticate'
             }, status=400)

--- a/main/settings.py
+++ b/main/settings.py
@@ -6,7 +6,7 @@ localhost = 'localhost'
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
-DEBUG = True
+DEBUG = False
 ALLOWED_HOSTS = [localhost, frontend_url,]
 
 INSTALLED_APPS = [


### PR DESCRIPTION
@danielfdsilva I tried a few things to wrap the default error response but it was more trouble than I anticipated. However, turning off `debug` seems to get us close to what we want. Instead of the original messages, in a few tests I've gotten this instead:

`{"error_message": "Sorry, this request could not be processed. Please try again later."}`

I can switch over the other messages to mimic this but don't think I can expend more effort trying to change these now. 