### PR TITLE
Change dref ingest

### DIFF
--- a/api/management/commands/ingest_appeals.py
+++ b/api/management/commands/ingest_appeals.py
@@ -75,13 +75,20 @@ class Command(BaseCommand):
             else:
                 detail = sorted(r['Details'], reverse=True, key=lambda x: self.parse_date(x['APD_startDate']))[0]
 
-            amount_funded = 0 if detail['ContributionAmount'] is None else detail['ContributionAmount']
             atypes = {66: AppealType.DREF, 64: AppealType.APPEAL, 1537: AppealType.INTL}
+            atype = atypes[detail['APD_TYP_Id']]
+
+            if atype == AppealType.DREF:
+                # appeals are always fully-funded
+                amount_funded = detail['APD_amountCHF']
+            else:
+                amount_funded = 0 if detail['ContributionAmount'] is None else detail['ContributionAmount']
+
             fields = {
                 'aid': r['APP_Id'],
                 'name': r['APP_name'],
                 'dtype': dtype,
-                'atype': atypes[detail['APD_TYP_Id']],
+                'atype': atype,
 
                 'country': country,
                 'region': region,

--- a/api/management/commands/ingest_mdb.py
+++ b/api/management/commands/ingest_mdb.py
@@ -200,7 +200,7 @@ class Command(BaseCommand):
                 record.update({
                     'rdrt': {'': 0, 'No': 0, 'Yes': 3, 'Planned/Requested': 2}[response['RDRT']],
                     'fact': {'': 0, 'No': 0, 'Yes': 3, 'Planned/Requested': 2}[response['FACT']],
-                    #'eru': {'': 0, 'Yes': 3, 'Planned/Requested': 2, 'No': 0}[response['ERU']]
+                    'eru_relief': {'': 0, 'Yes': 3, 'Planned/Requested': 2, 'No': 0}[response['ERU']]
                 })
 
             field_report = FieldReport(**record)

--- a/api/management/commands/ingest_mdb.py
+++ b/api/management/commands/ingest_mdb.py
@@ -10,6 +10,7 @@ from ftplib import FTP
 from zipfile import ZipFile
 from django.core.management.base import BaseCommand
 from django.contrib.auth.models import User
+from django.core.exceptions import ObjectDoesNotExist
 from api.models import DisasterType, Country, FieldReport, Action, ActionsTaken, Contact, SourceType, Source
 from api.fixtures.dtype_map import PK_MAP
 
@@ -207,7 +208,7 @@ class Command(BaseCommand):
 
             try:
                 country = Country.objects.select_related().get(pk=report['CountryID'])
-            except Country.DoesNotExist():
+            except ObjectDoesNotExist:
                 print('Could not find a matching country for %s' % report['CountryID'])
                 country = None
 
@@ -298,7 +299,7 @@ class Command(BaseCommand):
 
             try:
                 user = User.objects.get(username=user_data['UserName'])
-            except User.DoesNotExist:
+            except ObjectDoesNotExist:
                 user = None
 
             if user is None:


### PR DESCRIPTION
- Set DREF contribution amount to always equal requested amount, since DREFs come from esiting funds (and not on-the-fly fundraising).
- Fix an issue with catching `DoesNotExist` 
- Sets historic ERU as the currnet "relief" ERU subcategory.