### PR TITLE
use custom geo serializers for region, country and district

### DIFF
--- a/api/drf_views.py
+++ b/api/drf_views.py
@@ -57,11 +57,13 @@ from .serializers import (
     DisasterTypeSerializer,
 
     RegionSerializer,
+    RegionGeoSerializer,
     RegionKeyFigureSerializer,
     RegionSnippetSerializer,
     RegionRelationSerializer,
 
     CountrySerializer,
+    CountryGeoSerializer,
     MiniCountrySerializer,
     CountryKeyFigureSerializer,
     CountrySnippetSerializer,
@@ -69,6 +71,7 @@ from .serializers import (
 
     DistrictSerializer,
     MiniDistrictSerializer,
+    MiniDistrictGeoSerializer,
 
     SnippetSerializer,
     ListMiniEventSerializer,
@@ -112,7 +115,7 @@ class RegionViewset(viewsets.ReadOnlyModelViewSet):
     queryset = Region.objects.all()
     def get_serializer_class(self):
         if self.action == 'list':
-            return RegionSerializer
+            return RegionGeoSerializer
         return RegionRelationSerializer
 
 
@@ -148,7 +151,7 @@ class CountryViewset(viewsets.ReadOnlyModelViewSet):
         if self.request.GET.get('mini', 'false').lower() == 'true':
             return MiniCountrySerializer
         if self.action == 'list':
-            return CountrySerializer
+            return CountryGeoSerializer
         return CountryRelationSerializer
 
     @action(
@@ -226,7 +229,7 @@ class DistrictViewset(viewsets.ReadOnlyModelViewSet):
 
     def get_serializer_class(self):
         if self.action == 'list':
-            return MiniDistrictSerializer
+            return MiniDistrictGeoSerializer
         else:
             return DistrictSerializer
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -45,6 +45,11 @@ class DisasterTypeSerializer(serializers.ModelSerializer):
         fields = ('name', 'summary', 'id',)
 
 class RegionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Region
+        fields = ('name', 'id', 'region_name',)
+
+class RegionGeoSerializer(serializers.ModelSerializer):
     bbox = serializers.SerializerMethodField()
 
     def get_bbox(self, region):
@@ -57,8 +62,13 @@ class RegionSerializer(serializers.ModelSerializer):
         model = Region
         fields = ('name', 'id', 'region_name', 'bbox',)
 
-
 class CountrySerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Country
+        fields = ('name', 'iso', 'iso3', 'society_name', 'society_url', 'region', 'overview', 'key_priorities', 'inform_score', 'id', 'url_ifrc', 'record_type', 'independent',)
+
+class CountryGeoSerializer(serializers.ModelSerializer):
     bbox = serializers.SerializerMethodField()
     centroid = serializers.SerializerMethodField()
 
@@ -76,12 +86,12 @@ class CountrySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Country
-        fields = ('name', 'iso', 'iso3', 'society_name', 'society_url', 'region', 'overview', 'key_priorities', 'inform_score', 'id', 'url_ifrc', 'record_type', 'bbox', 'centroid',)
+        fields = ('name', 'iso', 'iso3', 'society_name', 'society_url', 'region', 'overview', 'key_priorities', 'inform_score', 'id', 'url_ifrc', 'record_type', 'bbox', 'centroid', 'independent')
 
 class MiniCountrySerializer(serializers.ModelSerializer):
     class Meta:
         model = Country
-        fields = ('name', 'iso', 'iso3', 'society_name', 'id', 'record_type', 'region',)
+        fields = ('name', 'iso', 'iso3', 'society_name', 'id', 'record_type', 'region', 'independent',)
 
 class RegoCountrySerializer(serializers.ModelSerializer):
     class Meta:
@@ -100,6 +110,11 @@ class DistrictSerializer(serializers.ModelSerializer):
         fields = ('name', 'code', 'country', 'country_iso', 'country_name', 'id',)
 
 class MiniDistrictSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = District
+        fields = ('name', 'code', 'country_iso', 'country_name', 'id', 'is_enclave',)
+
+class MiniDistrictGeoSerializer(serializers.ModelSerializer):
     bbox = serializers.SerializerMethodField()
     centroid = serializers.SerializerMethodField()
 


### PR DESCRIPTION
This PR introduces custom geo serializers for region, country and districts. It will ensure that other api end points that depend on the default serializers don't get burdened with the additional querying on bbox and centroid.

## Changes

* New geo serializers
* Region, Country and District list endpoints uses geo serializers
* Country endpoints now also return a `independent` field -- this will be used to determine whether the country needs to be available in the dropdowns etc.

