### PR TITLE
Create geographical restrictions to admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Default country and regional user group and permissions.
+- A regionally restricted admin class to filter querysets depending on a user's permissions.
 - Logging to Azure Queue storage.
 - A cron job to detet changes to field reports, events, and appeals, and index them to elasticsearch/notify subscribers.
 - Add a CSV renderer so data can be exported as CSV for any model.

--- a/api/admin.py
+++ b/api/admin.py
@@ -3,6 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.html import format_html_join
 from django.utils.safestring import mark_safe
 from api.event_sources import SOURCES
+from api.admin_classes import RegionRestrictedAdmin
 import api.models as models
 
 
@@ -122,7 +123,10 @@ class SituationReportInline(admin.TabularInline):
     model = models.SituationReport
 
 
-class EventAdmin(admin.ModelAdmin):
+class EventAdmin(RegionRestrictedAdmin):
+    country_in = 'countries__pk__in'
+    region_in = 'regions__pk__in'
+
     inlines = [KeyFigureInline, SnippetInline, EventContactInline, SituationReportInline]
     list_display = ('name', 'alert_level', 'glide', 'auto_generated', 'auto_generated_source',)
     list_filter = [IsFeaturedFilter, EventSourceFilter,]
@@ -150,7 +154,9 @@ class EventAdmin(admin.ModelAdmin):
     field_reports.short_description = 'Field Reports'
 
 
-class GdacsAdmin(admin.ModelAdmin):
+class GdacsAdmin(RegionRestrictedAdmin):
+    country_in = 'countries__pk__in'
+    region_in = None
     search_fields = ('title',)
 
 
@@ -166,7 +172,10 @@ class FieldReportContactInline(admin.TabularInline):
     model = models.FieldReportContact
 
 
-class FieldReportAdmin(admin.ModelAdmin):
+class FieldReportAdmin(RegionRestrictedAdmin):
+    country_in = 'countries__pk__in'
+    region_in = 'regions__pk__in'
+
     inlines = [ActionsTakenInline, SourceInline, FieldReportContactInline]
     list_display = ('summary', 'event', 'visibility',)
     list_select_related = ('event',)
@@ -201,7 +210,9 @@ class AppealDocumentInline(admin.TabularInline):
     model = models.AppealDocument
 
 
-class AppealAdmin(admin.ModelAdmin):
+class AppealAdmin(RegionRestrictedAdmin):
+    country_in = 'country__pk__in'
+    region_in = 'region__pk__in'
     inlines = [AppealDocumentInline]
     list_display = ('code', 'name', 'atype', 'needs_confirmation', 'event', 'start_date',)
     list_select_related = ('event',)
@@ -249,7 +260,9 @@ class AppealAdmin(admin.ModelAdmin):
         super().save_model(request, obj, form, change)
 
 
-class AppealDocumentAdmin(admin.ModelAdmin):
+class AppealDocumentAdmin(RegionRestrictedAdmin):
+    country_in = 'appeal__country__in'
+    region_in = 'appeal__region__in'
     search_fields = ('name', 'appeal__code', 'appeal__name')
 
 
@@ -285,16 +298,22 @@ class RegionContactInline(admin.TabularInline):
     model = models.RegionContact
 
 
-class DistrictAdmin(admin.ModelAdmin):
+class DistrictAdmin(RegionRestrictedAdmin):
+    country_in = 'country__pk__in'
+    region_in = 'country__region__in'
     search_fields = ('name', 'country_name',)
 
 
-class CountryAdmin(admin.ModelAdmin):
+class CountryAdmin(RegionRestrictedAdmin):
+    country_in = 'pk__in'
+    region_in = 'region__pk__in'
     search_fields = ('name',)
     inlines = [CountryKeyFigureInline, CountrySnippetInline, CountryLinkInline, CountryContactInline,]
 
 
-class RegionAdmin(admin.ModelAdmin):
+class RegionAdmin(RegionRestrictedAdmin):
+    country_in = None
+    region_in = 'pk__in'
     inlines = [RegionKeyFigureInline, RegionSnippetInline, RegionLinkInline, RegionContactInline,]
     search_fields = ('name',)
 
@@ -303,7 +322,9 @@ class UserProfileAdmin(admin.ModelAdmin):
     search_fields = ('user__username', 'user__email',)
 
 
