### PR TITLE
Fix scrape_pdfs error

### DIFF
--- a/api/management/commands/scrape_pdfs.py
+++ b/api/management/commands/scrape_pdfs.py
@@ -109,7 +109,7 @@ class Command(BaseCommand):
             response = requests.get(url)
             if response.status_code != 200:
                 body = { "name": "scrape_pdfs",
-                    "message": 'Error scraping ' + pdf_type + ' PDF-s from ' + url,
+                    "message": 'Error scraping ' + pdf_type + ' PDF-s from ' + url + '. (' + str(response.status_code) + ')',
                     "status": CronJobStatus.ERRONEOUS }
                 CronJob.sync_cron(body)
             items = xmltodict.parse(response.content)['rss']['channel']['item']


### PR DESCRIPTION
## Changes
- Fixed `url` wasn't a valid variable where it was used for the CronJob sync function
- Added status code to the error message if the response is other than `200`