### PR TITLE
Feature/automatic emergency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- New field reports, when created at the `api/v2/create_field_report` endpoint, will create an attached emergency if none is attached already.
 - Add views to create, edit field reports.
 - Create a separate API route for emergency snippets.
 - Add an API path for viewing elasticsearch cluster health.

--- a/api/event_sources.py
+++ b/api/event_sources.py
@@ -3,4 +3,5 @@ SOURCES = {
     'report_ingest': 'Field report DMIS ingest',
     'report_admin': 'Field report admin',
     'appeal_admin': 'Appeal admin',
+    'new_report': 'New field report',
 }

--- a/api/test_views.py
+++ b/api/test_views.py
@@ -54,7 +54,7 @@ class FieldReportTest(APITestCase):
 
     fixtures = ['DisasterTypes', 'Actions']
 
-    def test_create(self):
+    def test_create_and_update(self):
         user = User.objects.create(username='jo')
         region = models.Region.objects.create(name=1)
         country1 = models.Country.objects.create(name='abc', region=region)
@@ -86,7 +86,7 @@ class FieldReportTest(APITestCase):
         created = models.FieldReport.objects.get(pk=response['id'])
 
         self.assertEqual(created.countries.count(), 2)
-        # one region created automatically
+        # one region attached automatically
         self.assertEqual(created.regions.count(), 1)
 
         self.assertEqual(created.sources.count(), 2)
@@ -104,6 +104,10 @@ class FieldReportTest(APITestCase):
         self.assertEqual(created.visibility, 1)
         self.assertEqual(created.dtype.id, 7)
         self.assertEqual(created.summary, 'test')
+
+        # created an emergency automatically
+        self.assertEqual(created.event.name, 'test')
+        event_pk = created.event.id
 
         body['countries'] = [country2.id]
         body['sources'] = [
@@ -129,3 +133,5 @@ class FieldReportTest(APITestCase):
         self.assertEqual(updated.actions_taken.count(), 0)
         self.assertEqual(updated.contacts.count(), 1)
         self.assertEqual(updated.visibility, 2)
+        # emergency still attached
+        self.assertEqual(updated.event.id, event_pk)


### PR DESCRIPTION
Closes https://github.com/IFRCGo/go-frontend/issues/314

## Changes

- When a field report is posted to `api/v2/create_field_report`, if there is no emergency attached to it, will create and attach an emergency.

## Checklist 
Things that should succeed before merging.

- [x] Updated/ran unit tests
- [x] Updated CHANGELOG.md