### PR TITLE
Implemented PER Draft deletion

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -45,6 +45,7 @@ from per.views import (
     OverviewSent,
     DelWorkPlan,
     DelOverview,
+    DelDraft,
 )
 
 # DRF routes
@@ -123,6 +124,7 @@ urlpatterns = [
     url(r'^sendperworkplan', WorkPlanSent.as_view()),
     url(r'^api/v2/del_perworkplan', DelWorkPlan.as_view()),
     url(r'^api/v2/del_peroverview', DelOverview.as_view()),
+    url(r'^api/v2/del_perdraft', DelDraft.as_view()),
     url(r'^verify_email', VerifyEmail.as_view()),
     url(r'^validate_user', ValidateUser.as_view()),
     url(r'^change_password', ChangePassword.as_view()),

--- a/per/serializers.py
+++ b/per/serializers.py
@@ -13,7 +13,7 @@ class ListDraftSerializer(serializers.ModelSerializer):
     country = RegoCountrySerializer()
     class Meta:
         model = Draft
-        fields = ('country', 'code', 'user', 'data',)
+        fields = ('country', 'code', 'user', 'data', 'id',)
 
 class FormStatSerializer(serializers.ModelSerializer):
     class Meta:

--- a/per/views.py
+++ b/per/views.py
@@ -429,6 +429,34 @@ class DelOverview(PublicJsonPostView):
 
         return JsonResponse({'status': 'ok'})
 
+def delete_draft(raw):
+    Draft.objects.filter(id=raw['id']).delete()
+    return
+
+class DelDraft(PublicJsonPostView):
+    def handle_post(self, request, *args, **kwargs):
+        u = None
+        richtokenstring = request.META.get('HTTP_AUTHORIZATION')
+        if richtokenstring:
+            try:
+                receivedtoken = Token.objects.get(key=richtokenstring[6:])
+            except:
+                return bad_request('User token is not correct.')
+            u = User.objects.filter(is_active=True, pk=receivedtoken.user_id)
+        else:
+            return bad_request('User token is not given.')
+        if not u:
+            return bad_request('User is not logged in or inactive.')
+        
+        body = json.loads(request.body.decode('utf-8'))
+
+        try:
+            workplan = delete_draft(body)
+        except:
+            return bad_request('Could not delete PER Draft.')
+        
+        return JsonResponse({'status': 'ok'})
+
 # *** Test script from bash (similar to test_views.py, but remains in db):
 # curl --header "Content-Type: application/json" \
 #  --request POST \

--- a/per/views.py
+++ b/per/views.py
@@ -429,8 +429,9 @@ class DelOverview(PublicJsonPostView):
 
         return JsonResponse({'status': 'ok'})
 
-def delete_draft(raw):
-    Draft.objects.filter(id=raw['id']).delete()
+def delete_draft(draftId):
+    if draftId:
+        Draft.objects.filter(id=draftId).delete()
     return
 
 class DelDraft(PublicJsonPostView):
@@ -451,7 +452,7 @@ class DelDraft(PublicJsonPostView):
         body = json.loads(request.body.decode('utf-8'))
 
         try:
-            workplan = delete_draft(body)
+            workplan = delete_draft(body['id'])
         except:
             return bad_request('Could not delete PER Draft.')
         


### PR DESCRIPTION
Needed for the frontend change to be able to delete PER drafts. 

## Changes

* Implemented the API endpoint for the deletion which requires the `id` of the record.
* Added `id` to the serializer to send back for the frontend to use.