### PR TITLE
Add Test For New Project API

### DIFF
--- a/deployments/drf_views.py
+++ b/deployments/drf_views.py
@@ -135,17 +135,10 @@ class RegionalProjectViewset(viewsets.ReadOnlyModelViewSet):
     search_fields = ('name',)
 
 
-
 class ProjectViewset(RevisionMixin, viewsets.ModelViewSet):
     queryset = Project.objects.prefetch_related(
         'user', 'reporting_ns', 'project_district', 'event', 'dtype', 'regional_project',
     ).all()
-    # XXX: Use this as default authentication classes
-    authentication_classes = (
-        TokenAuthentication,
-        BasicAuthentication,
-        SessionAuthentication,
-    )
     # TODO: May require different permission for UNSAFE_METHODS (Also Country Level)
     filter_class = ProjectFilter
     serializer_class = ProjectSerializer

--- a/deployments/filters.py
+++ b/deployments/filters.py
@@ -6,6 +6,7 @@ from .models import (
     OperationTypes,
     ProgrammeTypes,
     Sectors,
+    SectorTags,
     Statuses,
     Project,
 )
@@ -18,11 +19,19 @@ class ProjectFilter(filters.FilterSet):
     operation_type = filters.MultipleChoiceFilter(choices=OperationTypes.choices(), widget=filters.widgets.CSVWidget)
     programme_type = filters.MultipleChoiceFilter(choices=ProgrammeTypes.choices(), widget=filters.widgets.CSVWidget)
     primary_sector = filters.MultipleChoiceFilter(choices=Sectors.choices(), widget=filters.widgets.CSVWidget)
+    secondary_sectors = filters.MultipleChoiceFilter(
+        choices=SectorTags.choices(), widget=filters.widgets.CSVWidget, method='filter_secondary_sectors',
+    )
     status = filters.MultipleChoiceFilter(choices=Statuses.choices(), widget=filters.widgets.CSVWidget)
 
     # Supporting/Receiving NS Filters (Multiselect)
     project_country = filters.ModelMultipleChoiceFilter(queryset=Country.objects.all(), widget=filters.widgets.CSVWidget)
     reporting_ns = filters.ModelMultipleChoiceFilter(queryset=Country.objects.all(), widget=filters.widgets.CSVWidget)
+
+    def filter_secondary_sectors(self, queryset, name, value):
+        if len(value):
+            return queryset.filter(secondary_sectors__overlap=value)
+        return queryset
 
     def filter_country(self, queryset, name, value):
         if value:

--- a/deployments/forms.py
+++ b/deployments/forms.py
@@ -34,7 +34,7 @@ class ProjectForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['secondary_sectors'].widget = EnumArrayWidget(
-            choices=Sectors.choices(),
+            choices=SectorTags.choices(),
         )
 
 
@@ -66,18 +66,6 @@ class ProjectImportForm(forms.Form):
         sectors = {label.lower(): value for value, label in Sectors.choices()}
         sector_tags = {label.lower(): value for value, label in SectorTags.choices()}
         statuses = {label.lower(): value for value, label in Statuses.choices()}
-
-        # Handle Custom Sectors/Tags for Health (Keys all lower)
-        sectors.update({
-            'health': Sectors.HEALTH_PUBLIC,
-            'health (public)': Sectors.HEALTH_PUBLIC,
-            'health (clinical)': Sectors.HEALTH_CLINICAL,
-        })
-        sector_tags.update({
-            'health': SectorTags.HEALTH_PUBLIC,
-            'health (public)': SectorTags.HEALTH_PUBLIC,
-            'health (clinical)': SectorTags.HEALTH_CLINICAL,
-        })
 
         # Extract from import csv file
         for row in reader:

--- a/deployments/serializers.py
+++ b/deployments/serializers.py
@@ -106,6 +106,11 @@ class ProjectSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer)
     reporting_ns_detail = MiniCountrySerializer(source='reporting_ns', read_only=True)
     regional_project_detail = RegionalProjectSerializer(source='regional_project', read_only=True)
     event_detail = MiniEventSerializer(source='event', read_only=True)
+    primary_sector_display = serializers.CharField(source='get_primary_sector_display', read_only=True)
+    programme_type_display = serializers.CharField(source='get_programme_type_display', read_only=True)
+    operation_type_display = serializers.CharField(source='get_operation_type_display', read_only=True)
+    status_display = serializers.CharField(source='get_status_display', read_only=True)
+    secondary_sectors_display = serializers.ListField(source='get_secondary_sectors_display', read_only=True)
 
     class Meta:
         model = Project

--- a/deployments/test_views.py
+++ b/deployments/test_views.py
@@ -1,9 +1,9 @@
 import json
 from django.test import TestCase
-from rest_framework.test import APITestCase
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.models import User, Permission
-from api.models import Country, District
+from api.models import Country, District, Region
+from main.test_case import APITestCase
 from .models import (
     Project,
     ProgrammeTypes,
@@ -12,29 +12,20 @@ from .models import (
     Statuses,
 )
 
-username = 'jo'
-password = '12345678'
 
 class ProjectGetTest(APITestCase):
     def setUp(self):
-        user = User.objects.create(username=username)
-        user.set_password(password)
-        user.save()
+        super().setUp()
+        self.country1 = Country.objects.create(name='country1', iso='XX')
+        self.country2 = Country.objects.create(name='country2', iso='YY')
 
-        country1 = Country.objects.create(name='country1', iso='XX')
-        country1.save()
-        country2 = Country.objects.create(name='country2', iso='YY')
-        country2.save()
-
-        district1 = District.objects.create(name='district1', country=country1)
-        district1.save
-        district2 = District.objects.create(name='district2', country=country2)
-        district2.save
+        self.district1 = District.objects.create(name='district1', country=self.country1)
+        self.district2 = District.objects.create(name='district2', country=self.country2)
 
         first = Project.objects.create(
-                     user             = user
-                    ,reporting_ns     = country1
-                    ,project_district = district1
+                     user             = self.user
+                    ,reporting_ns     = self.country1
+                    ,project_district = self.district1
                     ,name             = 'aaa'
                     ,programme_type   = 0
                     ,primary_sector   = 0
@@ -46,9 +37,9 @@ class ProjectGetTest(APITestCase):
         first.save()
 
         second = Project.objects.create(
-                     user             = user
-                    ,reporting_ns     = country1
-                    ,project_district = district2
+                     user             = self.user
+                    ,reporting_ns     = self.country1
+                    ,project_district = self.district2
                     ,name             = 'bbb'
                     ,programme_type   = 1
                     ,primary_sector   = 1
@@ -61,34 +52,33 @@ class ProjectGetTest(APITestCase):
 
         second.save()
 
+    def create_project(self, **kwargs):
+        return Project.objects.create(
+            user=self.user,
+            name='Project Name',
+            start_date='2011-11-11',
+            end_date='2011-11-11',
+            reporting_ns=self.country1,
+            project_district=self.district1,
+            programme_type=ProgrammeTypes.BILATERAL,
+            primary_sector=Sectors.WASH,
+            operation_type=OperationTypes.PROGRAMME,
+            status=Statuses.PLANNED,
+            budget_amount=1000,
+            target_total=8000,
+            reached_total=1000,
+            **kwargs,
+        )
+
     def test_1(self):
-        user = User.objects.get(username=username)
-        body = {
-            'username': username,
-            'password': password
-        }
-        headers = {'CONTENT_TYPE': 'application/json'}
-        response = self.client.post('/get_auth_token', body, format='json', headers=headers).content
-        response = json.loads(response)
-        token = response.get('token')
-        self.assertIsNotNone(token)
-        self.client.credentials(HTTP_AUTHORIZATION = 'Token ' + token)
+        self.authenticate(self.user)
         resp = self.client.get('/api/v2/project/')
         self.assertEqual(resp.status_code, 200)
 
     def test_2(self):
         country2 = Country.objects.get(name='country2')
         district2 = District.objects.get(name='district2')
-        user = User.objects.get(username=username)
-        body = {
-            'username': username,
-            'password': password
-        }
-        headers = {'CONTENT_TYPE': 'application/json'}
-        response = self.client.post('/get_auth_token', body, format='json', headers=headers).content
-        response = json.loads(response)
-        token = response.get('token')
-        self.assertIsNotNone(token)
+        self.authenticate(self.user)
         body = {
             'reporting_ns': country2.id,
             'project_country': district2.country.id,
@@ -104,8 +94,6 @@ class ProjectGetTest(APITestCase):
             'target_total': 100,
             'status': Statuses.PLANNED.value,
         }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
-        self.client.force_authenticate(user=user, token=token)
         resp = self.client.post('/api/v2/project/', body)
         self.assertEqual(resp.status_code, 201, resp.content)
 
@@ -132,17 +120,7 @@ class ProjectGetTest(APITestCase):
         self.assertEqual(len(Project.objects.all()), 3)  # we created 3 projects until now here
 
     def test_get_projects(self):
-        user = User.objects.get(username=username)
-        body = {
-            'username': username,
-            'password': password
-        }
-        headers = {'CONTENT_TYPE': 'application/json'}
-        response = self.client.post('/get_auth_token', body, format='json', headers=headers).content
-        response = json.loads(response)
-        token = response.get('token')
-        self.assertIsNotNone(token)
-        self.client.credentials(HTTP_AUTHORIZATION = 'Token ' + token)
+        self.authenticate(self.user)
         resp = self.client.get('/api/v2/project/', format='json')
         self.assertEqual(resp.status_code, 200)
         data = json.loads(resp.content)
@@ -152,12 +130,225 @@ class ProjectGetTest(APITestCase):
         self.assertEqual(resp_country_filter.status_code, 200)
         data = json.loads(resp_country_filter.content)
         self.assertEqual(data['count'], 1)
-        self.assertEqual(data['results'][0]['name'], 'bbb')       
+        self.assertEqual(data['results'][0]['name'], 'bbb')
         resp_budget_filter = self.client.get('/api/v2/project/?budget_amount=6000', format='json')
         self.assertEqual(resp_budget_filter.status_code, 200)
         data = json.loads(resp_budget_filter.content)
         self.assertEqual(data['count'], 1)
-        self.assertEqual(data['results'][0]['name'], 'aaa')  
+        self.assertEqual(data['results'][0]['name'], 'aaa')
 
+    def test_visibility_project_get(self):
+        # Create country for scoping new projects
+        country = Country.objects.create(name='new_country', iso='NC')
+        public_project = self.create_project(project_country=country, visibility=Project.PUBLIC)
+        private_project = self.create_project(project_country=country, visibility=Project.LOGGED_IN_USER)
+        ifrc_only_project = self.create_project(project_country=country, visibility=Project.IFRC_ONLY)
+        # Unauthenticated user
+        resp = self.client.get(f'/api/v2/project/?project_country={country.pk}')
+        p_ids = [p['id'] for p in resp.json()['results']]
+        assert (
+            public_project.pk in p_ids and
+            private_project.pk not in p_ids and ifrc_only_project.pk not in p_ids
+        )
+        # Normal user
+        self.authenticate(self.user)
+        resp = self.client.get(f'/api/v2/project/?project_country={country.pk}')
+        p_ids = [p['id'] for p in resp.json()['results']]
+        assert (
+            public_project.pk in p_ids and private_project.pk in p_ids and
+            ifrc_only_project.pk not in p_ids
+        )
+        # IFRC user
+        self.authenticate(self.ifrc_user)
+        resp = self.client.get(f'/api/v2/project/?project_country={country.pk}')
+        p_ids = [p['id'] for p in resp.json()['results']]
+        assert (public_project.pk in p_ids and private_project.pk in p_ids and ifrc_only_project.pk in p_ids)
 
+    def test_regional_project_get(self):
+        # Get/Create a region
+        # NOTE: If this test fails make sure there no project create for below region
+        region, _ = Region.objects.get_or_create(name=1)
+        # Remove all the projects for above region
+        Project.objects.filter(project_country__region=region).delete()
+        # Reporting NS
+        rcountry1 = Country.objects.create(name='rcountry1', iso='XX', society_name='country1_sn')
+        rcountry2 = Country.objects.create(name='rcountry2', iso='XX', society_name='country2_sn')
+        # Create countries
+        country1 = Country.objects.create(name='country1', iso='XX', region=region)
+        country2 = Country.objects.create(name='country2', iso='XX', region=region)
+        # Create districts
+        district1 = District.objects.create(name='district1', country=country1)
+        district2 = District.objects.create(name='district2', country=country2)
+        # Create new Projects
+        for i, pdata in enumerate([
+            (
+                rcountry1, district1,
+                ProgrammeTypes.BILATERAL, Sectors.WASH, OperationTypes.PROGRAMME, Statuses.PLANNED,
+                6000, 1000, 2),
+            (
+                rcountry1, district1,
+                ProgrammeTypes.MULTILATERAL, Sectors.WASH, OperationTypes.EMERGENCY_OPERATION, Statuses.ONGOING,
+                1000, 2000, 2),
+            (
+                rcountry1, district2,
+                ProgrammeTypes.DOMESTIC, Sectors.CEA, OperationTypes.PROGRAMME, Statuses.ONGOING,
+                4000, 3000, 1000),
+            (
+                rcountry1, district2,
+                ProgrammeTypes.BILATERAL, Sectors.HEALTH_PUBLIC, OperationTypes.EMERGENCY_OPERATION, Statuses.COMPLETED,
+                6000, 9000, 1000),
+            (
+                rcountry2, district1,
+                ProgrammeTypes.BILATERAL, Sectors.WASH, OperationTypes.PROGRAMME, Statuses.PLANNED,
+                86000, 6000, 3000),
+            (
+                rcountry2, district1,
+                ProgrammeTypes.MULTILATERAL, Sectors.EDUCATION, OperationTypes.EMERGENCY_OPERATION, Statuses.COMPLETED,
+                6000, 5000, 2000),
+            (
+                rcountry2, district2,
+                ProgrammeTypes.DOMESTIC, Sectors.DRR, OperationTypes.PROGRAMME, Statuses.PLANNED,
+                100, 4000, 2000),
+            (
+                rcountry2, district2,
+                ProgrammeTypes.BILATERAL, Sectors.MIGRATION, OperationTypes.PROGRAMME, Statuses.COMPLETED,
+                2, 1000, 50),
+        ]):
+            Project.objects.create(
+                user=self.user,
+                name=f'Project {i}',
+                start_date='2011-11-11',
+                end_date='2011-11-11',
+                # Dynamic values
+                reporting_ns=pdata[0],
+                project_district=pdata[1],
+                programme_type=pdata[2],
+                primary_sector=pdata[3],
+                operation_type=pdata[4],
+                status=pdata[5],
+                budget_amount=pdata[6],
+                target_total=pdata[7],
+                reached_total=pdata[8],
+            )
+        resp = self.client.get(f'/api/v2/region-project/{region.pk}/overview/', format='json')
+        self.assertEqual(
+            resp.json(), {
+                'total_projects': 8,
+                'ns_with_ongoing_activities': 1,
+                'total_budget': 109102,
+                'target_total': 31000,
+                'reached_total': 9054,
+                'projects_by_status': [
+                    {'status': 0, 'count': 3},
+                    {'status': 1, 'count': 2},
+                    {'status': 2, 'count': 3}
+                ]
+            }
+        )
 
+        resp = self.client.get(f'/api/v2/region-project/{region.pk}/movement-activities/', format='json')
+        self.assertEqual(
+            resp.json(), {
+                'total_projects': 8,
+                'countries_count': [
+                    {
+                        'id': country1.id,
+                        'name': 'country1',
+                        'iso': 'XX',
+                        'iso3': None,
+                        'projects_count': 4,
+                        'planned_projects_count': 2,
+                        'ongoing_projects_count': 1,
+                        'completed_projects_count': 1
+                    },
+                    {
+                        'id': country2.id,
+                        'name': 'country2',
+                        'iso': 'XX',
+                        'iso3': None,
+                        'projects_count': 4,
+                        'planned_projects_count': 1,
+                        'ongoing_projects_count': 1,
+                        'completed_projects_count': 2
+                    }
+                ],
+                'country_ns_sector_count': [
+                    {
+                        'id': country1.id,
+                        'name': 'country1',
+                        'reporting_national_societies': [
+                            {
+                                'id': rcountry1.id,
+                                'name': 'rcountry1',
+                                'sectors': [
+                                    {'id': 0, 'sector': Sectors.WASH.label, 'count': 2}
+                                ]
+                            }, {
+                                'id': rcountry2.id,
+                                'name': 'rcountry2',
+                                'sectors': [
+                                    {'id': 0, 'sector': Sectors.WASH.label, 'count': 1},
+                                    {'id': 8, 'sector': Sectors.EDUCATION.label, 'count': 1}
+                                ]
+                            }
+                        ]
+                    }, {
+                        'id': country2.id,
+                        'name': 'country2',
+                        'reporting_national_societies': [
+                            {
+                                'id': rcountry1.id,
+                                'name': 'rcountry1',
+                                'sectors': [
+                                    {'id': 2, 'sector': Sectors.CEA.label, 'count': 1},
+                                    {'id': 4, 'sector': Sectors.HEALTH_PUBLIC.label, 'count': 1}
+                                ]
+                            }, {
+                                'id': rcountry2.id,
+                                'name': 'rcountry2',
+                                'sectors': [
+                                    {'id': 3, 'sector': Sectors.MIGRATION.label, 'count': 1},
+                                    {'id': 5, 'sector': Sectors.DRR.label, 'count': 1}
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                'supporting_ns': [
+                    {'count': 4, 'id': rcountry1.id, 'name': 'rcountry1'},
+                    {'count': 4, 'id': rcountry2.id, 'name': 'rcountry2'}
+                ]
+            })
+
+        resp = self.client.get(f'/api/v2/region-project/{region.pk}/national-society-activities/', format='json')
+        self.assertEqual(
+            resp.json(), {
+                'nodes': [
+                    {'id': rcountry1.id, 'type': 'supporting_ns', 'name': 'country1_sn', 'iso': 'XX', 'iso3': None},
+                    {'id': rcountry2.id, 'type': 'supporting_ns', 'name': 'country2_sn', 'iso': 'XX', 'iso3': None},
+                    {'id': 0, 'type': 'sector', 'name': Sectors.WASH.label},
+                    {'id': 2, 'type': 'sector', 'name': Sectors.CEA.label},
+                    {'id': 3, 'type': 'sector', 'name': Sectors.MIGRATION.label},
+                    {'id': 4, 'type': 'sector', 'name': Sectors.HEALTH_PUBLIC.label},
+                    {'id': 5, 'type': 'sector', 'name': Sectors.DRR.label},
+                    {'id': 8, 'type': 'sector', 'name': Sectors.EDUCATION.label},
+                    {'id': country1.id, 'type': 'receiving_ns', 'name': 'country1', 'iso': 'XX', 'iso3': None},
+                    {'id': country2.id, 'type': 'receiving_ns', 'name': 'country2', 'iso': 'XX', 'iso3': None}
+                ],
+                'links': [
+                    {'source': 0, 'target': 2, 'value': 2},
+                    {'source': 0, 'target': 3, 'value': 1},
+                    {'source': 0, 'target': 5, 'value': 1},
+                    {'source': 1, 'target': 2, 'value': 1},
+                    {'source': 1, 'target': 4, 'value': 1},
+                    {'source': 1, 'target': 6, 'value': 1},
+                    {'source': 1, 'target': 7, 'value': 1},
+                    {'source': 2, 'target': 8, 'value': 3},
+                    {'source': 3, 'target': 9, 'value': 1},
+                    {'source': 4, 'target': 9, 'value': 1},
+                    {'source': 5, 'target': 9, 'value': 1},
+                    {'source': 6, 'target': 9, 'value': 1},
+                    {'source': 7, 'target': 8, 'value': 1}
+                ]
+            }
+        )

--- a/main/settings.py
+++ b/main/settings.py
@@ -56,6 +56,11 @@ INSTALLED_APPS = [
 ]
 
 REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+        'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 50,
     'DEFAULT_FILTER_BACKENDS': (

--- a/main/test_case.py
+++ b/main/test_case.py
@@ -1,0 +1,44 @@
+from rest_framework.authtoken.models import Token
+from rest_framework import test
+
+from django.contrib.auth.models import User
+
+
+class APITestCase(test.APITestCase):
+    """
+    Base TestCase
+    """
+    def setUp(self):
+        self.root_user = User.objects.create_user(
+            username='root@test.com',
+            first_name='Root',
+            last_name='Toot',
+            password='admin123',
+            email='root@test.com',
+            is_superuser=True,
+            is_staff=True,
+        )
+
+        self.user = User.objects.create_user(
+            username='jon@dave.com',
+            first_name='Jon',
+            last_name='Mon',
+            password='test123',
+            email='jon@dave.com',
+        )
+
+        self.ifrc_user = User.objects.create_user(
+            username='jon@@ifrc.org',
+            first_name='IFRC',
+            last_name='GO',
+            password='test123',
+            email='jon@@ifrc.org',
+        )
+
+    def authenticate(self, user=None):
+        user = user or self.user
+        api_key, created = Token.objects.get_or_create(user=user)
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Token {}'.format(api_key)
+        )
+        return api_key


### PR DESCRIPTION
## Changes

- Add base ApiTestCase as common helper.
- Add Test for Project Visibility.
- Add Test for Regional Project API.
- Add custom labels for Sectors and SectorTags.
- Add `_display` for Project API enumfields.
- Add Project filter by secondary_sectors.
- Set default authentication configuration. https://github.com/IFRCGo/go-frontend/issues/1179
- Few bug fixes.