### PR TITLE
Added retries to ES timeouts

### DIFF
--- a/api/esconnection.py
+++ b/api/esconnection.py
@@ -3,7 +3,7 @@ from elasticsearch import Elasticsearch
 
 host = os.environ.get('ES_HOST')
 if host is not None:
-    ES_CLIENT = Elasticsearch([host])
+    ES_CLIENT = Elasticsearch([host], max_retries=3, retry_on_timeout=True)
 else:
     print('Warning: No elasticsearch host found, will not index elasticsearch')
     ES_CLIENT = None


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-frontend/issues/1353

In theory this should make the search requests retry 3 times max. if they time out (after 10 seconds). Couldn't reproduce the error locally, but hopefully this temporarily makes the user experience a bit better while we find the cause of these timeouts.