-class SituationReportAdmin(admin.ModelAdmin):
+class SituationReportAdmin(RegionRestrictedAdmin):
+    country_in = 'event__countries__in'
+    region_in = 'event__regions__in'
     search_fields = ('name', 'event__name',)
 
 

--- a/api/admin_classes.py
+++ b/api/admin_classes.py
@@ -23,7 +23,7 @@ class RegionRestrictedAdmin(admin.ModelAdmin):
         return countries, regions
 
     def get_filtered_queryset(self, request, queryset):
-        if request.user.is_superuser:
+        if request.user.is_superuser or request.user.has_perm('api.ifrc_admin'):
             return queryset
         countries, regions = self.get_request_user_regions(request)
 

--- a/api/admin_classes.py
+++ b/api/admin_classes.py
@@ -1,0 +1,50 @@
+from django.contrib import admin
+from django.db.models import Q
+
+# Extend the model admin with methods for determining whether a user has
+# country- and region-specific permissions.
+# If the user does not have specific permissions for any country or region,
+# the result is an empty queryset.
+
+class RegionRestrictedAdmin(admin.ModelAdmin):
+    def get_request_user_regions(self, request):
+        permissions = request.user.get_all_permissions()
+        regions = []
+        countries = []
+        for permission_name in permissions:
+            if 'api.country_admin_' in permission_name:
+                country_id = permission_name[18:]
+                if country_id.isdigit():
+                    countries.append(country_id)
+            elif 'api.region_admin_' in permission_name:
+                region_id = permission_name[17:]
+                if region_id.isdigit():
+                    regions.append(region_id)
+        return countries, regions
+
+    def get_filtered_queryset(self, request, queryset):
+        if request.user.is_superuser:
+            return queryset
+        countries, regions = self.get_request_user_regions(request)
+
+        # No countries and regions are present;
+        # return an empty queryset
+        if not len(countries) and not len(regions):
+            return queryset.none()
+
+        # Create an OR filter for records relating to this country or region
+        country_in = getattr(self, 'country_in', None)
+        region_in = getattr(self, 'region_in', None)
+        query = Q()
+        has_valid_query = False
+        if len(countries) and country_in is not None:
+            query.add(Q(**{country_in: countries}), Q.OR)
+            has_valid_query = True
+        if len(regions) and region_in is not None:
+            query.add(Q(**{region_in: regions}), Q.OR)
+            has_valid_query = True
+        return queryset.filter(query) if has_valid_query else queryset.none()
+
+    def get_queryset(self, request):
+        queryset = super(admin.ModelAdmin, self).get_queryset(request)
+        return self.get_filtered_queryset(request, queryset)

--- a/api/management/commands/make_permissions.py
+++ b/api/management/commands/make_permissions.py
@@ -35,6 +35,6 @@ class Command(BaseCommand):
             )
             # If it's a new permission, create a group for it
             group, created = Group.objects.get_or_create(
-                name='%s Admins' % region.name
+                name='%s Regional Admins' % region.name
             )
             group.permissions.add(permission)

--- a/api/management/commands/make_permissions.py
+++ b/api/management/commands/make_permissions.py
@@ -1,0 +1,40 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
+from api.models import Country, Region
+
+class Command(BaseCommand):
+    help = 'Create standard geographic permissions classes and groups'
+
+    def handle(self, *args, **options):
+        country_content_type = ContentType.objects.get_for_model(Country)
+        countries = Country.objects.all()
+        for country in countries:
+            codename = 'country_admin_%s' % country.id
+            name = 'Admin for %s' % country.name
+            permission, created = Permission.objects.get_or_create(
+                codename=codename,
+                name=name,
+                content_type=country_content_type
+            )
+            # If it's a new permission, create a group for it
+            group, created = Group.objects.get_or_create(
+                name='%s Admins' % country.name
+            )
+            group.permissions.add(permission)
+
+        region_content_type = ContentType.objects.get_for_model(Region)
+        regions = Region.objects.all()
+        for region in regions:
+            codename = 'region_admin_%s' % region.id
+            name = 'Admin for %s' % region.name
+            permission, created = Permission.objects.get_or_create(
+                codename=codename,
+                name=name,
+                content_type=region_content_type
+            )
+            # If it's a new permission, create a group for it
+            group, created = Group.objects.get_or_create(
+                name='%s Admins' % region.name
+            )
+            group.permissions.add(permission)

