### PR TITLE
Fix Keyerror in the registration process

### DIFF
--- a/registrations/views.py
+++ b/registrations/views.py
@@ -39,7 +39,7 @@ def is_valid_domain(email):
 def get_valid_admins(contacts):
     if not type(contacts) is list:
         return False
-    emails = [admin['email'] for admin in contacts if admin['email'] is not None]
+    emails = [admin.get('email', None) for admin in contacts]
     if len(emails) < 1:
         return False
     admin_users = User.objects.filter(email__in=emails)


### PR DESCRIPTION
Found some Keyerror messages in the logs on production. By default there should be no way to be able to submit the registration without filling out the admin contact emails, but it seems somehow it still happened. Could be linked to: https://github.com/IFRCGo/go-api/issues/737 but unlikely.

```
  File "/home/ifrc/go-api/api/views.py", line 307, in post
    return self.handle_post(request, *args, **kwargs)
  File "/home/ifrc/go-api/registrations/views.py", line 93, in handle_post
    admins = True if is_staff else get_valid_admins(body['contact'])
  File "/home/ifrc/go-api/registrations/views.py", line 42, in get_valid_admins
    emails = [admin['email'] for admin in contacts if admin['email'] is not None]
  File "/home/ifrc/go-api/registrations/views.py", line 42, in <listcomp>
    emails = [admin['email'] for admin in contacts if admin['email'] is not None]
KeyError: 'email'
```

cc @batpad 