### PR TITLE
Red shadow around the delete checkboxes

### DIFF
--- a/api/templates/admin/base.html
+++ b/api/templates/admin/base.html
@@ -28,6 +28,9 @@
         z-index: 1001;
         bottom: 0;
       }
+      tr > .delete > input {
+        box-shadow: 0px 0px 2px 2px #ff3232bd;
+      }
     </style>
   </head>
 {% load i18n %}


### PR DESCRIPTION
Natalie's request to make some distinction between the usual checkboxes and the "delete" ones, because if there are a lot of records which requires scrolling they could be mixed up.