### PR TITLE
We use all records, do NOT check if last_modified > since_last_checked

### DIFF
--- a/api/management/commands/ingest_appeals.py
+++ b/api/management/commands/ingest_appeals.py
@@ -42,14 +42,12 @@ class Command(BaseCommand):
             with open('appeals.json', 'w') as outfile:
                 json.dump(records, outfile)
 
-            since_last_checked = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(minutes=90)
             codes = [a.code for a in Appeal.objects.all()]
             for r in records:
                 if not r['APP_code'] in codes:
                     new.append(r)
-                last_modified = self.parse_date(r['APP_modifyTime'])
-                if last_modified > since_last_checked:
-                    modified.append(r)
+                # We use all records, do NOT check if last_modified > since_last_checked
+                modified.append(r)
 
         return new, modified
 

--- a/api/management/commands/ingest_appeals.py
+++ b/api/management/commands/ingest_appeals.py
@@ -42,14 +42,12 @@ class Command(BaseCommand):
             with open('appeals.json', 'w') as outfile:
                 json.dump(records, outfile)
 
-            in_4_years = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(days=1460)
             codes = [a.code for a in Appeal.objects.all()]
             for r in records:
                 if not r['APP_code'] in codes:
                     new.append(r)
-                last_modified = self.parse_date(r['APP_modifyTime'])
-                if last_modified > in_4_years:
-                    modified.append(r)
+                # We use all records, do NOT check if last_modified > since_last_checked
+                modified.append(r)
 
         return new, modified
 

--- a/api/management/commands/ingest_appeals.py
+++ b/api/management/commands/ingest_appeals.py
@@ -42,12 +42,14 @@ class Command(BaseCommand):
             with open('appeals.json', 'w') as outfile:
                 json.dump(records, outfile)
 
+            in_3_years = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(days=1095)
             codes = [a.code for a in Appeal.objects.all()]
             for r in records:
                 if not r['APP_code'] in codes:
                     new.append(r)
-                # We use all records, do NOT check if last_modified > since_last_checked
-                modified.append(r)
+                last_modified = self.parse_date(r['APP_modifyTime'])
+                if last_modified > in_3_years:
+                    modified.append(r)
 
         return new, modified
 

--- a/api/management/commands/ingest_appeals.py
+++ b/api/management/commands/ingest_appeals.py
@@ -42,13 +42,13 @@ class Command(BaseCommand):
             with open('appeals.json', 'w') as outfile:
                 json.dump(records, outfile)
 
-            in_3_years = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(days=1095)
+            in_4_years = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(days=1460)
             codes = [a.code for a in Appeal.objects.all()]
             for r in records:
                 if not r['APP_code'] in codes:
                     new.append(r)
                 last_modified = self.parse_date(r['APP_modifyTime'])
-                if last_modified > in_3_years:
+                if last_modified > in_4_years:
                     modified.append(r)
 
         return new, modified


### PR DESCRIPTION
A useful feature now omitted due to Natig's new financial API solution,
removing:
                since_last_checked = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(minutes=90)
                last_modified = self.parse_date(r['APP_modifyTime'])
                if last_modified > since_last_checked:
