### PR TITLE
Add 'entity_encoding: raw' to TinyMCE config

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -173,6 +173,7 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 TINYMCE_DEFAULT_CONFIG = {
+    'entity_encoding': 'raw',
     'height': 360,
     'width': 1120,
     'cleanup_on_startup': True,


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-api/issues/837

## Changes

- Added `'entity_encoding': 'raw'` to TinyMCE settings

This seems to be resolving only the future additions of RTE fields' texts so special characters save right to the database.