### PR TITLE
Add translated fields to searches

### DIFF
--- a/lang/admin.py
+++ b/lang/admin.py
@@ -98,6 +98,13 @@ class TranslationAdmin(TranslationAdminMixin, O_TranslationAdmin):
         if instances and formset.model in self.TRANSLATION_REGISTERED_MODELS:
             TranslatedModelSerializerMixin.trigger_field_translation_in_bulk(formset.model, instances)
 
+    def get_search_fields(self, request):
+        # Ex. 'name' is translatable - add 'name_fr', 'name_es', etc
+        concated_search = (
+            list(self.search_fields) + TranslatedModelSerializerMixin._get_translated_fields_list(self.model, self.search_fields)
+        )
+        return concated_search
+
 
 class TranslationInlineModelAdmin(TranslationAdminMixin, O_TranslationInlineModelAdmin):
     pass

--- a/lang/admin.py
+++ b/lang/admin.py
@@ -101,7 +101,9 @@ class TranslationAdmin(TranslationAdminMixin, O_TranslationAdmin):
     def get_search_fields(self, request):
         # Ex. 'name' is translatable - add 'name_fr', 'name_es', etc
         concated_search = (
-            list(self.search_fields) + TranslatedModelSerializerMixin._get_translated_fields_list(self.model, self.search_fields)
+            list(self.search_fields) + TranslatedModelSerializerMixin._get_translated_searchfields_list(
+                self.model, self.search_fields
+            )
         )
         return concated_search
 

--- a/lang/serializers.py
+++ b/lang/serializers.py
@@ -74,6 +74,17 @@ class TranslatedModelSerializerMixin(serializers.ModelSerializer):
         return included_fields_lang, excluded_fields, additional_fields
 
     @classmethod
+    def _get_translated_fields_list(cls, model, orig_searchfields=[]):
+        """
+        Add translatable fieldnames to search if the original field is in search
+        """
+        field_list = []
+        for field in get_translatable_fields_for_model(model) or []:
+            if field in orig_searchfields:
+                field_list.extend([f'{field}_en', f'{field}_es', f'{field}_fr', f'{field}_ar'])
+        return field_list
+
+    @classmethod
     def _get_language_clear_validated_data(cls, instance, validated_data, included_fields_lang):
         """
         Clear value for other languages for fields if single language is specified

--- a/lang/serializers.py
+++ b/lang/serializers.py
@@ -74,7 +74,7 @@ class TranslatedModelSerializerMixin(serializers.ModelSerializer):
         return included_fields_lang, excluded_fields, additional_fields
 
     @classmethod
-    def _get_translated_fields_list(cls, model, orig_searchfields=[]):
+    def _get_translated_searchfields_list(cls, model, orig_searchfields=[]):
         """
         Add translatable fieldnames to search if the original field is in search
         """


### PR DESCRIPTION
## Changes
- Adds translation fields to the `search_fields` too

Example: `name` is translatable -> `name_en`, `name_fr`, `name_es`, `name_ar` are all added to the list