### PR TITLE
Changed blob urls to use https

### DIFF
--- a/api/storage.py
+++ b/api/storage.py
@@ -196,6 +196,7 @@ class AzureStorage(Storage):
         blob_url_args = {
             'container_name': self.container,
             'blob_name': name,
+            'protocol': 'https'
         }
 
         if self.cdn_host:


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-api/issues/771

## Changes
Azure Storage (blob) URLs to use 'https' instead, this affects (API values too):
- Country - logo
- Country Snippet - image
- Region Snippet - image
- (Event/Emergency) Snippet - image
- Situation Report - document
- Appeal Document - document
- Databank > Key Document - file
- PER Document - document