### PR TITLE
Fix/notifications visibility

### DIFF
--- a/api/management/commands/index_and_notify.py
+++ b/api/management/commands/index_and_notify.py
@@ -542,7 +542,6 @@ class Command(BaseCommand):
         if uid is None:
             # Handle Visibility for Field Reports
             if rtype == RecordType.FIELD_REPORT:
-                import pdb; pdb.set_trace()
                 rtype_of_subscr, stype = self.fix_types_for_subs(rtype, stype)
                 non_ifrc_records = [rec for rec in record_entries if int(rec['visibility']) != 2]
                 if non_ifrc_records:
@@ -550,7 +549,7 @@ class Command(BaseCommand):
                         & Q(subscription__stype=stype)
                         & Q(is_active=True)
                         & (~Q(groups__name='IFRC Admins') & ~Q(is_superuser=True)))
-                    non_ifrc_recipients = User.objects.filter(non_ifrc_filters).values('email')
+                    non_ifrc_recipients = list(User.objects.filter(non_ifrc_filters).values_list('email', flat=True))
                     
                     # FIXME: Code duplication but this whole thing would need a huge refactor
                     # (almost the same as above and in the 'else' part)
@@ -568,7 +567,7 @@ class Command(BaseCommand):
                     & Q(subscription__stype=stype)
                     & Q(is_active=True)
                     & (Q(groups__name='IFRC Admins') | Q(is_superuser=True)))
-                ifrc_emails = User.objects.filter(ifrc_filters).values('email')
+                ifrc_emails = list(User.objects.filter(ifrc_filters).values_list('email', flat=True))
                 ifrc_recipients = ifrc_emails
 
                 # FIXME: Code duplication but this whole thing would need a huge refactor

--- a/api/management/commands/revoke_staff_status.py
+++ b/api/management/commands/revoke_staff_status.py
@@ -23,10 +23,13 @@ class Command(BaseCommand):
         for usr in User.objects.filter(is_superuser=False):
             if not usr.email:
                 continue
-            if usr.email.lower().split('@')[1] == 'ifrc.org' and not usr.groups.filter(name__icontains='read only') and not usr.groups.filter(name__icontains='IFRC Admins'):
+            if (usr.email.lower().split('@')[1] == 'ifrc.org' and
+                    not usr.groups.filter(name__icontains='read only') and
+                    not usr.groups.filter(name__icontains='IFRC Admins')):
                 ifrc_domain_users.append(usr)
                 count += 1
-                logger.info(u"IFRC Admins group < IFRC domain user: %s", usr.get_full_name() + ' | ' + usr.email + ' (' + str(count) + ')')
+                logger.info(u"IFRC Admins group < IFRC domain user: %s",
+                    usr.get_full_name() + ' | ' + usr.email + ' (' + str(count) + ')')
                 # Prints a lots of users
         return ifrc_domain_users
 
@@ -46,7 +49,8 @@ class Command(BaseCommand):
 
         users = self.get_readonly_users()
         if len(users) > 0:
-            logger.info('Revoking staff status from %s user%s' % (len(users), 's' if len(users) > 1 else ''))
+            logger.info('Revoking staff status from %s user%s'
+                % (len(users), 's' if len(users) > 1 else ''))
             num_updated = 0
             for usr in users:
                 usr.is_staff = False
@@ -57,7 +61,8 @@ class Command(BaseCommand):
                     logger.error('Could not update user %s' % usr.email)
                     continue
                 num_updated += 1
-                logger.info(' %s user%s updated' % (num_updated, 's' if num_updated > 1 else ''))
+                logger.info(' %s user%s updated'
+                    % (num_updated, 's' if num_updated > 1 else ''))
             logger.info('... user%s moving completed' % ('s' if len(users) > 1 else ''))
         else:
             logger.info('... not found any users to be moved')
@@ -65,12 +70,15 @@ class Command(BaseCommand):
         ifrc_users = self.get_ifrc_domain_users()
         ifrc_grp = Group.objects.get(name='IFRC Admins')
         if len(ifrc_users) > 0:
-            logger.info('Adding IFRC Admins Group membership to %s user%s' % (len(ifrc_users), 's' if len(ifrc_users) > 1 else ''))
+            logger.info('Adding IFRC Admins Group membership to %s user%s'
+                % (len(ifrc_users), 's' if len(ifrc_users) > 1 else ''))
             num_i_updated = 0
             for usr in ifrc_users:
                 ifrc_grp.user_set.add(usr)
                 num_i_updated += 1
-                logger.info(' %s user%s added' % (num_i_updated, 's' if num_i_updated > 1 else ''))
-            logger.info('... user%s adding to IFRC Admins Group completed' % ('s' if len(ifrc_users) > 1 else ''))
+                logger.info(' %s user%s added'
+                    % (num_i_updated, 's' if num_i_updated > 1 else ''))
+            logger.info('... user%s adding to IFRC Admins Group completed'
+                % ('s' if len(ifrc_users) > 1 else ''))
         else:
             logger.info('... not found any users to be put into IFRC Admins')

--- a/notifications/notification.py
+++ b/notifications/notification.py
@@ -11,12 +11,12 @@ from api.logger import logger
 # from api.models import CronJob, CronJobStatus
 
 
-EMAIL_USER = os.environ.get('EMAIL_USER')
 # EMAIL_PASS = os.environ.get('EMAIL_PASS')
 # EMAIL_HOST = os.environ.get('EMAIL_HOST')
 # EMAIL_PORT = os.environ.get('EMAIL_PORT')
-IS_PROD = os.environ.get('PRODUCTION')
+EMAIL_USER = os.environ.get('EMAIL_USER')
 EMAIL_API_ENDPOINT = os.environ.get('EMAIL_API_ENDPOINT')
+IS_PROD = os.environ.get('PRODUCTION')
 
 test_emails = os.environ.get('TEST_EMAILS')
 if test_emails:
@@ -25,7 +25,7 @@ else:
     test_emails = ['gergely.horvath@ifrc.org']
 
 
-def send_notification(subject, recipients, html, is_followed_event=False):
+def send_notification(subject, recipients, html):
     if not EMAIL_USER or not EMAIL_API_ENDPOINT:
         logger.warn('Cannot send notifications.')
         logger.warn('No username and/or API endpoint set as environment variables.')
@@ -64,7 +64,7 @@ def send_notification(subject, recipients, html, is_followed_event=False):
     if res.status_code == 200:
         logger.info('E-mails were sent successfully.')
     elif res.status_code == 401 or res.status_code == 403:
-        logger.info('Authorization/authentication failed ({}) failed to the e-mail sender API.'.format(res.status_code))
+        logger.info('Authorization/authentication failed ({}) to the e-mail sender API.'.format(res.status_code))
     elif res.status_code == 500:
         logger.error('Could not reach the e-mail sender API.')
 


### PR DESCRIPTION
## Changes
Separates the notification mail sending method into one which includes all Users who doesn't have superuser status or not in the 'IFRC Admins' group, and two those who do have either of those.

### Notes
There is a new `fix_types_for_subs` abstracted method, which feels pretty unnecessary if we only had the usable `RecordType`s and converted everyone's old subscriptions into those instead in the database. The whole `index_and_notify` file and related things could make use of a refactor/rewrite because this will only become a bigger mess later.