### PR TITLE
Fix/email issues

### DIFF
--- a/api/logger.py
+++ b/api/logger.py
@@ -21,6 +21,7 @@ if (os.environ.get('AZURE_STORAGE_ACCOUNT') is not None and
                       when='M',
                       interval=90,
                       container='logs',
+                      encoding='utf-8'
                       )
     handler.setFormatter(formatter)
     logger.addHandler(handler)

--- a/api/management/commands/index_and_notify.py
+++ b/api/management/commands/index_and_notify.py
@@ -41,7 +41,11 @@ RTYPE_NAMES = {
     2: 'Field Report',
     3: 'Surge Alert',
     8: 'Followed Emergency',
+    9: 'Surge Deployment',
     11: 'Weekly Digest',
+    12: 'Field Report/Emergency',
+    13: 'New Operation',
+    14: 'General Announcement'
 }
 
 

--- a/notifications/notification.py
+++ b/notifications/notification.py
@@ -46,7 +46,8 @@ class SendMail(threading.Thread):
             server.quit()
             logger.info('E-mails were sent successfully.')
         except Exception as exc:
-            logger.error('Could not send emails with Python smtlib, exception: {} -- {}'.format(type(exc).__name__, exc.args))
+            logger.error('Could not send emails with Python smtlib, exception: {} -- {}'.format(type(exc).__name__,
+                                                                                                exc.args))
 
 
 def send_notification(subject, recipients, html, mailtype=''):


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-api/issues/737

There were some encoding errors happening for the `index_and_notify.py` cronjob. Hope this helps?

```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/logging/__init__.py", line 994, in emit
    stream.write(msg)


UnicodeEncodeError: 'ascii' codec can't encode character '\xf3' in position 69: ordinal not in range(128)
^^^^^^^^^^^^^^^^^^


Call stack:
  File "/home/ifrc/go-api/manage.py", line 22, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/home/ifrc/go-api/api/management/commands/index_and_notify.py", line 739, in handle
    self.notify(new_reports, RecordType.FIELD_REPORT, SubscriptionType.NEW)
  File "/home/ifrc/go-api/api/management/commands/index_and_notify.py", line 615, in notify
    RTYPE_NAMES[rtype] + ' notification (ifrc) - ' + subject)
  File "/home/ifrc/go-api/notifications/notification.py", line 77, in send_notification
    logger.info('Subject: {subject}, Recipients: {recs}'.format(subject=subject, recs=recipients_as_string))


  File "/usr/local/lib/python3.6/site-packages/azure_storage_logging/handlers.py", line 211, in emit
    super(BlobStorageTimedRotatingFileHandler, self).emit(record)
^^^^^^^^^^^^^^^^^^^^
```

Edit:
Added back the old way of sending emails as a backup if the API returns with `500`.