### PR TITLE
Removed multi-upload, fixes doc URL save too

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -486,23 +486,6 @@ class SituationReportAdmin(CompareVersionAdmin, RegionRestrictedAdmin):
         return format_html('<a href="{}" style="font-weight: 600;">{}</a>', link, obj.event.name)
     link_to_event.allow_tags=True
 
-    # Works, but gives azure storageclient ERROR - Client-Request-ID=... Retry policy did not allow for a retry: ... HTTP status code=404, Exception=The specified blob does not exist.
-    # Has a duplication at PER NiceDocuments
-    def save_model(self, request, obj, form, change):
-       if change:
-           obj.save()
-       else:
-           for i,one_document in enumerate(request.FILES.getlist('documents_multiple')):
-               if i<30: # not letting tons of documents to be attached
-                   models.SituationReport.objects.create(
-                       name        =obj.name if i == 0 else obj.name + '-' + str(i),
-                       document    =one_document,
-                       document_url=obj.document_url,
-                       event       =obj.event,
-                       type        =obj.type,
-                       visibility  =obj.visibility,
-                       )
-
 class SituationReportTypeAdmin(CompareVersionAdmin):
     search_fields = ('type',)
 

--- a/api/templates/admin/includes/fieldset.html
+++ b/api/templates/admin/includes/fieldset.html
@@ -17,15 +17,7 @@
                         {% if field.is_readonly %}
                             <div class="readonly">{{ field.contents }}</div>
                         {% else %}
-                            {% if field.field.name == 'document' and request.path|slice:"-5:" == '/add/' %}
-                                {% if opts.verbose_name == 'situation report' or opts.verbose_name == 'PER Document' %}{# other types may come here also. () not allowed. #}
-                                    <input type="file" name="documents_multiple" id="id_documents" multiple />
-                                {% else %}
-                                    {{ field.field }}{# you can check other variables here to debug #} 
-                                {% endif %}
-                            {% else %}
-                                {{ field.field }}{# you can check other variables here to debug #} 
-                            {% endif %}
+                            {{ field.field }}
                         {% endif %}
                     {% endif %}
                     {% if field.field.help_text %}

--- a/per/admin.py
+++ b/per/admin.py
@@ -34,20 +34,6 @@ class OverviewAdmin(CompareVersionAdmin, RegionRestrictedAdmin):
 
 class NiceDocumentAdmin(CompareVersionAdmin, RegionRestrictedAdmin):
     country_in = 'country__in'
-#   Duplicated from situation reports
-    def save_model(self, request, obj, form, change):
-       if change:
-           obj.save()
-       else:
-           for i,one_document in enumerate(request.FILES.getlist('documents_multiple')):
-               if i<30: # not letting tons of documents to be attached
-                   models.NiceDocument.objects.create(
-                       name        =obj.name if i == 0 else obj.name + '-' + str(i),
-                       document    =one_document,
-                       document_url=obj.document_url,
-                       country     =obj.country,
-                       visibility  =obj.visibility,
-                       )
 
 admin.site.register(models.Form, FormAdmin)
 #admin.site.register(models.FormData, FormDataAdmin) - if we want to edit form data in Django


### PR DESCRIPTION
Ref.:
- https://github.com/IFRCGo/go-frontend/issues/1117#issuecomment-630436278 - 1
- https://github.com/IFRCGo/go-frontend/issues/1117#issuecomment-633956512 - 2

Makes document upload to allow only 1 at a time for Situation Reports and PER Documents. Also fixes an issue not being able to save them without an actual uploaded attachment.