### PR TITLE
Query fix for /personnel endpoint, CSV export simplify

### DIFF
--- a/api/drf_views.py
+++ b/api/drf_views.py
@@ -1,4 +1,5 @@
 import datetime
+
 from rest_framework.status import HTTP_201_CREATED, HTTP_200_OK
 from rest_framework.generics import GenericAPIView, CreateAPIView, UpdateAPIView
 from rest_framework.response import Response
@@ -12,12 +13,15 @@ from django.contrib.auth.models import User
 from django.db import models
 from django.db.models import Prefetch, Count
 from django.utils import timezone
+
+from main.utils import is_tableau
+from deployments.models import Personnel
+from databank.serializers import CountryOverviewSerializer
+
 from .event_sources import SOURCES
 from .exceptions import BadRequest
-from main.utils import is_tableau
 from .view_filters import ListFilter
 from .visibility_class import ReadOnlyVisibilityViewset
-from deployments.models import Personnel
 
 from .models import (
     DisasterType,
@@ -54,7 +58,6 @@ from .models import (
     MainContact
 )
 
-from databank.serializers import CountryOverviewSerializer
 from .serializers import (
     ActionSerializer,
     DisasterTypeSerializer,

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -125,6 +125,12 @@ class MiniCountrySerializer(EnumSupportSerializerMixin, ModelSerializer):
         )
 
 
+class MicroCountrySerializer(ModelSerializer):
+    class Meta:
+        model = Country
+        fields = ('name', 'iso', 'id')
+
+
 class RegoCountrySerializer(ModelSerializer):
     class Meta:
         model = Country
@@ -408,32 +414,32 @@ class ListEventTableauSerializer(EnumSupportSerializerMixin, serializers.ModelSe
     ifrc_severity_level_display = serializers.CharField(source='get_ifrc_severity_level_display', read_only=True)
 
     def get_countries(self, obj):
-        country_fields = {}
+        country_fields = {
+            'id': '',
+            'name': ''
+        }
         countries = obj.countries.all()
         if countries.exists():
             country_fields['id'] = ', '.join([str(id) for id in countries.values_list('id', flat=True)])
             country_fields['name'] = ', '.join(countries.values_list('name', flat=True))
-        else:
-            country_fields['id'] = ''
-            country_fields['name'] = ''
         return country_fields
 
     def get_field_reports(self, obj):
-        field_reports_fields = {}
+        field_reports_fields = {
+            'id': ''
+        }
         field_reports = obj.field_reports.all()
         if len(field_reports) > 0:
             field_reports_fields['id'] = ', '.join([str(field_reports.id) for field_reports in field_reports])
-        else:
-            field_reports_fields['id'] = ''
         return field_reports_fields
 
     def get_appeals(self, obj):
-        appeals_fields = {}
+        appeals_fields = {
+            'id': ''
+        }
         appeals = obj.appeals.all()
         if len(appeals) > 0:
             appeals_fields['id'] = ', '.join([str(appeals.id) for appeals in appeals])
-        else:
-            appeals_fields['id'] = ''
         return appeals_fields
 
     class Meta:
@@ -468,21 +474,21 @@ class ListEventCsvSerializer(EnumSupportSerializerMixin, serializers.ModelSerial
         return country_fields
 
     def get_field_reports(self, obj):
-        field_reports_fields = {}
+        field_reports_fields = {
+            'id': ''
+        }
         field_reports = obj.field_reports.all()
         if len(field_reports) > 0:
             field_reports_fields['id'] = ', '.join([str(field_reports.id) for field_reports in field_reports])
-        else:
-            field_reports_fields['id'] = ''
         return field_reports_fields
 
     def get_appeals(self, obj):
-        appeals_fields = {}
+        appeals_fields = {
+            'id': ''
+        }
         appeals = obj.appeals.all()
         if len(appeals) > 0:
             appeals_fields['id'] = ', '.join([str(appeals.id) for appeals in appeals])
-        else:
-            appeals_fields['id'] = ''
         return appeals_fields
 
     class Meta:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -466,7 +466,7 @@ class ListEventForPersonnelCsvSerializer(EnumSupportSerializerMixin, serializers
 
     # NOTE: prefetched at deployments/drf_views.py::PersonnelViewset::get_queryset
     def get_countries(self, obj):
-        fields = ['id', 'name', 'iso', 'iso3']
+        fields = ['id', 'name', 'iso', 'iso3', 'society_name']
         return get_merged_items_by_fields(obj.countries.all(), fields)
 
     def get_field_reports(self, obj):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -500,6 +500,55 @@ class ListEventCsvSerializer(EnumSupportSerializerMixin, serializers.ModelSerial
         )
 
 
+class ListEventForPersonnelCsvSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+    appeals = serializers.SerializerMethodField()
+    field_reports = serializers.SerializerMethodField()
+    countries = serializers.SerializerMethodField()
+    dtype_name = serializers.SerializerMethodField()
+
+    def get_countries(self, obj):
+        country_fields = {
+            'id': '',
+            'name': ''
+        }
+        countries = obj.countries.all()
+        if countries.exists():
+            country_fields['id'] = ', '.join([str(id) for id in countries.values_list('id', flat=True)])
+            country_fields['name'] = ', '.join(countries.values_list('name', flat=True))
+        return country_fields
+
+    def get_field_reports(self, obj):
+        field_reports_fields = {
+            'id': ''
+        }
+        field_reports = obj.field_reports.all()
+        if len(field_reports) > 0:
+            field_reports_fields['id'] = ', '.join([str(field_reports.id) for field_reports in field_reports])
+        return field_reports_fields
+
+    def get_appeals(self, obj):
+        appeals_fields = {
+            'id': ''
+        }
+        appeals = obj.appeals.all()
+        if len(appeals) > 0:
+            appeals_fields['id'] = ', '.join([str(appeals.id) for appeals in appeals])
+        return appeals_fields
+
+    def get_dtype_name(self, obj):
+        if obj.dtype:
+            return obj.dtype.name
+        return None
+
+    class Meta:
+        model = Event
+        fields = (
+            'name', 'dtype_name', 'countries', 'summary', 'num_affected', 'ifrc_severity_level',
+            'glide', 'disaster_start_date', 'created_at', 'appeals',
+            'field_reports', 'updated_at', 'id', 'parent_event',
+        )
+
+
 class ListEventDeploymentsSerializer(serializers.Serializer):
     id = serializers.IntegerField()
     type = serializers.CharField()

--- a/deployments/drf_views.py
+++ b/deployments/drf_views.py
@@ -12,11 +12,9 @@ from django.db.models import (
     Subquery,
     OuterRef,
     IntegerField,
-    CharField,
     Prefetch,
 )
-from django.db.models.functions import Coalesce, Cast
-from django.contrib.postgres.aggregates import StringAgg
+from django.db.models.functions import Coalesce
 from django.shortcuts import get_object_or_404
 from rest_framework import viewsets
 from reversion.views import RevisionMixin

--- a/deployments/factories/personnel.py
+++ b/deployments/factories/personnel.py
@@ -1,0 +1,23 @@
+import factory
+
+from api.factories.country import CountryFactory
+from api.factories.region import RegionFactory
+from deployments.models import (
+    Personnel,
+    PersonnelDeployment,
+)
+
+
+class PersonnelDeploymentFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = PersonnelDeployment
+
+    country_deployed_to = factory.SubFactory(CountryFactory)
+    region_deployed_to = factory.SubFactory(RegionFactory)
+
+
+class PersonnelFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Personnel
+
+    deployment = factory.SubFactory(PersonnelDeploymentFactory)

--- a/deployments/models.py
+++ b/deployments/models.py
@@ -115,7 +115,7 @@ class PersonnelDeployment(models.Model):
     updated_at = models.DateTimeField(verbose_name=_('updated at'), auto_now=True)
     previous_update = models.DateTimeField(verbose_name=_('previous update'), null=True, blank=True)
     comments = models.TextField(verbose_name=_('comments'), null=True, blank=True)
-    is_molnix = models.BooleanField(default=False) # Source is Molnix API
+    is_molnix = models.BooleanField(default=False)  # Source is Molnix API
 
     class Meta:
         verbose_name = _('Personnel Deployment')
@@ -128,7 +128,7 @@ class PersonnelDeployment(models.Model):
 class MolnixTag(models.Model):
     '''
     We store tags from molnix in its own model, to make m2m relations
-    from notifications.models.SurgeAlert and DeployedPerson        
+    from notifications.models.SurgeAlert and DeployedPerson
     '''
     molnix_id = models.IntegerField()
     name = models.CharField(max_length=255)

--- a/deployments/serializers.py
+++ b/deployments/serializers.py
@@ -20,8 +20,10 @@ from .models import (
 from api.serializers import (
     DisasterTypeSerializer,
     ListEventSerializer,
+    ListEventForPersonnelCsvSerializer,
     MiniEventSerializer,
     MiniCountrySerializer,
+    MicroCountrySerializer,
     MiniDistrictSerializer,
 )
 
@@ -70,6 +72,16 @@ class MolnixTagSerializer(ModelSerializer):
         fields = ('id', 'molnix_id', 'name', 'color', 'tag_type')
         model = MolnixTag
 
+
+class PersonnelDeploymentCsvSerializer(ModelSerializer):
+    country_deployed_to = MicroCountrySerializer()
+    event_deployed_to = ListEventForPersonnelCsvSerializer()
+
+    class Meta:
+        model = PersonnelDeployment
+        fields = ('country_deployed_to', 'event_deployed_to', 'comments', 'id')
+
+
 class PersonnelSerializer(ModelSerializer):
     country_from = MiniCountrySerializer()
     deployment = PersonnelDeploymentSerializer()
@@ -79,6 +91,15 @@ class PersonnelSerializer(ModelSerializer):
         model = Personnel
         fields = ('start_date', 'end_date', 'name', 'role', 'type', 'country_from',
                   'deployment', 'molnix_id', 'molnix_tags', 'is_active', 'id',)
+
+
+class PersonnelCsvSerializer(ModelSerializer):
+    country_from = MicroCountrySerializer()
+    deployment = PersonnelDeploymentCsvSerializer()
+
+    class Meta:
+        model = Personnel
+        fields = ('start_date', 'end_date', 'name', 'role', 'type', 'country_from', 'deployment', 'id',)
 
 
 class PartnerDeploymentActivitySerializer(ModelSerializer):

--- a/deployments/serializers.py
+++ b/deployments/serializers.py
@@ -1,7 +1,17 @@
 from django.utils.translation import ugettext
 from rest_framework import serializers
 from enumfields.drf.serializers import EnumSupportSerializerMixin
+
 from lang.serializers import ModelSerializer
+from api.serializers import (
+    DisasterTypeSerializer,
+    ListEventSerializer,
+    ListEventForPersonnelCsvSerializer,
+    MiniEventSerializer,
+    MiniCountrySerializer,
+    MicroCountrySerializer,
+    MiniDistrictSerializer,
+)
 
 from .models import (
     ERUOwner,
@@ -16,15 +26,6 @@ from .models import (
 
     OperationTypes,
     ProgrammeTypes,
-)
-from api.serializers import (
-    DisasterTypeSerializer,
-    ListEventSerializer,
-    ListEventForPersonnelCsvSerializer,
-    MiniEventSerializer,
-    MiniCountrySerializer,
-    MicroCountrySerializer,
-    MiniDistrictSerializer,
 )
 
 

--- a/deployments/serializers.py
+++ b/deployments/serializers.py
@@ -99,7 +99,7 @@ class PersonnelCsvSerializer(ModelSerializer):
 
     class Meta:
         model = Personnel
-        fields = ('start_date', 'end_date', 'name', 'role', 'type', 'country_from', 'deployment', 'id',)
+        fields = ('start_date', 'end_date', 'name', 'role', 'type', 'country_from', 'deployment', 'id', 'is_active',)
 
 
 class PartnerDeploymentActivitySerializer(ModelSerializer):

--- a/deployments/test_views.py
+++ b/deployments/test_views.py
@@ -1,4 +1,5 @@
 import json
+import csv
 
 from django.conf import settings
 
@@ -6,6 +7,8 @@ from modeltranslation.utils import build_localized_fieldname
 from api.models import Country, District, Region, DisasterType
 from main.test_case import APITestCase
 from api.models import VisibilityCharChoices
+
+from .factories.personnel import PersonnelFactory
 
 from .models import (
     Project,
@@ -369,6 +372,18 @@ class ProjectGetTest(APITestCase):
             'nodes': sorted(resp['nodes'], key=lambda item: dict_to_string(item)),
             'links': sorted(resp['links'], key=lambda item: dict_to_string(item)),
         })
+
+    def test_personnel_csv_api(self):
+        [PersonnelFactory() for i in range(10)]
+
+        url = '/api/v2/personnel/?format=csv'
+        resp = self.client.get(url)
+        self.assert_401(resp)
+
+        self.authenticate(self.user)
+        resp = self.client.get(url)
+        self.assert_200(resp)
+        list(csv.reader(resp.content.decode('utf-8').splitlines(), delimiter=','))
 
 
 class TranslationTest(APITestCase):

--- a/main/test_case.py
+++ b/main/test_case.py
@@ -68,6 +68,9 @@ class APITestCase(test.APITestCase):
     def assert_400(self, response):
         self.assert_http_code(response, status.HTTP_400_BAD_REQUEST)
 
+    def assert_401(self, response):
+        self.assert_http_code(response, status.HTTP_401_UNAUTHORIZED)
+
     def assert_403(self, response):
         self.assert_http_code(response, status.HTTP_403_FORBIDDEN)
 

--- a/main/utils.py
+++ b/main/utils.py
@@ -12,7 +12,7 @@ def get_merged_items_by_fields(items, fields, seperator=', '):
     """
     For given array and fields:
     input: [{'name': 'name 1', 'age': 2}, {'name': 'name 2', 'height': 32}], ['name', 'age']
-    output: {'name': 'name 1, name 2', 'age': '2'}
+    output: {'name': 'name 1, name 2', 'age': '2, '}
     """
     data = defaultdict(list)
     for item in items:

--- a/main/utils.py
+++ b/main/utils.py
@@ -1,5 +1,26 @@
+from collections import defaultdict
+
+
 def is_tableau(request):
     """ Checking the request for the 'tableau' parameter
         (used mostly for switching to the *TableauSerializers)
     """
     return request.GET.get('tableau', 'false').lower() == 'true'
+
+
+def get_merged_items_by_fields(items, fields, seperator=', '):
+    """
+    For given array and fields:
+    input: [{'name': 'name 1', 'age': 2}, {'name': 'name 2', 'height': 32}], ['name', 'age']
+    output: {'name': 'name 1, name 2', 'age': '2'}
+    """
+    data = defaultdict(list)
+    for item in items:
+        for field in fields:
+            value = getattr(item, field, None)
+            if value is not None:
+                data[field].append(str(value))
+    return {
+        field: seperator.join(data[field])
+        for field in fields
+    }


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-api/issues/903

## Changes
- Somewhat simplifies the CSV export of the `/api/v2/personnel` endpoint
- Added `select_related()` and `prefetch_related()` to the query

This is still a sample (mockup) version of the export. Would be good to test on staging.