### PR TITLE
Change ES timeout to 5 seconds from 10

### DIFF
--- a/api/esconnection.py
+++ b/api/esconnection.py
@@ -3,7 +3,7 @@ from elasticsearch import Elasticsearch
 
 host = os.environ.get('ES_HOST')
 if host is not None:
-    ES_CLIENT = Elasticsearch([host], max_retries=3, retry_on_timeout=True)
+    ES_CLIENT = Elasticsearch([host], timeout=5, max_retries=3, retry_on_timeout=True)
 else:
     print('Warning: No elasticsearch host found, will not index elasticsearch')
     ES_CLIENT = None


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-frontend/issues/989

Changed Elasticsearch timeout from `10` to `5` seconds, so the retry would hit faster. The usual ES response returns `~400-500ms`.