--- a/api/management/commands/make_permissions.py
+++ b/api/management/commands/make_permissions.py
@@ -38,3 +38,15 @@ class Command(BaseCommand):
                 name='%s Regional Admins' % region.name
             )
             group.permissions.add(permission)
+
+        # Create an IFRC permission and attach it to a group
+        ifrc_permission, perm_created = Permission.objects.get_or_create(
+            codename='ifrc_admin',
+            name='IFRC Admin',
+            content_type=ContentType.objects.get_for_model(Country),
+        )
+
+        ifrc_group, group_created = Group.objects.get_or_create(
+            name='IFRC Admins'
+        )
+        ifrc_group.permissions.add(ifrc_permission)

--- a/deployments/admin.py
+++ b/deployments/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 import deployments.models as models
+from api.admin_classes import RegionRestrictedAdmin
 
 
 class ERUInline(admin.TabularInline):
@@ -7,13 +8,17 @@ class ERUInline(admin.TabularInline):
     autocomplete_fields = ('deployed_to', 'event',)
 
 
-class ERUOwnerAdmin(admin.ModelAdmin):
+class ERUOwnerAdmin(RegionRestrictedAdmin):
+    country_in = 'national_society_country__in'
+    region_in = 'national_society_country__region__in'
     inlines = [ERUInline]
     autocomplete_fields = ('national_society_country',)
     search_fields = ('national_society_country__name',)
 
 
-class HeopAdmin(admin.ModelAdmin):
+class HeopAdmin(RegionRestrictedAdmin):
+    country_in = 'country__pk__in'
+    region_in = 'region__pk__in'
     search_fields = ('country__name', 'region__name', 'person', 'role',)
 
 
@@ -21,7 +26,9 @@ class FactPersonInline(admin.TabularInline):
     model = models.FactPerson
 
 
-class FactAdmin(admin.ModelAdmin):
+class FactAdmin(RegionRestrictedAdmin):
+    country_in = 'country__pk__in'
+    region_in = 'region__pk__in'
     inlines = [FactPersonInline]
     search_fields = ('country__name', 'region__name',)
 
@@ -30,7 +37,9 @@ class RdrtPersonInline(admin.TabularInline):
     model = models.RdrtPerson
 
 
-class RdrtAdmin(admin.ModelAdmin):
+class RdrtAdmin(RegionRestrictedAdmin):
+    country_in = 'country__pk__in'
+    region_in = 'region__pk__in'
     inlines = [RdrtPersonInline]
     search_fields = ('country__name', 'region__name',)
 
@@ -39,7 +48,9 @@ class PartnerSocietyActivityAdmin(admin.ModelAdmin):
     search_fields = ('activity',)
 
 
-class PartnerSocietyDeploymentAdmin(admin.ModelAdmin):
+class PartnerSocietyDeploymentAdmin(RegionRestrictedAdmin):
+    country_in = 'parent_society__in'
+    region_in = 'parent_society__region__in'
     autocomplete_fields = ('parent_society', 'country_deployed_to', 'district_deployed_to',)
     search_fields = ('activity__activity', 'name', 'role', 'country_deployed_to__name', 'parent_society__name', 'district_deployed_to__name',)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,10 @@ services:
     <<: *base_django_setup
     command: python manage.py makemigrations
 
+  make_permissions:
+    <<: *base_django_setup
+    command: python manage.py make_permissions
+
   test:
     <<: *base_django_setup
     command: python manage.py test -k

--- a/notifications/admin.py
+++ b/notifications/admin.py
@@ -1,7 +1,10 @@
 from django.contrib import admin
 import notifications.models as models
+from api.admin_classes import RegionRestrictedAdmin
 
-class SurgeAlertAdmin(admin.ModelAdmin):
+class SurgeAlertAdmin(RegionRestrictedAdmin):
+    country_in = 'event__countries__in'
+    region_in = 'event__regions__in'
     autocomplete_fields = ('event',)
     search_fields = ('operation', 'message', 'event__name',)
 


### PR DESCRIPTION
Depends on #256

Adds a geographical restriction admin class that defaults to showing no records. If the child class has either `country_in` or `region_in` set, it will use that property to filter for countries or regions that child class is related to.

Also includes a script to generate default country and regional groups, with the proper country and region permission added.

Finally, generates an IFRC group. If the user is in the IFRC group, or is a superuser, all the geographically restricted admins will show the entire queryset.

## Checklist 
Things that should succeed before merging.

- [x] Updated/ran unit tests
- [x] Updated CHANGELOG.md