### PR TITLE
make label for additional tab name field consistent, fix Region Admin class

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -458,7 +458,7 @@ class CountryAdmin(geoadmin.OSMGeoAdmin, CompareVersionAdmin, RegionRestrictedAd
     exclude = ('key_priorities',)
 
 
-class RegionAdmin(geoadmin.OSMGeoAdmin, CompareVersionAdmin, RegionRestrictedAdmin):
+class RegionAdmin(geoadmin.OSMGeoAdmin, CompareVersionAdmin, RegionRestrictedAdmin, TranslationAdmin):
     country_in = None
     region_in = 'pk__in'
     inlines = [

--- a/api/models.py
+++ b/api/models.py
@@ -166,7 +166,7 @@ class Country(models.Model):
     wb_year = models.CharField(
         verbose_name=_('WB Year'), max_length=4, null=True, blank=True, help_text=_('population data year from WB API')
     )
-    additional_tab_name = models.CharField(verbose_name=_('Label for Extra Tab'), max_length=100, blank=True)
+    additional_tab_name = models.CharField(verbose_name=_('Label for Additional Tab'), max_length=100, blank=True)
 
     # Additional NS Indicator fields
     nsi_income = models.IntegerField(verbose_name=_('Income (CHF)'), blank=True, null=True)


### PR DESCRIPTION
Refs https://github.com/IFRCGo/go-frontend/issues/1621#issuecomment-733641519

 - makes the label for the additional tab field consistent between Region and Country
 - Removes the extra field for additional tab name showing up in the Region admin

cc @GregoryHorvath 