### PR TITLE
Fix/fr queries

### DIFF
--- a/api/drf_views.py
+++ b/api/drf_views.py
@@ -419,7 +419,9 @@ class FieldReportViewset(ReadOnlyVisibilityViewset):
 
     def get_queryset(self, *args, **kwargs):
         qset = super().get_queryset(*args, **kwargs)
-        return qset.prefetch_related('actions_taken', 'districts', 'countries', 'actions_taken__actions', 'regions', 'dtype', 'event')
+        qset = qset.select_related('dtype', 'event')
+        return qset.prefetch_related('actions_taken', 'actions_taken__actions',
+                                     'countries', 'districts', 'regions')
 
 
     def get_serializer_class(self):

--- a/api/drf_views.py
+++ b/api/drf_views.py
@@ -416,6 +416,12 @@ class FieldReportFilter(filters.FilterSet):
 class FieldReportViewset(ReadOnlyVisibilityViewset):
     authentication_classes = (TokenAuthentication,)
     visibility_model_class = FieldReport
+
+    def get_queryset(self, *args, **kwargs):
+        qset = super().get_queryset(*args, **kwargs)
+        return qset.prefetch_related('actions_taken', 'districts', 'countries', 'actions_taken__actions', 'regions', 'dtype', 'event')
+
+
     def get_serializer_class(self):
         if self.action == 'list':
             request_format_type = self.request.GET.get('format', 'json')


### PR DESCRIPTION
Addresses https://github.com/IFRCGo/go-frontend/issues/1072#issuecomment-617427419

## Changes

 - Optimizes SQL queries on field report API end-point, reducing no of queries from 300+ to 9.

## Checklist 
Things that should succeed before merging.

 - [ ] Field Report API endpoint should work same as before, just much faster.


cc @GregoryHorvath 