### PR TITLE
return fallback queryset, uncomment code

### DIFF
--- a/per/drf_views.py
+++ b/per/drf_views.py
@@ -358,17 +358,17 @@ class NSPhaseViewset(viewsets.ReadOnlyModelViewSet):
     def filter_queryset(self, queryset):
         for backend in list(self.filter_backends):
             queryset = backend().filter_queryset(self.request, queryset, self)
-        #|  # If this feature is not needed in the future (2020.01.30), this section can be deleted:
-        #|
-        #|  # Giving a default value when queryset is empty, with the given country_id (if exists)
-        #| if not queryset:
-        #|     j = {'id': -1}
-        #|     country_param = self.request.query_params.get('country', None) if self.request.query_params.get('country', None) !='' else None
-        #|     if country_param and Country.objects.filter(pk = country_param):
-        #|             j.update({'country': Country.objects.get(pk = country_param)})
-        #|     j.update({'updated_at': pytz.timezone("Europe/Zurich").localize(datetime(2011, 11, 11, 1, 1, 1, 0))})
-        #|     j.update({'phase': 0})
-        #|     return [j]
+            # If this feature is not needed in the future (2020.01.30), this section can be deleted:
+         
+            # Giving a default value when queryset is empty, with the given country_id (if exists)
+            if not queryset:
+                j = {'id': -1}
+                country_param = self.request.query_params.get('country', None) if self.request.query_params.get('country', None) !='' else None
+                if country_param and Country.objects.filter(pk = country_param):
+                    j.update({'country': Country.objects.get(pk = country_param)})
+                j.update({'updated_at': pytz.timezone("Europe/Zurich").localize(datetime(2011, 11, 11, 1, 1, 1, 0))})
+                j.update({'phase': 0})
+                return [j]
         return queryset
 
 class WorkPlanFilter(filters.FilterSet):


### PR DESCRIPTION
Addresses https://github.com/IFRCGo/go-frontend/issues/950#issuecomment-589101827

## Changes

 - Uncomments code to continue to return fallback queryset to not break preparedness tab on country pages

## Checklist 
 - Preparedness tab on country page frontend should not crash even when a country does not have PER / phase data.