### PR TITLE
Remove event editable fields from list view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Appeals now order by start date, not end date.
 - Events now have a column for where they were auto-generated from.
 
+### Removed
+
+- Removed event editable fields from appeal, field report list admin views.
+
 ## 1.0.0
 
 ### Added

--- a/api/admin.py
+++ b/api/admin.py
@@ -161,7 +161,6 @@ class FieldReportContactInline(admin.TabularInline):
 class FieldReportAdmin(admin.ModelAdmin):
     inlines = [ActionsTakenInline, SourceInline, FieldReportContactInline]
     list_display = ('summary', 'event', 'visibility',)
-    list_editable = ('event',)
     list_select_related = ('event',)
     search_fields = ['countries', 'regions', 'summary',]
     autocomplete_fields = ('countries', 'districts',)
@@ -196,7 +195,6 @@ class AppealDocumentInline(admin.TabularInline):
 class AppealAdmin(admin.ModelAdmin):
     inlines = [AppealDocumentInline]
     list_display = ('code', 'name', 'atype', 'needs_confirmation', 'event', 'start_date',)
-    list_editable = ('event',)
     list_select_related = ('event',)
     search_fields = ['code', 'name',]
     readonly_fields = ('region',)


### PR DESCRIPTION
Removes editable event fields from list views.

This was causing huge slow-downs in loading the admin panels, because a huge dropdown of events had to be populated for each row of data.

## Checklist 
Things that should succeed before merging.

- [x] Updated/ran unit tests
- [x] Updated CHANGELOG.md