### PR TITLE
return region bbox only if it exists

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -48,7 +48,11 @@ class RegionSerializer(serializers.ModelSerializer):
     bbox = serializers.SerializerMethodField()
 
     def get_bbox(self, region):
-        return json.loads(region.bbox.geojson)
+        if region.bbox:
+            return json.loads(region.bbox.geojson)
+        else:
+            return None
+
     class Meta:
         model = Region
         fields = ('name', 'id', 'region_name', 'bbox',)


### PR DESCRIPTION
Addresses 500s @batpad noticed on staging while querying appeals. The logs from @GregoryHorvath confirms that it was because we were trying to return bbox for a region with no bbox. This will now be fixed by running the `update-region-bbox` management command, but this PR safeguards any further issues.

