### PR TITLE
Simplify ENV vars export for cronjobs

### DIFF
--- a/main/runserver.sh
+++ b/main/runserver.sh
@@ -34,31 +34,8 @@ exec gunicorn main.wsgi:application \
 
 # set up cron
 rm $HOME/.env
-echo "export GO_FTPHOST=\"$GO_FTPHOST\"" >> $HOME/.env
-echo "export GO_FTPUSER=\"$GO_FTPUSER\"" >> $HOME/.env
-echo "export GO_FTPPASS=\"$GO_FTPPASS\"" >> $HOME/.env
-echo "export GO_DBPASS=\"$GO_DBPASS\"" >> $HOME/.env
-echo "export PATH=\"$PATH:/usr/local/bin\"" >> $HOME/.env
-echo "export DJANGO_SECRET_KEY=\"$DJANGO_SECRET_KEY\"" >> $HOME/.env
-echo "export DJANGO_DB_NAME=\"$DJANGO_DB_NAME\"" >> $HOME/.env
-echo "export DJANGO_DB_USER=\"$DJANGO_DB_USER\"" >> $HOME/.env
-echo "export DJANGO_DB_PASS=\"$DJANGO_DB_PASS\"" >> $HOME/.env
-echo "export DJANGO_DB_HOST=\"$DJANGO_DB_HOST\"" >> $HOME/.env
-echo "export DJANGO_DB_PORT=\"$DJANGO_DB_PORT\"" >> $HOME/.env
-echo "export APPEALS_USER=\"$APPEALS_USER\"" >> $HOME/.env
-echo "export APPEALS_PASS=\"$APPEALS_PASS\"" >> $HOME/.env
-echo "export ES_HOST=\"$ES_HOST\"" >> $HOME/.env
-echo "export EMAIL_HOST=\"$EMAIL_HOST\"" >> $HOME/.env
-echo "export EMAIL_PORT=\"$EMAIL_PORT\"" >> $HOME/.env
-echo "export EMAIL_USER=\"$EMAIL_USER\"" >> $HOME/.env
-echo "export EMAIL_PASS=\"$EMAIL_PASS\"" >> $HOME/.env
-echo "export EMAIL_API_ENDPOINT=\"$EMAIL_API_ENDPOINT\"" >> $HOME/.env
-echo "export AZURE_STORAGE_ACCOUNT=\"$AZURE_STORAGE_ACCOUNT\"" >> $HOME/.env
-echo "export AZURE_STORAGE_KEY=\"$AZURE_STORAGE_KEY\"" >> $HOME/.env
-echo "export API_FQDN=\"$API_FQDN\"" >> $HOME/.env
-echo "export FRONTEND_URL=\"$FRONTEND_URL\"" >> $HOME/.env
-echo "export PRODUCTION=\"$PRODUCTION\"" >> $HOME/.env
-echo "export TEST_EMAILS=\"$TEST_EMAILS\"" >> $HOME/.env
+# Exporting env vars, like: echo "export PRODUCTION=\"$PRODUCTION\"" >> $HOME/.env
+printenv | sed 's/^\([a-zA-Z0-9_]*\)=\(.*\)$/export \1="\2"/g' > $HOME/.env
 
 (crontab -l 2>/dev/null; echo 'SHELL=/bin/bash') | crontab -
 (crontab -l 2>/dev/null; echo '15 * * * * . /home/ifrc/.env; python /home/ifrc/go-api/manage.py ingest_appeal_docs >> /home/ifrc/logs/ingest_appeal_docs.log 2>&1') | crontab -


### PR DESCRIPTION
Simplifies the construction of the `.env` file for the cronjobs. Also includes FDRS vars (ref.: https://github.com/IFRCGo/go-api/issues/851).

cc @thenav56 