### PR TITLE
Only show WARN log if there are errors

### DIFF
--- a/api/management/commands/ingest_appeals.py
+++ b/api/management/commands/ingest_appeals.py
@@ -298,7 +298,8 @@ class Command(BaseCommand):
                 logger.error(err_text)
                 errors.append(err_text)
 
-        create_cron_record(CRON_NAME, '\n'.join(errors), CronJobStatus.WARNED, len(errors))
+        if errors:
+            create_cron_record(CRON_NAME, '\n'.join(errors), CronJobStatus.WARNED, len(errors))
 
         appeals_count = Appeal.objects.all().count()
         logger.info(f'{num_created} appeals created')


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-api/issues/750#issuecomment-690924912

## Changes
- Fix for creating WARN logs even if there are no errors