### PR TITLE
fix mapping of CAM geographic code to Honduras from Haiti, refs #1671

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 1.1.302
+
+ - Hotfix: Appeal ingest geo-mapping fix
+
 ## 1.1.300
 
 ### Added

--- a/api/management/commands/ingest_appeals.py
+++ b/api/management/commands/ingest_appeals.py
@@ -22,7 +22,7 @@ REGION_TO_COUNTRY = {
     'EAF': 'KE',  # Eastern Africa country cluster: Kenya
     'CAF': 'CM',  # Central Africa country cluster: Cameroon
     'SAF': 'ZA',  # Southern Africa country cluster: South Africa
-    'CAM': 'HT',  # Latin Caribbean Country Cluster Office: Haiti
+    'CAM': 'HN',  # Latin Caribbean Country Cluster Office: Honduras
     'CAR': 'TT',  # Caribbean Country Cluster: Trinidad and Tobago
     'NAM': 'PA',  # Americas regional office: Panama
     'AME': 'PA',  # Americas regional office: Panama


### PR DESCRIPTION
Addresses https://github.com/IFRCGo/go-frontend/issues/1671

## Changes

Fixes mapping of CAM geo-code in ingest_appeals script to Honduras instead of Haiti.