### PR TITLE
Sped up Projects admin page query

### DIFF
--- a/deployments/admin.py
+++ b/deployments/admin.py
@@ -93,6 +93,9 @@ class ProjectAdmin(CompareVersionAdmin, TranslationAdmin):
     class Media:  # Required by AutocompleteFilter
         pass
 
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('reporting_ns')
+
     def get_url_namespace(self, name, absolute=True):
         meta = self.model._meta
         namespace = f'{meta.app_label}_{meta.model_name}_{name}'


### PR DESCRIPTION
(Somewhat) ref.: https://github.com/IFRCGo/go-api/issues/763

Adds `JOIN` to the query and reduces the query count to 1 regarding getting the Projects list.