### PR TITLE
Minor/log location

### DIFF
--- a/api/filehandler.py
+++ b/api/filehandler.py
@@ -1,0 +1,10 @@
+import logging
+import os
+
+
+class MakeFileHandler(logging.FileHandler):
+    """https://stackoverflow.com/questions/20666764/python-logging-how-to-ensure-logfile-directory-is-created"""
+
+    def __init__(self, filename, mode='a', encoding=None, delay=0):
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        logging.FileHandler.__init__(self, filename, mode, encoding, delay)

--- a/main/settings.py
+++ b/main/settings.py
@@ -259,7 +259,7 @@ LOGGING = {
         'file': {
             'level': 'INFO',
             'class': 'logging.FileHandler',
-            'filename': '../logger.log',
+            'filename': '../logs/logger.log',
             'formatter': 'timestamp',
         },
     },

--- a/main/settings.py
+++ b/main/settings.py
@@ -258,7 +258,7 @@ LOGGING = {
     'handlers': {
         'file': {
             'level': 'INFO',
-            'class': 'logging.FileHandler',
+            'class': 'api.filehandler.MakeFileHandler',
             'filename': '../logs/logger.log',
             'formatter': 'timestamp',
         },


### PR DESCRIPTION
Put `logger.log` into the folder alongside the other log files so it retains after a new deployment.