### PR TITLE
Probable fix for updated records indexing

### DIFF
--- a/api/management/commands/index_and_notify.py
+++ b/api/management/commands/index_and_notify.py
@@ -694,6 +694,7 @@ class Command(BaseCommand):
             if mailcontents_of_fe:
                 send_followedevent_notifications(mailcontents_of_fe)
         else:
+            # ".annotate(diff...)" - To check if a record was newly created, we check if `created_at` and `updated_at` are within one minute of each other, since those values can be off by some miliseconds upon insertion.
             new_reports = FieldReport.objects.filter(cond1)
             updated_reports = FieldReport.objects.annotate(
                 diff = ExpressionWrapper(F('updated_at') - F('created_at'), output_field=DurationField())

--- a/api/management/commands/index_and_notify.py
+++ b/api/management/commands/index_and_notify.py
@@ -372,7 +372,6 @@ class Command(BaseCommand):
                 shortened = shortened[:max_length] + \
                             shortened[max_length:].split(' ', 1)[0] + '...' # look for the first space
 
-        # TODO: Operation Update and Announcement types are missing
         if rtype == RecordType.FIELD_REPORT:
             rec_obj = {
                 'resource_uri': self.get_resource_uri(record, rtype),
@@ -516,7 +515,6 @@ class Command(BaseCommand):
             else:
                 emails = list(usr.values_list('email', flat=True))  # Only one email in this case
         
-        # TODO: maybe this needs to be adjusted based on the new functionality (at first only handling Weekly Digest)
         # Only serialize the first 10 records
         record_entries = []
         if rtype == RecordType.WEEKLY_DIGEST:


### PR DESCRIPTION
Addresses Elasticsearch indexing issue

## Issue description

It was trying to index new records as updated ones and it obviously failed if the records were just created and didn't have an index yet.

## Changes

Added a filter to the queries of `updated_*` records which checks if the `created_at` and `updated_at/modified_at/etc` datetimes were in the same minute, which querysets are used for the Elasticsearch indexing.