### PR TITLE
prefetch_related for EventViewset query

### DIFF
--- a/api/drf_views.py
+++ b/api/drf_views.py
@@ -257,9 +257,15 @@ class EventViewset(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         if self.action == 'mini_events':
+            # FIXME: Why do we have an 'if' here when the (base) query is the same?
             return Event.objects.filter(parent_event__isnull=True).prefetch_related('dtype')
-        return Event.objects.filter(parent_event__isnull=True)
-        # return Event.get_for(self.request.user).filter(parent_event__isnull=True)
+        return (Event.objects.filter(parent_event__isnull=True)
+                             .select_related('dtype')
+                             .prefetch_related('appeals')
+                             .prefetch_related('countries')
+                             .prefetch_related('field_reports')
+                             .prefetch_related('regions')
+                             .prefetch_related('districts'))
 
     def get_serializer_class(self):
         if self.action == 'mini_events':


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-frontend/issues/1412

Hopefully solves the CSV export slowness. Tested locally (left: without `prefetch` - right: with `prefetch`):
- 1m14s - 37s
- 56s - 24s
- 4m6s - 31s

As it seems it's pretty hectic but with `prefetch` it was at least twice as fast in every run.

cc @batpad @kamicut merging this to develop for staging testing