### PR TITLE
add is_enclave and record_type to district and country serializers

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -55,7 +55,7 @@ class CountrySerializer(serializers.ModelSerializer):
 class MiniCountrySerializer(serializers.ModelSerializer):
     class Meta:
         model = Country
-        fields = ('name', 'iso', 'society_name', 'id',)
+        fields = ('name', 'iso', 'society_name', 'id', 'record_type',)
 
 class RegoCountrySerializer(serializers.ModelSerializer):
     class Meta:
@@ -76,7 +76,7 @@ class DistrictSerializer(serializers.ModelSerializer):
 class MiniDistrictSerializer(serializers.ModelSerializer):
     class Meta:
         model = District
-        fields = ('name', 'code', 'country_iso', 'country_name', 'id',)
+        fields = ('name', 'code', 'country_iso', 'country_name', 'id', 'is_enclave',)
 
 class RegionKeyFigureSerializer(serializers.ModelSerializer):
     class Meta:


### PR DESCRIPTION
@szabozoltan69 this adds the `is_enclave` and `record_type` data to the serializers so they can be consumed by the frontend.

Could you please look, test that it works okay and merge this? Thank you!