### PR TITLE
Hopeful fix to all logging encoding errors

### DIFF
--- a/databank/management/commands/ingest_databank.py
+++ b/databank/management/commands/ingest_databank.py
@@ -76,7 +76,7 @@ class Command(BaseCommand):
             index, country_count = 1, Country.objects.count()
             print('\nLoading Sources data for each country to GO DB:: ')
             for country in Country.objects.prefetch_related('countryoverview').all():
-                print(u'\t -> ({}/{}) {}'.format(index, country_count, str(country).encode('utf-8')))
+                print(u'\t -> ({}/{}) {}'.format(index, country_count, str(country)))
                 overview = (
                     country.countryoverview if hasattr(country, 'countryoverview') else
                     CountryOverview.objects.create(country=country)

--- a/main/settings.py
+++ b/main/settings.py
@@ -298,6 +298,7 @@ LOGGING = {
             'class': 'api.filehandler.MakeFileHandler',
             'filename': '../logs/logger.log',
             'formatter': 'timestamp',
+            'encoding': 'utf-8',
         },
     },
     'loggers': {

--- a/notifications/notification.py
+++ b/notifications/notification.py
@@ -139,13 +139,13 @@ def send_notification(subject, recipients, html, mailtype=''):
         NotificationGUID.objects.create(
             api_guid=res_text,
             email_type=mailtype,
-            to_list='To: {to}; Bcc: {bcc}'.format(to=EMAIL_TO, bcc=recipients_as_string)
+            to_list=f'To: {EMAIL_TO}; Bcc: {recipients_as_string}'
         )
 
         logger.info('E-mails were sent successfully.')
     elif res.status_code == 401 or res.status_code == 403:
         # Try sending with Python smtplib, if reaching the API fails
-        logger.error('Authorization/authentication failed ({}) to the e-mail sender API.'.format(res.status_code))
+        logger.error(f'Authorization/authentication failed ({res.status_code}) to the e-mail sender API.')
         msg = construct_msg(subject, html)
         SendMail(to_addresses, msg).start()
     else:


### PR DESCRIPTION
There are multiple errors in most places where logged variables might contain accented/special characters.

## Changes
- Added `encoding: 'utf-8'` to the logger settings