### PR TITLE
vanity url validation - doesn't start with a number

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -8,6 +8,7 @@ from django.core.validators import FileExtensionValidator, validate_slug
 from django.contrib.postgres.fields import ArrayField
 from datetime import datetime, timedelta
 import pytz
+from .utils import validate_slug_number
 
 # Write model properties to dictionary
 def to_dict(instance):
@@ -243,7 +244,7 @@ class Event(models.Model):
     """ A disaster, which could cover multiple countries """
 
     name = models.CharField(max_length=100)
-    slug = models.CharField(max_length=50, default=None, unique=True, null=True, blank=True, validators=[validate_slug], help_text='Optional string for a clean URL. For example, go.ifrc.org/emergencies/hurricane-katrina-2019. The string is forced to be lowercase. Recommend using hyphens over underscores. Special characters like # is not allowed.')
+    slug = models.CharField(max_length=50, default=None, unique=True, null=True, blank=True, validators=[validate_slug, validate_slug_number], help_text='Optional string for a clean URL. For example, go.ifrc.org/emergencies/hurricane-katrina-2019. The string cannot start with a number and is forced to be lowercase. Recommend using hyphens over underscores. Special characters like # is not allowed.')
     dtype = models.ForeignKey(DisasterType, null=True, on_delete=models.SET_NULL)
     districts = models.ManyToManyField(District, blank=True)
     countries = models.ManyToManyField(Country)

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,5 +1,5 @@
 import base64
-
+from django.core.exceptions import ValidationError
 
 def pretty_request(request):
     headers = ''
@@ -28,3 +28,7 @@ def base64_encode(string):
     return base64.urlsafe_b64encode(
         string.encode('UTF-8')
     ).decode('ascii')
+
+def validate_slug_number(value):
+    if value[0].isdigit():
+        raise ValidationError('slug should not start with a number')


### PR DESCRIPTION
One more validation https://github.com/IFRCGo/go-api/pull/642#issuecomment-603198696 to ensure slug doesn't start with a number. cc @teklal @GregoryHorvath @batpad 