### PR TITLE
Wire in MDR65002 to avoid automatic overwriting

### DIFF
--- a/api/management/commands/ingest_appeals.py
+++ b/api/management/commands/ingest_appeals.py
@@ -74,6 +74,9 @@ class Command(BaseCommand):
 
             codes = [a.code for a in Appeal.objects.all()]
             for r in records:
+                # Temporary filtering, the manual version should be kept:
+                if r['APP_code'] in ['MDR65002']:
+                    continue
                 if not r['APP_code'] in codes:
                     new.append(r)
                 # We use all records, do NOT check if last_modified > since_last_checked


### PR DESCRIPTION
In ingest_appeals there is a temporary fix to avoid automatic overwriting of MDR65002 appeal.