### PR TITLE
new locale files regenerated with new strings

### DIFF
--- a/api/locale/ar/LC_MESSAGES/django.po
+++ b/api/locale/ar/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-24 07:55+0000\n"
+"POT-Creation-Date: 2020-11-30 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,2040 +16,2176 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
-#: api/admin.py:51
+#: admin.py:32 models.py:1306
+msgid "user profile"
+msgstr "ملف تعريف المستخدم"
+
+#: admin.py:67
 msgid "related emergency"
 msgstr "الطوارئ ذات الصلة"
 
-#: api/admin.py:56
+#: admin.py:72
 msgid "Exists"
 msgstr "موجود"
 
-#: api/admin.py:57
+#: admin.py:73
 msgid "Needs confirmation"
 msgstr "يحتاج إلى تأكيد"
 
-#: api/admin.py:58
+#: admin.py:74
 msgid "None"
 msgstr "لايوجد"
 
-#: api/admin.py:71
+#: admin.py:87
 msgid "membership"
 msgstr "عضوية"
 
-#: api/admin.py:83 api/models.py:670
+#: admin.py:99 models.py:779
 msgid "appeal type"
 msgstr "نوع الاستئناف"
 
-#: api/admin.py:95
+#: admin.py:111
 msgid "featured"
 msgstr "متميز"
 
-#: api/admin.py:100
+#: admin.py:116
 msgid "Featured"
 msgstr "مميز"
 
-#: api/admin.py:101
+#: admin.py:117
 msgid "Not Featured"
 msgstr "غير مميز"
 
-#: api/admin.py:112 api/models.py:233 api/models.py:532 api/models.py:1175
+#: admin.py:128 models.py:285 models.py:641 models.py:1261
 msgid "source"
 msgstr "المصدر"
 
-#: api/admin.py:117
+#: admin.py:133
 msgid "Manual input"
 msgstr "إدخال يدويّ"
 
-#: api/admin.py:118
+#: admin.py:134
 msgid "GDACs scraper"
 msgstr "مكشطة GDACs"
 
-#: api/admin.py:119
+#: admin.py:135
 msgid "WHO scraper"
 msgstr "مكشطة منظمة الصحة العالمية"
 
-#: api/admin.py:120
+#: admin.py:136
 msgid "Field report ingest"
 msgstr "استيعاب التقرير الميداني"
 
-#: api/admin.py:121
+#: admin.py:137
 msgid "Field report admin"
 msgstr "مشرف تقرير ميداني"
 
-#: api/admin.py:122
+#: admin.py:138
 msgid "Appeals admin"
 msgstr "يستأنف المشرف"
 
-#: api/admin.py:123
+#: admin.py:139
 msgid "Unknown automated"
 msgstr "آلياً غير معروف"
 
-#: api/apps.py:6
+#: apps.py:6
 msgid "api"
 msgstr "واجهة برمجة التطبيقات"
 
-#: api/forms.py:8 api/models.py:1114
+#: forms.py:8 models.py:1200
 msgid "organizations"
 msgstr "المنظمات"
 
-#: api/forms.py:9 api/models.py:1118
+#: forms.py:9 models.py:1204
 msgid "field report types"
 msgstr "أنواع التقارير الميدانية"
 
-#: api/models.py:38 api/models.py:67 api/models.py:125 api/models.py:178
-#: api/models.py:350 api/models.py:392 api/models.py:420 api/models.py:514
-#: api/models.py:585 api/models.py:668 api/models.py:773 api/models.py:1053
-#: api/models.py:1111 api/models.py:1156 api/models.py:1549
+#: models.py:39 models.py:68 models.py:136 models.py:225 models.py:459
+#: models.py:501 models.py:623 models.py:694 models.py:777 models.py:882
+#: models.py:1139 models.py:1197 models.py:1242 models.py:1636
 msgid "name"
 msgstr "الاسم"
 
-#: api/models.py:39 api/models.py:414 api/models.py:835 api/models.py:1141
+#: models.py:40 models.py:523 models.py:944 models.py:1227
 msgid "summary"
 msgstr "ملخص"
 
-#: api/models.py:43 api/models.py:403 api/models.py:669 api/models.py:837
+#: models.py:44 models.py:512 models.py:778 models.py:946
 msgid "disaster type"
 msgstr "نوع الكارثة"
 
-#: api/models.py:44
+#: models.py:45
 msgid "disaster types"
 msgstr "أنواع الكوارث"
 
-#: api/models.py:58
+#: models.py:59
 msgid "Africa"
 msgstr "أفريقيا"
 
-#: api/models.py:59
+#: models.py:60
 msgid "Americas"
 msgstr "أميركا"
 
-#: api/models.py:60
+#: models.py:61
 msgid "Asia Pacific"
 msgstr "آسيا والمحيط الهادئ"
 
-#: api/models.py:61
+#: models.py:62
 msgid "Europe"
 msgstr "أوروبا"
 
-#: api/models.py:62
+#: models.py:63
 msgid "Middle East & North Africa"
 msgstr "الشرق الأوسط وشمال أفريقيا"
 
-#: api/models.py:85 api/models.py:132 api/models.py:246 api/models.py:288
-#: api/models.py:333 api/models.py:363 api/models.py:692
+#: models.py:70
+#, fuzzy
+#| msgid "number of highest risk"
+msgid "name of the region"
+msgstr "عدد من أعلى المخاطر"
+
+#: models.py:95 models.py:144 models.py:298 models.py:340 models.py:358
+#: models.py:374 models.py:390 models.py:441 models.py:472 models.py:801
 msgid "region"
 msgstr "إقليم"
 
-#: api/models.py:86 api/models.py:406 api/models.py:843
+#: models.py:96 models.py:515 models.py:952
 msgid "regions"
 msgstr "أقاليم"
 
-#: api/models.py:110
+#: models.py:120
 msgid "Country"
 msgstr "البلد"
 
-#: api/models.py:111
+#: models.py:121
 msgid "Cluster"
 msgstr "تجمع"
 
-#: api/models.py:112
+#: models.py:122
 msgid "Region"
 msgstr "المنطقة"
 
-#: api/models.py:113
+#: models.py:123
 msgid "Country Office"
 msgstr "المكتب الاقليمي"
 
-#: api/models.py:114
+#: models.py:124
 msgid "Representative Office"
 msgstr "المكتب التمثيلي"
 
-#: api/models.py:126 api/models.py:349 api/models.py:513 api/models.py:565
-#: api/models.py:593 api/models.py:1052 api/models.py:1168
+#: models.py:137 models.py:458 models.py:622 models.py:674 models.py:702
+#: models.py:1138 models.py:1254
 msgid "type"
 msgstr "النوع"
 
-#: api/models.py:126
+#: models.py:137
 msgid "Type of entity"
 msgstr "نوع الجهة"
 
-#: api/models.py:127
+#: models.py:138
 msgid "ISO"
 msgstr "ايزو"
 
-#: api/models.py:128
+#: models.py:139
 msgid "ISO3"
 msgstr "ISO3"
 
-#: api/models.py:129
+#: models.py:140
+msgid "FDRS"
+msgstr ""
+
+#: models.py:141
 msgid "society name"
 msgstr "اسم المجتمع"
 
-#: api/models.py:130
+#: models.py:142
 msgid "URL - Society"
 msgstr "موقع الجمعية"
 
-#: api/models.py:131
+#: models.py:143
 msgid "URL - IFRC"
 msgstr "موقع الاتحاد"
 
-#: api/models.py:133
+#: models.py:145
 msgid "overview"
 msgstr "فكرة عامة"
 
-#: api/models.py:134
+#: models.py:146
 msgid "key priorities"
 msgstr "الأولويات الرئيسية"
 
-#: api/models.py:135
+#: models.py:147
 msgid "inform score"
 msgstr "أدخل النتيجة أو إدخال النتيجة"
 
-#: api/models.py:137
+#: models.py:149
 msgid "logo"
 msgstr "شعار"
 
-#: api/models.py:143 api/models.py:189
+#: models.py:156
+#, fuzzy
+#| msgid "Is it an enclave away from parent country?"
+msgid "Is this an independent country?"
+msgstr "هل هو جيب بعيد عن البلد الأم؟"
+
+#: models.py:159
+msgid "Is this an active, valid country?"
+msgstr ""
+
+#: models.py:164 models.py:241
 msgid "WB population"
 msgstr "سكان الضفة الغربية"
 
-#: api/models.py:143 api/models.py:189
+#: models.py:164 models.py:241
 msgid "population data from WB API"
 msgstr "البيانات السكانية من WB API"
 
-#: api/models.py:146
+#: models.py:167
 msgid "WB Year"
 msgstr "سنة WB"
 
-#: api/models.py:146 api/models.py:192
+#: models.py:167 models.py:244
 msgid "population data year from WB API"
 msgstr "سنة البيانات السكانية من WB API"
 
-#: api/models.py:168 api/models.py:180 api/models.py:254 api/models.py:306
-#: api/models.py:341 api/models.py:371 api/models.py:691 api/models.py:1207
+#: models.py:169
+msgid "Label for Additional Tab"
+msgstr ""
+
+#: models.py:172
+msgid "Income (CHF)"
+msgstr ""
+
+#: models.py:173
+msgid "Expenditures (CHF)"
+msgstr ""
+
+#: models.py:174
+msgid "Branches"
+msgstr ""
+
+#: models.py:175
+msgid "Staff"
+msgstr ""
+
+#: models.py:176
+#, fuzzy
+#| msgid "number of volunteers"
+msgid "Volunteers"
+msgstr "عدد المتطوعين"
+
+#: models.py:177
+msgid "Youth - 6-19 Yrs"
+msgstr ""
+
+#: models.py:178
+msgid "Trained in First Aid"
+msgstr ""
+
+#: models.py:179
+msgid "Gov Financial Support"
+msgstr ""
+
+#: models.py:180
+msgid ">50% Domestically Generated Income"
+msgstr ""
+
+#: models.py:181
+msgid "Annual Reporting to FDRS"
+msgstr ""
+
+#: models.py:182
+msgid "Your Policy / Programme Implementation"
+msgstr ""
+
+#: models.py:183
+msgid "Risk Management Framework"
+msgstr ""
+
+#: models.py:184
+msgid "Complying with CMC Dashboard"
+msgstr ""
+
+#: models.py:187
+msgid "Total WASH Staff"
+msgstr ""
+
+#: models.py:188
+msgid "WASH Kit2"
+msgstr ""
+
+#: models.py:189
+msgid "WASH Kit5"
+msgstr ""
+
+#: models.py:190
+msgid "WASH Kit10"
+msgstr ""
+
+#: models.py:191
+msgid "WASH Staff at HQ"
+msgstr ""
+
+#: models.py:192
+msgid "WASH Staff at Branch"
+msgstr ""
+
+#: models.py:193
+msgid "NDRT Trained"
+msgstr ""
+
+#: models.py:194
+msgid "RDRT Trained"
+msgstr ""
+
+#: models.py:215 models.py:227 models.py:306 models.py:414 models.py:450
+#: models.py:480 models.py:800 models.py:1293
 msgid "country"
 msgstr "البلد"
 
-#: api/models.py:169 api/models.py:405 api/models.py:627 api/models.py:842
+#: models.py:216 models.py:514 models.py:736 models.py:951
 msgid "countries"
 msgstr "الدول"
 
-#: api/models.py:179 api/models.py:673
+#: models.py:226 models.py:782
 msgid "code"
 msgstr "الرمز"
 
-#: api/models.py:181
-msgid "country ISO3"
+#: models.py:228
+#, fuzzy
+#| msgid "country ISO3"
+msgid "country ISO2"
 msgstr "بلد ISO3"
 
-#: api/models.py:182
+#: models.py:229
 msgid "country name"
 msgstr "اسم الدولة"
 
-#: api/models.py:184
+#: models.py:231
 msgid "is enclave?"
 msgstr "هو الجيب؟"
 
-#: api/models.py:184
+#: models.py:231
 msgid "Is it an enclave away from parent country?"
 msgstr "هل هو جيب بعيد عن البلد الأم؟"
 
-#: api/models.py:192
+#: models.py:237
+msgid "Is this an active, valid district?"
+msgstr ""
+
+#: models.py:244
 msgid "WB year"
 msgstr "سنة WB"
 
-#: api/models.py:197
+#: models.py:249
 msgid "district"
 msgstr "القضاء أو المحافظة"
 
-#: api/models.py:198 api/models.py:404 api/models.py:841
+#: models.py:250 models.py:513 models.py:950
 msgid "districts"
 msgstr "الاقضية أو المحفظات"
 
-#: api/models.py:210 api/models.py:222
+#: models.py:262 models.py:274
 msgid "Membership"
 msgstr "العضوية"
 
-#: api/models.py:211 api/models.py:223
+#: models.py:263 models.py:275
 msgid "IFRC Only"
 msgstr "الاتحاد الدولي لجمعيات الصليب الأحمر والهلال الأحمر فقط"
 
-#: api/models.py:212 api/models.py:224
+#: models.py:264 models.py:276
 msgid "Public"
 msgstr "عام"
 
-#: api/models.py:231
+#: models.py:283
 msgid "figure"
 msgstr "رسم أو صورة ليست رقم "
 
-#: api/models.py:232 api/models.py:531
+#: models.py:284 models.py:640
 msgid "deck"
 msgstr "منصة"
 
-#: api/models.py:234 api/models.py:293 api/models.py:311 api/models.py:550
-#: api/models.py:595 api/models.py:934
+#: models.py:286 models.py:345 models.py:419 models.py:659 models.py:704
+#: models.py:1020
 msgid "visibility"
 msgstr "أو الرؤيا حسب موقع الجملة"
 
-#: api/models.py:238
+#: models.py:290
 msgid "admin key figure"
 msgstr "الرقم الرئيسي للمشرف"
 
-#: api/models.py:239
+#: models.py:291
 msgid "admin key figures"
 msgstr "الشخصيات الرئيسية المشرف"
 
-#: api/models.py:249
+#: models.py:301
 msgid "region key figure"
 msgstr "رقم مفتاح المنطقة"
 
-#: api/models.py:250
+#: models.py:302
 msgid "region key figures"
 msgstr "الشخصيات الرئيسية في المنطقة"
 
-#: api/models.py:257
+#: models.py:309
 msgid "country key figure"
 msgstr "الرقم الرئيسي البلد"
 
-#: api/models.py:258
+#: models.py:310
 msgid "country key figures"
 msgstr "الشخصيات الرئيسية في البلاد"
 
-#: api/models.py:269
+#: models.py:321
 msgid "Top"
 msgstr "أعلى الموقع"
 
-#: api/models.py:270
+#: models.py:322
 msgid "High"
 msgstr "مرتفع"
 
-#: api/models.py:271
+#: models.py:323
 msgid "Middle"
 msgstr "أوسط"
 
-#: api/models.py:272
+#: models.py:324
 msgid "Low"
 msgstr "متدني"
 
-#: api/models.py:273
+#: models.py:325
 msgid "Bottom"
 msgstr "أسفل الموقع"
 
-#: api/models.py:282
+#: models.py:334
 msgid "Tab 1"
 msgstr "جدول 1"
 
-#: api/models.py:283
+#: models.py:335
 msgid "Tab 2"
 msgstr "جدول 2"
 
-#: api/models.py:284
+#: models.py:336
 msgid "Tab 3"
 msgstr "جدول 3"
 
-#: api/models.py:289 api/models.py:307 api/models.py:545 api/models.py:556
+#: models.py:341 models.py:360 models.py:376 models.py:392 models.py:415
+#: models.py:654 models.py:665
 msgid "snippet"
 msgstr "مقتطف أو مستخرج"
 
-#: api/models.py:291 api/models.py:309 api/models.py:547 api/models.py:612
+#: models.py:343 models.py:417 models.py:656 models.py:721
 msgid "image"
 msgstr "صورة"
 
-#: api/models.py:294 api/models.py:312 api/models.py:551 api/models.py:1215
+#: models.py:346 models.py:362 models.py:378 models.py:394 models.py:420
+#: models.py:660 models.py:1301
 msgid "position"
 msgstr "المركز"
 
-#: api/models.py:298
+#: models.py:350
 msgid "region snippet"
 msgstr "مقتطف المنطقة"
 
-#: api/models.py:299
+#: models.py:351
 msgid "region snippets"
 msgstr "مقتطفات المنطقة"
 
-#: api/models.py:316
+#: models.py:366
+#, fuzzy
+#| msgid "region snippet"
+msgid "region emergencies snippet"
+msgstr "مقتطف المنطقة"
+
+#: models.py:367
+#, fuzzy
+#| msgid "region snippets"
+msgid "region emergencies snippets"
+msgstr "مقتطفات المنطقة"
+
+#: models.py:382
+#, fuzzy
+#| msgid "region snippet"
+msgid "region preparedness snippet"
+msgstr "مقتطف المنطقة"
+
+#: models.py:383
+#, fuzzy
+#| msgid "region snippets"
+msgid "region preparedness snippets"
+msgstr "مقتطفات المنطقة"
+
+#: models.py:398
+#, fuzzy
+#| msgid "region snippet"
+msgid "region profile snippet"
+msgstr "مقتطف المنطقة"
+
+#: models.py:399
+#, fuzzy
+#| msgid "region snippets"
+msgid "region profile snippets"
+msgstr "مقتطفات المنطقة"
+
+#: models.py:424
 msgid "country snippet"
 msgstr "مقتطف البلد"
 
-#: api/models.py:317
+#: models.py:425
 msgid "country snippets"
 msgstr "مقتطفات البلد"
 
-#: api/models.py:324 api/models.py:351 api/models.py:515 api/models.py:610
-#: api/models.py:1054
+#: models.py:432 models.py:460 models.py:624 models.py:719 models.py:1140
 msgid "title"
 msgstr "العنوان"
 
-#: api/models.py:325
+#: models.py:433
 msgid "url"
 msgstr "عنوان URL"
 
-#: api/models.py:328
+#: models.py:436
 msgid "admin link"
 msgstr "رابط المشرف "
 
-#: api/models.py:329
+#: models.py:437
 msgid "admin links"
 msgstr "روابط المسؤول"
 
-#: api/models.py:336
+#: models.py:445
 msgid "region link"
 msgstr "رابط الإقليم"
 
-#: api/models.py:337
+#: models.py:446
 msgid "region links"
 msgstr "روابط الأقاليم"
 
-#: api/models.py:344
+#: models.py:453
 msgid "country link"
 msgstr "صفحة ارتباط البلد"
 
-#: api/models.py:345
+#: models.py:454
 msgid "country links"
 msgstr "روابط الدول"
 
-#: api/models.py:352 api/models.py:516 api/models.py:1055
+#: models.py:461 models.py:625 models.py:1141
 msgid "email"
 msgstr "البريد الإلكتروني"
 
-#: api/models.py:355
+#: models.py:464
 msgid "admin contact"
 msgstr "تواصل مع المشرف"
 
-#: api/models.py:356
+#: models.py:465
 msgid "admin contacts"
 msgstr "اتصالات المسؤول"
 
-#: api/models.py:366
+#: models.py:475
 msgid "region contact"
 msgstr "جهة اتصال المنطقة"
 
-#: api/models.py:367
+#: models.py:476
 msgid "region contacts"
 msgstr "اتصالات المنطقة"
 
-#: api/models.py:374
+#: models.py:483
 msgid "country contact"
 msgstr "جهة اتصال البلد"
 
-#: api/models.py:375
+#: models.py:484
 msgid "country contacts"
 msgstr "اتصالات البلد"
 
-#: api/models.py:384
+#: models.py:493
 msgid "Green"
 msgstr "أخضر"
 
-#: api/models.py:385
+#: models.py:494
 msgid "Orange"
 msgstr "برتقالي "
 
-#: api/models.py:386
+#: models.py:495
 msgid "Red"
 msgstr "أحمر"
 
-#: api/models.py:395
+#: models.py:504
 msgid "slug"
 msgstr "سبيكة"
 
-#: api/models.py:398
+#: models.py:507
 msgid ""
-"Optional string for a clean URL. For example, "
-"go.ifrc.org/emergencies/hurricane-katrina-2019. The string cannot start with"
-" a number and is forced to be lowercase. Recommend using hyphens over "
-"underscores. Special characters like # is not allowed."
+"Optional string for a clean URL. For example, go.ifrc.org/emergencies/"
+"hurricane-katrina-2019. The string cannot start with a number and is forced "
+"to be lowercase. Recommend using hyphens over underscores. Special "
+"characters like # is not allowed."
 msgstr ""
-"سلسلة اختيارية لعنوان URL نظيف.على سبيل المثال ، "
-"go.ifrc.org/emergencies/hurricane-katrina-2019.لا يمكن أن تبدأ السلسلة برقم "
-"ويجب أن تكون صغيرة.نوصي باستخدام واصلات فوق الشرطات السفلية.الأحرف الخاصة "
-"مثل # غير مسموح بها."
+"سلسلة اختيارية لعنوان URL نظيف.على سبيل المثال ، go.ifrc.org/emergencies/"
+"hurricane-katrina-2019.لا يمكن أن تبدأ السلسلة برقم ويجب أن تكون صغيرة.نوصي "
+"باستخدام واصلات فوق الشرطات السفلية.الأحرف الخاصة مثل # غير مسموح بها."
 
-#: api/models.py:408
+#: models.py:517
 msgid "Parent Emergency"
 msgstr "طوارئ الوالدين"
 
-#: api/models.py:410
+#: models.py:519
 msgid ""
-"If needed, you have to change the connected Appeals', Field Reports', etc to"
-" point to the parent Emergency manually."
+"If needed, you have to change the connected Appeals', Field Reports', etc to "
+"point to the parent Emergency manually."
 msgstr ""
 "إذا لزم الأمر ، يجب عليك تغيير الطعون المتصلة ، والتقارير الميدانية ، وما "
 "إلى ذلك للإشارة إلى حالة الطوارئ الأصلية يدويًا."
 
-#: api/models.py:416 api/models.py:848
+#: models.py:525 models.py:957
 msgid "number of injured"
 msgstr "عدد الجرحى"
 
-#: api/models.py:417 api/models.py:849
+#: models.py:526 models.py:958
 msgid "number of dead"
 msgstr "عدد الموتي"
 
-#: api/models.py:418 api/models.py:850
+#: models.py:527 models.py:959
 msgid "number of missing"
 msgstr "عدد المفقودين"
 
-#: api/models.py:419 api/models.py:851
+#: models.py:528 models.py:960
 msgid "number of affected"
 msgstr "عدد المتأثرين"
 
-#: api/models.py:422
-msgid "IFRC Severity level"
-msgstr "مستوى الخطورة"
-
-#: api/models.py:423
-msgid "glide"
-msgstr ""
-"أزَلّ ; أفْلَت ; أفْلَص مِن ; اِنْزَلَق ; اِنْساب ; تَزَحْلَق ; تَزَلّج ; "
-"تَمَلّص ; تَمَلّص مِن ; جَرَى ; زَحْلَق ; زَلّ ; زَلَج ; زَلَق"
-
-#: api/models.py:425
-msgid "disaster start date"
-msgstr "تاريخ بدء الكارثة"
-
-#: api/models.py:426 api/models.py:584 api/models.py:682 api/models.py:772
-#: api/models.py:994 api/models.py:1551 api/models.py:1624 api/models.py:1639
-msgid "created at"
-msgstr "أنشئت في"
-
-#: api/models.py:427 api/models.py:995
-msgid "updated at"
-msgstr "تم التحديث في"
-
-#: api/models.py:428 api/models.py:684
-msgid "previous update"
-msgstr "التحديث السابق"
-
-#: api/models.py:430
-msgid "auto generated"
-msgstr "يستخرج تلقائيا"
-
-#: api/models.py:432
-msgid "auto generated source"
-msgstr "مصدر تم إنشاؤه تلقائيًا"
-
-#: api/models.py:436
-msgid "is featured on home page"
-msgstr "مميزة للصفحة الرئيسية"
-
-#: api/models.py:439
-msgid "is featured on region page"
-msgstr "واردة في صفحة المنطقة"
-
-#: api/models.py:441
-msgid "hide attached field reports?"
-msgstr "إخفاء التقارير الميدانية المرفقة؟"
-
-#: api/models.py:445
-msgid "tab one title"
-msgstr "عنوان الجدول رقم 1"
-
-#: api/models.py:447
-msgid "tab two title"
-msgstr "عنوان الجدول رقم 2"
-
-#: api/models.py:448
-msgid "tab three title"
-msgstr "عنوان الجدول رقم 3"
-
-#: api/models.py:452
-msgid "emergency"
-msgstr "إسْتِثْنائِيّ ; إضْطِرار ; إضْطِرارِيّ ; أزْمَة ; طارِئ"
-
-#: api/models.py:453
-msgid "emergencies"
-msgstr "طَوارِئ"
-
-#: api/models.py:517 api/models.py:1056
-msgid "phone"
-msgstr "رقم الهاتف"
-
-#: api/models.py:518 api/models.py:529 api/models.py:549 api/models.py:591
-#: api/models.py:688 api/models.py:839
-msgid "event"
-msgstr "فعالية"
-
-#: api/models.py:521
-msgid "event contact"
-msgstr "اتصال الحدث"
-
-#: api/models.py:522
-msgid "event contacts"
-msgstr "اتصالات الحدث"
-
-#: api/models.py:530
-msgid "number"
-msgstr "الرقم"
-
-#: api/models.py:530
-msgid "key figure metric"
-msgstr "مقياس الرقم الرئيسي"
-
-#: api/models.py:531
-msgid "key figure units"
-msgstr "وحدات الشكل الرئيسية"
-
-#: api/models.py:532
-msgid "key figure website link, publication"
-msgstr "رابط الموقع الرقم الرئيسي ، النشر"
-
-#: api/models.py:535
-msgid "key figure"
-msgstr "شخصية رئيسية"
-
-#: api/models.py:536
-msgid "key figures"
-msgstr "الأرقام الرئيسية"
-
-#: api/models.py:552
-msgid "tab"
-msgstr "عُرْوَة ; لِسَان"
-
-#: api/models.py:557
-msgid "snippets"
-msgstr "مقتطفات"
-
-#: api/models.py:567
-msgid "is primary?"
-msgstr "أساسي؟"
-
-#: api/models.py:568
-msgid "Ensure this type gets precedence over others that are empty"
-msgstr "تأكد من أن هذا النوع له الأسبقية على الأنواع الأخرى الفارغة"
-
-#: api/models.py:572
-msgid "situation report type"
-msgstr "201 - غرفة الدراسة والتحليل"
-
-#: api/models.py:573
-msgid "situation report types"
-msgstr "أنواع تقرير الحالة"
-
-#: api/models.py:587 api/models.py:775
-msgid "document"
-msgstr "وَثيقَة[ج:وَثائِق]"
-
-#: api/models.py:589 api/models.py:777
-msgid "document url"
-msgstr "رابط الوثيقة"
-
-#: api/models.py:596
-msgid "is pinned?"
-msgstr "مثبت؟"
-
-#: api/models.py:596
-msgid "pin this report at the top"
-msgstr "ثبت هذا التقرير في الأعلى"
-
-#: api/models.py:599
-msgid "situation report"
-msgstr "201 - غرفة الدراسة والتحليل"
-
-#: api/models.py:600
-msgid "situation reports"
-msgstr "تقارير عن الأوضاع"
-
-#: api/models.py:609
-msgid "event id"
-msgstr "آی دی  گردهمایی"
-
-#: api/models.py:611 api/models.py:836
-msgid "description"
-msgstr "وصف"
-
-#: api/models.py:613
-msgid "report"
-msgstr "بلاغ"
-
-#: api/models.py:614
-msgid "publication date"
-msgstr "تاريخ النشر"
-
-#: api/models.py:615
-msgid "year"
-msgstr "السنة"
-
-#: api/models.py:616
-msgid "latitude"
-msgstr "حَدّ ; مَجَال ; مَدىً ; نِطَاق"
-
-#: api/models.py:617
-msgid "longitude"
-msgstr "خط الطول"
-
-#: api/models.py:618
-msgid "event type"
-msgstr "طبيعة الإجراء الدال"
-
-#: api/models.py:619
-msgid "alert level"
-msgstr "مُسْتَوى اليَقَظَة"
-
-#: api/models.py:620
-msgid "alert score"
-msgstr "درجة التنبيه"
-
-#: api/models.py:621
-msgid "severity"
-msgstr ""
-"تَزَمّت ; تَشَدّد ; تَصْمِيم ; حَزْم ; حُمَيّا ; حِدّة ; سَوْرَة ; شِدّة ; "
-"صَرَامَة ; ضَغْط ; عُنْف ; فَوْرَة ; قَسَاوَة ; قَسْوَة ; قُوّة ; وَطْأة"
-
-#: api/models.py:622
-msgid "severity unit"
-msgstr "وحدة الشدة"
-
-#: api/models.py:623
-msgid "severity value"
-msgstr "قيمة الخطورة"
-
-#: api/models.py:624
-msgid "population unit"
-msgstr "وحدة سكانية"
-
-#: api/models.py:625
-msgid "population value"
-msgstr "قيمة السكان"
-
-#: api/models.py:626
-msgid "vulnerability"
-msgstr "سُرْعَةُ التَّأَثُّر؛تَعَرُّضِيَّة"
-
-#: api/models.py:628
-msgid "country text"
-msgstr "نص البلد"
-
-#: api/models.py:631
-msgid "gdacs event"
-msgstr "حدث gdacs"
-
-#: api/models.py:632
-msgid "gdacs events"
-msgstr "أحداث gdacs"
-
-#: api/models.py:645 api/models.py:938
-msgid "DREF"
-msgstr "DREF"
-
-#: api/models.py:646
-msgid "Emergency Appeal"
-msgstr "نداء الطوارئ"
-
-#: api/models.py:647
-msgid "International Appeal"
-msgstr "نداء دولي"
-
-#: api/models.py:657
-msgid "Active"
-msgstr "ناشط"
-
-#: api/models.py:658
-msgid "Closed"
-msgstr "مغلق"
-
-#: api/models.py:659
-msgid "Frozen"
-msgstr "مجمدة"
-
-#: api/models.py:660
-msgid "Archived"
-msgstr "مؤرشف"
-
-#: api/models.py:667
-msgid "appeal ID"
-msgstr "معرف الاستئناف"
-
-#: api/models.py:672 api/models.py:844 api/models.py:1550
-msgid "status"
-msgstr ""
-"بال ; حال ; حالَة ; دَرَجَة ; رُتْبَة ; سُدّة ; طَوْر ; مَرْكَز ; مَقَام ; "
-"مَكَانَة ; مَنْزِلَة ; مَنْصِب ; مَوْقِف ; وَضْع"
-
-#: api/models.py:674
-msgid "sector"
-msgstr "حَقْل ; قِسْم ; قِطَاع ; قاطِع ; مَجَال"
-
-#: api/models.py:676
-msgid "number of beneficiaries"
-msgstr "عدد المستفيدين"
-
-#: api/models.py:677
-msgid "amount requested"
-msgstr "المبلغ المطلوب"
-
-#: api/models.py:678
-msgid "amount funded"
-msgstr "المبلغ الممول"
-
-#: api/models.py:680 api/models.py:988
-msgid "start date"
-msgstr "تاريخ البدء"
-
-#: api/models.py:681
-msgid "end date"
-msgstr "تاريخ النهاية"
-
-#: api/models.py:683
-msgid "modified at"
-msgstr "تعديل في"
-
-#: api/models.py:685
-msgid "real data update"
-msgstr "تحديث البيانات الحقيقية"
-
-#: api/models.py:690
-msgid "needs confirmation?"
-msgstr "بحاجة الى تأكيد؟"
-
-#: api/models.py:733 api/models.py:779 api/models.py:940
-msgid "appeal"
-msgstr "استئناف"
-
-#: api/models.py:734
-msgid "appeals"
-msgstr "الاستئناف"
-
-#: api/models.py:782
-msgid "appeal document"
-msgstr "وثيقة الاستئناف"
-
-#: api/models.py:783
-msgid "appeal documents"
-msgstr "مستندات الاستئناف"
-
-#: api/models.py:802
-msgid "No"
-msgstr "لا"
-
-#: api/models.py:803
-msgid "Requested"
-msgstr "مطلوب"
-
-#: api/models.py:804
-msgid "Planned"
-msgstr "مخطط"
-
-#: api/models.py:805
-msgid "Complete"
-msgstr "کامل شده"
-
-#: api/models.py:814
-msgid "Ministry of health"
-msgstr "وزارة الصحة"
-
-#: api/models.py:815
-msgid "WHO"
-msgstr "منظمة الصحة العالمية"
-
-#: api/models.py:816
-msgid "OTHER"
-msgstr "أخرى"
-
-#: api/models.py:823 api/models.py:1200
-msgid "user"
-msgstr "المستعمل"
-
-#: api/models.py:828
-msgid "is covid report?"
-msgstr "هو تقرير كوفيد؟"
-
-#: api/models.py:830
-msgid "Is this a Field Report specific to the COVID-19 emergency?"
-msgstr "هل هذا تقرير ميداني خاص بحالة طوارئ COVID-19؟"
-
-#: api/models.py:834
-msgid "r id"
-msgstr "r هوية"
-
-#: api/models.py:845
-msgid "request assistance"
-msgstr "طلب المساعدة"
-
-#: api/models.py:846
-msgid "NS request assistance"
-msgstr "طلب المساعدة"
-
-#: api/models.py:852
+#: models.py:529 models.py:961
 msgid "number of displaced"
 msgstr "عدد النازحين"
 
-#: api/models.py:853
+#: models.py:531
+msgid "IFRC Severity level"
+msgstr "مستوى الخطورة"
+
+#: models.py:532
+msgid "glide"
+msgstr ""
+"أزَلّ ; أفْلَت ; أفْلَص مِن ; اِنْزَلَق ; اِنْساب ; تَزَحْلَق ; تَزَلّج ; تَمَلّص ; تَمَلّص مِن ; جَرَى ; "
+"زَحْلَق ; زَلّ ; زَلَج ; زَلَق"
+
+#: models.py:534
+msgid "disaster start date"
+msgstr "تاريخ بدء الكارثة"
+
+#: models.py:535 models.py:693 models.py:791 models.py:881 models.py:1080
+#: models.py:1638 models.py:1711 models.py:1726
+msgid "created at"
+msgstr "أنشئت في"
+
+#: models.py:536 models.py:1081
+msgid "updated at"
+msgstr "تم التحديث في"
+
+#: models.py:537 models.py:793
+msgid "previous update"
+msgstr "التحديث السابق"
+
+#: models.py:539
+msgid "auto generated"
+msgstr "يستخرج تلقائيا"
+
+#: models.py:541
+msgid "auto generated source"
+msgstr "مصدر تم إنشاؤه تلقائيًا"
+
+#: models.py:545
+msgid "is featured on home page"
+msgstr "مميزة للصفحة الرئيسية"
+
+#: models.py:548
+msgid "is featured on region page"
+msgstr "واردة في صفحة المنطقة"
+
+#: models.py:550
+msgid "hide attached field reports?"
+msgstr "إخفاء التقارير الميدانية المرفقة؟"
+
+#: models.py:554
+msgid "tab one title"
+msgstr "عنوان الجدول رقم 1"
+
+#: models.py:556
+msgid "tab two title"
+msgstr "عنوان الجدول رقم 2"
+
+#: models.py:557
+msgid "tab three title"
+msgstr "عنوان الجدول رقم 3"
+
+#: models.py:561
+msgid "emergency"
+msgstr "إسْتِثْنائِيّ ; إضْطِرار ; إضْطِرارِيّ ; أزْمَة ; طارِئ"
+
+#: models.py:562
+msgid "emergencies"
+msgstr "طَوارِئ"
+
+#: models.py:626 models.py:1142
+msgid "phone"
+msgstr "رقم الهاتف"
+
+#: models.py:627 models.py:638 models.py:658 models.py:700 models.py:797
+#: models.py:948
+msgid "event"
+msgstr "فعالية"
+
+#: models.py:630
+msgid "event contact"
+msgstr "اتصال الحدث"
+
+#: models.py:631
+msgid "event contacts"
+msgstr "اتصالات الحدث"
+
+#: models.py:639
+msgid "number"
+msgstr "الرقم"
+
+#: models.py:639
+msgid "key figure metric"
+msgstr "مقياس الرقم الرئيسي"
+
+#: models.py:640
+msgid "key figure units"
+msgstr "وحدات الشكل الرئيسية"
+
+#: models.py:641
+msgid "key figure website link, publication"
+msgstr "رابط الموقع الرقم الرئيسي ، النشر"
+
+#: models.py:644
+msgid "key figure"
+msgstr "شخصية رئيسية"
+
+#: models.py:645
+msgid "key figures"
+msgstr "الأرقام الرئيسية"
+
+#: models.py:661
+msgid "tab"
+msgstr "عُرْوَة ; لِسَان"
+
+#: models.py:666
+msgid "snippets"
+msgstr "مقتطفات"
+
+#: models.py:676
+msgid "is primary?"
+msgstr "أساسي؟"
+
+#: models.py:677
+msgid "Ensure this type gets precedence over others that are empty"
+msgstr "تأكد من أن هذا النوع له الأسبقية على الأنواع الأخرى الفارغة"
+
+#: models.py:681
+msgid "situation report type"
+msgstr "201 - غرفة الدراسة والتحليل"
+
+#: models.py:682
+msgid "situation report types"
+msgstr "أنواع تقرير الحالة"
+
+#: models.py:696 models.py:884
+msgid "document"
+msgstr "وَثيقَة[ج:وَثائِق]"
+
+#: models.py:698 models.py:886
+msgid "document url"
+msgstr "رابط الوثيقة"
+
+#: models.py:705
+msgid "is pinned?"
+msgstr "مثبت؟"
+
+#: models.py:705
+msgid "pin this report at the top"
+msgstr "ثبت هذا التقرير في الأعلى"
+
+#: models.py:708
+msgid "situation report"
+msgstr "201 - غرفة الدراسة والتحليل"
+
+#: models.py:709
+msgid "situation reports"
+msgstr "تقارير عن الأوضاع"
+
+#: models.py:718
+msgid "event id"
+msgstr "آی دی  گردهمایی"
+
+#: models.py:720 models.py:945
+msgid "description"
+msgstr "وصف"
+
+#: models.py:722
+msgid "report"
+msgstr "بلاغ"
+
+#: models.py:723
+msgid "publication date"
+msgstr "تاريخ النشر"
+
+#: models.py:724
+msgid "year"
+msgstr "السنة"
+
+#: models.py:725
+msgid "latitude"
+msgstr "حَدّ ; مَجَال ; مَدىً ; نِطَاق"
+
+#: models.py:726
+msgid "longitude"
+msgstr "خط الطول"
+
+#: models.py:727
+msgid "event type"
+msgstr "طبيعة الإجراء الدال"
+
+#: models.py:728
+msgid "alert level"
+msgstr "مُسْتَوى اليَقَظَة"
+
+#: models.py:729
+msgid "alert score"
+msgstr "درجة التنبيه"
+
+#: models.py:730
+msgid "severity"
+msgstr ""
+"تَزَمّت ; تَشَدّد ; تَصْمِيم ; حَزْم ; حُمَيّا ; حِدّة ; سَوْرَة ; شِدّة ; صَرَامَة ; ضَغْط ; عُنْف ; "
+"فَوْرَة ; قَسَاوَة ; قَسْوَة ; قُوّة ; وَطْأة"
+
+#: models.py:731
+msgid "severity unit"
+msgstr "وحدة الشدة"
+
+#: models.py:732
+msgid "severity value"
+msgstr "قيمة الخطورة"
+
+#: models.py:733
+msgid "population unit"
+msgstr "وحدة سكانية"
+
+#: models.py:734
+msgid "population value"
+msgstr "قيمة السكان"
+
+#: models.py:735
+msgid "vulnerability"
+msgstr "سُرْعَةُ التَّأَثُّر؛تَعَرُّضِيَّة"
+
+#: models.py:737
+msgid "country text"
+msgstr "نص البلد"
+
+#: models.py:740
+msgid "gdacs event"
+msgstr "حدث gdacs"
+
+#: models.py:741
+msgid "gdacs events"
+msgstr "أحداث gdacs"
+
+#: models.py:754 models.py:1024
+msgid "DREF"
+msgstr "DREF"
+
+#: models.py:755
+msgid "Emergency Appeal"
+msgstr "نداء الطوارئ"
+
+#: models.py:756
+msgid "International Appeal"
+msgstr "نداء دولي"
+
+#: models.py:766
+msgid "Active"
+msgstr "ناشط"
+
+#: models.py:767
+msgid "Closed"
+msgstr "مغلق"
+
+#: models.py:768
+msgid "Frozen"
+msgstr "مجمدة"
+
+#: models.py:769
+msgid "Archived"
+msgstr "مؤرشف"
+
+#: models.py:776
+msgid "appeal ID"
+msgstr "معرف الاستئناف"
+
+#: models.py:781 models.py:953 models.py:1637
+msgid "status"
+msgstr ""
+"بال ; حال ; حالَة ; دَرَجَة ; رُتْبَة ; سُدّة ; طَوْر ; مَرْكَز ; مَقَام ; مَكَانَة ; مَنْزِلَة ; "
+"مَنْصِب ; مَوْقِف ; وَضْع"
+
+#: models.py:783
+msgid "sector"
+msgstr "حَقْل ; قِسْم ; قِطَاع ; قاطِع ; مَجَال"
+
+#: models.py:785
+msgid "number of beneficiaries"
+msgstr "عدد المستفيدين"
+
+#: models.py:786
+msgid "amount requested"
+msgstr "المبلغ المطلوب"
+
+#: models.py:787
+msgid "amount funded"
+msgstr "المبلغ الممول"
+
+#: models.py:789 models.py:1074
+msgid "start date"
+msgstr "تاريخ البدء"
+
+#: models.py:790
+msgid "end date"
+msgstr "تاريخ النهاية"
+
+#: models.py:792
+msgid "modified at"
+msgstr "تعديل في"
+
+#: models.py:794
+msgid "real data update"
+msgstr "تحديث البيانات الحقيقية"
+
+#: models.py:799
+msgid "needs confirmation?"
+msgstr "بحاجة الى تأكيد؟"
+
+#: models.py:842 models.py:888 models.py:1026
+msgid "appeal"
+msgstr "استئناف"
+
+#: models.py:843
+msgid "appeals"
+msgstr "الاستئناف"
+
+#: models.py:891
+msgid "appeal document"
+msgstr "وثيقة الاستئناف"
+
+#: models.py:892
+msgid "appeal documents"
+msgstr "مستندات الاستئناف"
+
+#: models.py:911
+msgid "No"
+msgstr "لا"
+
+#: models.py:912
+msgid "Requested"
+msgstr "مطلوب"
+
+#: models.py:913
+msgid "Planned"
+msgstr "مخطط"
+
+#: models.py:914
+msgid "Complete"
+msgstr "کامل شده"
+
+#: models.py:923
+msgid "Ministry of health"
+msgstr "وزارة الصحة"
+
+#: models.py:924
+msgid "WHO"
+msgstr "منظمة الصحة العالمية"
+
+#: models.py:925
+msgid "OTHER"
+msgstr "أخرى"
+
+#: models.py:932 models.py:1286
+msgid "user"
+msgstr "المستعمل"
+
+#: models.py:937
+msgid "is covid report?"
+msgstr "هو تقرير كوفيد؟"
+
+#: models.py:939
+msgid "Is this a Field Report specific to the COVID-19 emergency?"
+msgstr "هل هذا تقرير ميداني خاص بحالة طوارئ COVID-19؟"
+
+#: models.py:943
+msgid "r id"
+msgstr "r هوية"
+
+#: models.py:954
+msgid "request assistance"
+msgstr "طلب المساعدة"
+
+#: models.py:955
+msgid "NS request assistance"
+msgstr "طلب المساعدة"
+
+#: models.py:962
 msgid "number of assisted"
 msgstr "عدد المساعدة"
 
-#: api/models.py:854
+#: models.py:963
 msgid "number of localstaff"
 msgstr "عدد الموظفين المحليين"
 
-#: api/models.py:855
+#: models.py:964
 msgid "number of volunteers"
 msgstr "عدد المتطوعين"
 
-#: api/models.py:856
+#: models.py:965
 msgid "number of expatriate delegates"
 msgstr "عدد المندوبين الوافدين"
 
-#: api/models.py:859
+#: models.py:968
 msgid "number of potentially affected"
 msgstr "عدد الأشخاص المحتمل تأثرهم"
 
-#: api/models.py:860
+#: models.py:969
 msgid "number of highest risk"
 msgstr "عدد من أعلى المخاطر"
 
-#: api/models.py:861
+#: models.py:970
 msgid "affected population centres"
 msgstr "المراكز السكانية المتضررة"
 
-#: api/models.py:863
+#: models.py:972
 msgid "number of injured (goverment)"
 msgstr "عدد الجرحى (الحكومة)"
 
-#: api/models.py:864
+#: models.py:973
 msgid "number of dead (goverment)"
 msgstr "عدد القتلى (الحكومة)"
 
-#: api/models.py:865
+#: models.py:974
 msgid "number of missing (goverment)"
 msgstr "عدد المفقودين (الحكومة)"
 
-#: api/models.py:866
+#: models.py:975
 msgid "number of affected (goverment)"
 msgstr "عدد المتضررين (الحكومة)"
 
-#: api/models.py:867
+#: models.py:976
 msgid "number of displaced (goverment)"
 msgstr "عدد النازحين (الحكومة)"
 
-#: api/models.py:868
+#: models.py:977
 msgid "number of assisted (goverment)"
 msgstr "عدد المساعدة (الحكومية)"
 
-#: api/models.py:871
+#: models.py:980
 msgid "number of cases (epidemic)"
 msgstr "عدد الحالات (الوباء)"
 
-#: api/models.py:872
+#: models.py:981
 msgid "number of suspected cases (epidemic)"
 msgstr "عدد الحالات المشتبه بها (وباء)"
 
-#: api/models.py:873
+#: models.py:982
 msgid "number of probable cases (epidemic)"
 msgstr "عدد الحالات المحتملة (وباء)"
 
-#: api/models.py:874
+#: models.py:983
 msgid "number of confirmed cases (epidemic)"
 msgstr "عدد الحالات المؤكدة (الوباء)"
 
-#: api/models.py:875
+#: models.py:984
 msgid "number of dead (epidemic)"
 msgstr "عدد القتلى (الوباء)"
 
-#: api/models.py:876
+#: models.py:985
 msgid "figures source (epidemic)"
 msgstr "مصدر الارقام (وباء)"
 
-#: api/models.py:878
-msgid "number of cases (MOH)"
-msgstr "مقاييس الأداء (عدد الحالات)"
-
-#: api/models.py:879
-msgid "number of suspected cases (MOH)"
-msgstr "عدد الحالات المشتبه بها (وزارة الصحة)"
-
-#: api/models.py:880
-msgid "number of probabale cases (MOH)"
-msgstr "عدد الحالات المحتملة (وزارة الصحة)"
-
-#: api/models.py:881
-msgid "number of confirmed cases (MOH)"
-msgstr "عدد الحاﻻت المؤكدة"
-
-#: api/models.py:882
-msgid "number of dead (MOH)"
-msgstr "عدد القتلى (وزارة الصحة)"
-
-#: api/models.py:884
-msgid "number of cases (WHO)"
-msgstr "مقاييس الأداء (عدد الحالات)"
-
-#: api/models.py:885
-msgid "number of suspected cases (WHO)"
-msgstr "عدد الحالات المشتبه بها (منظمة الصحة العالمية)"
-
-#: api/models.py:886
-msgid "number of probable cases (WHO)"
-msgstr "عدد الحالات المحتملة (منظمة الصحة العالمية)"
-
-#: api/models.py:887
-msgid "number of confirmed cases (WHO)"
-msgstr "عدد الحاﻻت المؤكدة"
-
-#: api/models.py:888
-msgid "number of number of dead (WHO)"
-msgstr "عدد القتلى (منظمة الصحة العالمية)"
-
-#: api/models.py:890
-msgid "number of cases (other)"
-msgstr "عدد الحالات (أخرى)"
-
-#: api/models.py:891
-msgid "number of suspected cases (other)"
-msgstr "عدد الحالات المشتبه بها (أخرى)"
-
-#: api/models.py:892
-msgid "number of probable cases (other)"
-msgstr "عدد الحالات المحتملة (أخرى)"
-
-#: api/models.py:893
-msgid "number of confirmed cases (other)"
-msgstr "عدد الحالات المؤكدة (أخرى)"
-
-#: api/models.py:895 api/models.py:896
+#: models.py:987 models.py:988
 msgid "number of assisted (who)"
 msgstr "عدد المساعدين (من)"
 
-#: api/models.py:899
+#: models.py:991
 msgid "potentially affected (goverment)"
 msgstr "يحتمل أن تتأثر (الحكومة)"
 
-#: api/models.py:900
+#: models.py:992
 msgid "people at highest risk (goverment)"
 msgstr "الأشخاص الأكثر عرضة للخطر (الحكومة)"
 
-#: api/models.py:902
+#: models.py:994
 msgid "affected population centres (goverment)"
 msgstr "المراكز السكانية المتضررة (الحكومة)"
 
-#: api/models.py:904
+#: models.py:996
 msgid "number of injured (other)"
 msgstr "عدد الجرحى (أخرى)"
 
-#: api/models.py:905
+#: models.py:997
 msgid "number of dead (other)"
 msgstr "عدد القتلى (أخرى)"
 
-#: api/models.py:906
+#: models.py:998
 msgid "number of missing (other)"
 msgstr "عدد المفقودين (أخرى)"
 
-#: api/models.py:907
+#: models.py:999
 msgid "number of affected (other)"
 msgstr "عدد المتضررين (أخرى)"
 
-#: api/models.py:908
+#: models.py:1000
 msgid "number of displace (other)"
 msgstr "عدد الإزاحة (أخرى)"
 
-#: api/models.py:909
+#: models.py:1001
 msgid "number of assisted (other)"
 msgstr "عدد المساعدين (أخرى)"
 
-#: api/models.py:913
+#: models.py:1005
 msgid "number of potentially affected (other)"
 msgstr "عدد الأشخاص المحتمل تأثرهم (غير ذلك)"
 
-#: api/models.py:914
+#: models.py:1006
 msgid "number of highest risk (other)"
 msgstr "عدد من أعلى المخاطر (أخرى)"
 
-#: api/models.py:916
+#: models.py:1008
 msgid "number of affected population centres (other)"
 msgstr "عدد المراكز السكانية المتضررة (أخرى)"
 
-#: api/models.py:919
-msgid "number of cases"
-msgstr "عدد الحالات"
-
-#: api/models.py:920
-msgid "number of suspected cases"
-msgstr "عدد الحالات المشتبه فيها"
-
-#: api/models.py:921
-msgid "number of probable cases"
-msgstr "عدد الحالات المحتملة"
-
-#: api/models.py:922
-msgid "number of confirmed cases"
-msgstr "عدد الحاﻻت المؤكدة"
-
-#: api/models.py:925
+#: models.py:1011
 msgid "situation fields date"
 msgstr "تاريخ حقول الوضع"
 
-#: api/models.py:928
+#: models.py:1014
 msgid "sources (other)"
 msgstr "مصادر (أخرى)"
 
-#: api/models.py:931
+#: models.py:1017
 msgid "actions taken (others)"
 msgstr "الإجراءات المتخذة (أخرى)"
 
-#: api/models.py:937
+#: models.py:1023
 msgid "bullentin"
 msgstr "بولنتين"
 
-#: api/models.py:939
+#: models.py:1025
 msgid "DREF amount"
 msgstr "كمية DREF"
 
-#: api/models.py:941
+#: models.py:1027
 msgid "appeal amount"
 msgstr "مبلغ الاستئناف"
 
-#: api/models.py:942
+#: models.py:1028
 msgid "imminent dref"
 msgstr "dref وشيك"
 
-#: api/models.py:943
+#: models.py:1029
 msgid "imminent dref amount"
 msgstr "مبلغ dref وشيك"
 
-#: api/models.py:944
+#: models.py:1030
 msgid "forecast based action"
 msgstr "عمل قائم على التنبؤ"
 
-#: api/models.py:946
+#: models.py:1032
 msgid "forecast based action amount"
 msgstr "توقع مبلغ العمل القائم"
 
-#: api/models.py:949
+#: models.py:1035
 msgid "RDRT"
 msgstr "RDRT"
 
-#: api/models.py:950
+#: models.py:1036
 msgid "number of RDRT"
 msgstr "عدد"
 
-#: api/models.py:951
+#: models.py:1037
 msgid "fact"
 msgstr "حقيقة"
 
-#: api/models.py:952
+#: models.py:1038
 msgid "number of fact"
 msgstr "عدد الحقائق"
 
-#: api/models.py:953
+#: models.py:1039
 msgid "IFRC staff"
 msgstr "موظفو الاتحاد الدولي"
 
-#: api/models.py:954
+#: models.py:1040
 msgid "number of IFRC staff"
 msgstr "عدد الموظفين"
 
-#: api/models.py:957
+#: models.py:1043
 msgid "ERU base camp"
 msgstr "معسكر قاعدة ERU"
 
-#: api/models.py:958
+#: models.py:1044
 msgid "ERU base camp units"
 msgstr "وحدات معسكر قاعدة ERU"
 
-#: api/models.py:960
+#: models.py:1046
 msgid "ERU basic health care"
 msgstr "الرعاية الصحية الأساسية"
 
-#: api/models.py:961
+#: models.py:1047
 msgid "ERU basic health units"
 msgstr "وحدات الصحة الأساسية"
 
-#: api/models.py:963
+#: models.py:1049
 msgid "ERU IT telecom"
 msgstr "ERU IT Telecom"
 
-#: api/models.py:964
+#: models.py:1050
 msgid "ERU IT telecom units"
 msgstr "وحدات الاتصالات ERU IT"
 
-#: api/models.py:966
+#: models.py:1052
 msgid "ERU logistics"
 msgstr "لوجستيات ERU"
 
-#: api/models.py:967
+#: models.py:1053
 msgid "ERU logistics units"
 msgstr "وحدات لوجستية ERU"
 
-#: api/models.py:969
+#: models.py:1055
 msgid "ERU deployment hospital"
 msgstr "مستشفى نشر ERU"
 
-#: api/models.py:970
+#: models.py:1056
 msgid "ERU deployment hospital units"
 msgstr "وحدات مستشفى نشر ERU"
 
-#: api/models.py:972
+#: models.py:1058
 msgid "ERU referral hospital"
 msgstr "مستشفى إحالة"
 
-#: api/models.py:973
+#: models.py:1059
 msgid "ERU referral hospital units"
 msgstr "وحدات مستشفى الإحالة ERU"
 
-#: api/models.py:975
+#: models.py:1061
 msgid "ERU relief"
 msgstr "الإغاثة ERU"
 
-#: api/models.py:976
+#: models.py:1062
 msgid "ERU relief units"
 msgstr "وحدات الإغاثة ERU"
 
-#: api/models.py:978
+#: models.py:1064
 msgid "ERU water sanitaion M15"
 msgstr "مياه الصرف الصحي"
 
-#: api/models.py:979
+#: models.py:1065
 msgid "ERU water sanitaion M15 units"
 msgstr "مياه الصرف الصحي"
 
-#: api/models.py:981
+#: models.py:1067
 msgid "ERU water sanitaion M40"
 msgstr "مياه الصرف الصحي"
 
-#: api/models.py:982
+#: models.py:1068
 msgid "ERU water sanitaion M40 units"
 msgstr "مياه الصرف الصحي"
 
-#: api/models.py:984
+#: models.py:1070
 msgid "ERU water sanitaion MSM20"
 msgstr "مياه الصرف الصحي"
 
-#: api/models.py:985
+#: models.py:1071
 msgid "ERU water sanitaion MSM20 units"
 msgstr "مياه الصرف الصحي"
 
-#: api/models.py:993
+#: models.py:1079
 msgid "report date"
 msgstr "تاريخ التقرير"
 
-#: api/models.py:996
+#: models.py:1082
 msgid "previous updated at"
 msgstr "التحديث السابق في"
 
-#: api/models.py:1000 api/models.py:1058 api/models.py:1143 api/models.py:1171
+#: models.py:1086 models.py:1144 models.py:1229 models.py:1257
 msgid "field report"
 msgstr "تقرير ميداني"
 
-#: api/models.py:1001
+#: models.py:1087
 msgid "field reports"
 msgstr "تقارير الـ(أف بي أي) الميدانيّة"
 
-#: api/models.py:1062
-msgid "field report contact"
-msgstr "تقرير ميداني"
-
-#: api/models.py:1063
+#: models.py:1148 models.py:1149
 msgid "field report contacts"
 msgstr "تقارير ميدانية"
 
-#: api/models.py:1075 api/models.py:1191
+#: models.py:1161 models.py:1277
 msgid "National Society"
 msgstr "الجمعية الوطنية"
 
-#: api/models.py:1076
+#: models.py:1162
 msgid "Foreign Society"
 msgstr "المجتمع الأجنبي"
 
-#: api/models.py:1077
+#: models.py:1163
 msgid "Federation"
 msgstr "إتحاد مؤسسات"
 
-#: api/models.py:1088
+#: models.py:1174
 msgid "Event"
 msgstr "الحدث"
 
-#: api/models.py:1089
+#: models.py:1175
 msgid "Early Warning"
 msgstr "الإنذار المبكر"
 
-#: api/models.py:1090
+#: models.py:1176
 msgid "Epidemic"
 msgstr "وبائي"
 
-#: api/models.py:1091
+#: models.py:1177
 msgid "COVID-19"
 msgstr "كوفويد-19"
 
-#: api/models.py:1102
+#: models.py:1188
 msgid "General"
 msgstr "عام"
 
-#: api/models.py:1103
+#: models.py:1189
 msgid "Health"
 msgstr "الصحة"
 
-#: api/models.py:1104
+#: models.py:1190
 msgid "NS Institutional Strengthening"
 msgstr "2- تعزيز المؤسسات"
 
-#: api/models.py:1105
+#: models.py:1191
 msgid "Socioeconomic Interventions"
 msgstr "التدخلات الاجتماعية والاقتصادية"
 
-#: api/models.py:1121
+#: models.py:1207
 msgid "category"
 msgstr "تصنيف"
 
-#: api/models.py:1123
+#: models.py:1209
 msgid "is disabled?"
 msgstr "إذا كان الزوج معوقاً؛"
 
-#: api/models.py:1123
+#: models.py:1209
 msgid "Disable in form"
 msgstr "تعطيل في الشكل"
 
-#: api/models.py:1126 api/models.py:1622 api/models.py:1640
+#: models.py:1212 models.py:1709 models.py:1727
 msgid "action"
 msgstr ""
-"إجْراء ; اِنْعِكاس ; أثَر ; تَأثِير ; تَحَرّك ; تَدْبِير ; تَصَرّف ; تدَاعِي"
-" ; خُصُومَة ; دَعْوَى ; سُلُوك ; صَنِيع ; عَمَل ; عَمَلِيّة ; فِعْل ; "
-"قَضِيّة"
+"إجْراء ; اِنْعِكاس ; أثَر ; تَأثِير ; تَحَرّك ; تَدْبِير ; تَصَرّف ; تدَاعِي ; خُصُومَة ; دَعْوَى ; "
+"سُلُوك ; صَنِيع ; عَمَل ; عَمَلِيّة ; فِعْل ; قَضِيّة"
 
-#: api/models.py:1127 api/models.py:1140
+#: models.py:1213 models.py:1226
 msgid "actions"
 msgstr "عَجَلَة ; مُعَجّل ; عاجِل"
 
-#: api/models.py:1138 api/models.py:1211
+#: models.py:1224 models.py:1297
 msgid "organization"
 msgstr "تَعَضٍّ"
 
-#: api/models.py:1147
+#: models.py:1233
 msgid "actions taken"
 msgstr "الإجراءات التي تم اتخاذها"
 
-#: api/models.py:1148
+#: models.py:1234
 msgid "all actions taken"
 msgstr "الإجراءات التي تم اتخاذها"
 
-#: api/models.py:1159
+#: models.py:1245
 msgid "source type"
 msgstr "نوع المصدر"
 
-#: api/models.py:1160
+#: models.py:1246
 msgid "source types"
 msgstr "أنواع المصادر"
 
-#: api/models.py:1169
+#: models.py:1255
 msgid "spec"
 msgstr "المواصفات"
 
-#: api/models.py:1176
+#: models.py:1262
 msgid "sources"
 msgstr "المصادر"
 
-#: api/models.py:1192
+#: models.py:1278
 msgid "Delegation"
 msgstr "اسم مصدر بمعنى التوكيل"
 
-#: api/models.py:1193
+#: models.py:1279
 msgid "Secretariat"
 msgstr "الأمانة"
 
-#: api/models.py:1194
+#: models.py:1280
 msgid "ICRC"
 msgstr "ICRC"
 
-#: api/models.py:1195
+#: models.py:1281
 msgid "Other"
 msgstr "أخرى"
 
-#: api/models.py:1212
+#: models.py:1298
 msgid "organization type"
 msgstr "نوع المنظمة"
 
-#: api/models.py:1213
+#: models.py:1299
 msgid "city"
 msgstr "بَلَد ; بَلْدَة ; مَدِينَة ; مَدِينِيّ ; مِصْر"
 
-#: api/models.py:1214
+#: models.py:1300
 msgid "department"
 msgstr "القلب"
 
-#: api/models.py:1216
+#: models.py:1302
 msgid "phone number"
 msgstr "رقم الهاتف"
 
-#: api/models.py:1219
-msgid "user profile"
-msgstr "ملف تعريف المستخدم"
+#: models.py:1303
+msgid "last frontend login"
+msgstr ""
 
-#: api/models.py:1220
+#: models.py:1307
 msgid "user profiles"
 msgstr "ملف مستخدم"
 
-#: api/models.py:1229
+#: models.py:1316
 msgid "is validated?"
 msgstr "تم التحقق من صحتها؟"
 
-#: api/models.py:1229
+#: models.py:1316
 msgid "Did anyone check the editable data?"
 msgstr "هل قام أحد بفحص البيانات القابلة للتحرير؟"
 
-#: api/models.py:1231
+#: models.py:1318
 msgid "created_at"
 msgstr "تاريخ الإنشاء"
 
-#: api/models.py:1232
+#: models.py:1319
 msgid "modified_at"
 msgstr "تعديل في"
 
-#: api/models.py:1237
+#: models.py:1324
 msgid "appeal number (raw)"
 msgstr "رقم الاستئناف (خام)"
 
-#: api/models.py:1238
+#: models.py:1325
 msgid "date of issue (raw)"
 msgstr "تاريخ الإصدار (خام)"
 
-#: api/models.py:1239
+#: models.py:1326
 msgid "glide number (raw)"
 msgstr "رقم الانزلاق (خام)"
 
-#: api/models.py:1241
+#: models.py:1328
 msgid "number of people to be assisted (raw)"
 msgstr "عدد الأشخاص الذين ستتم مساعدتهم (خام)"
 
-#: api/models.py:1242
+#: models.py:1329
 msgid "number of people affected (raw)"
 msgstr "عدد الأشخاص المتضررين"
 
-#: api/models.py:1247
+#: models.py:1334
 msgid "number of disaster risk reduction female (raw)"
 msgstr "عدد الإناث الحد من مخاطر الكوارث (الخام)"
 
-#: api/models.py:1249
+#: models.py:1336
 msgid "number of disaster risk reduction male (raw)"
 msgstr "عدد الذكور الحد من مخاطر الكوارث (الخام)"
 
-#: api/models.py:1251
+#: models.py:1338
 msgid "number of disaster risk reduction people reached (raw)"
 msgstr "عدد الأشخاص الذين تم الوصول إليهم للحد من مخاطر الكوارث (الخام)"
 
-#: api/models.py:1253
+#: models.py:1340
 msgid "number of disaster risk reduction people targeted (raw)"
 msgstr "عدد الأشخاص المستهدفين للحد من مخاطر الكوارث (الخام)"
 
-#: api/models.py:1255
+#: models.py:1342
 msgid "number of disaster risk reduction requirements (raw)"
 msgstr "عدد متطلبات الحد من مخاطر الكوارث (الخام)"
 
-#: api/models.py:1256
+#: models.py:1343
 msgid "health female (raw)"
 msgstr "صحة أنثى (خام)"
 
-#: api/models.py:1257
+#: models.py:1344
 msgid "health male (raw)"
 msgstr "صحة الذكور (الخام)"
 
-#: api/models.py:1258
+#: models.py:1345
 msgid "health people reached (raw)"
 msgstr "الأشخاص الذين وصلوا إلى الصحة (الخام)"
 
-#: api/models.py:1259
+#: models.py:1346
 msgid "health people targeted (raw)"
 msgstr "صحة الناس المستهدفين (الخام)"
 
-#: api/models.py:1260
+#: models.py:1347
 msgid "health requirements (raw)"
 msgstr "المتطلبات الصحية (الخام)"
 
-#: api/models.py:1262
+#: models.py:1349
 msgid "number of livelihhods and basic needs female (raw)"
 msgstr "عدد المواشي والاحتياجات الأساسية للإناث (الخام)"
 
-#: api/models.py:1264
+#: models.py:1351
 msgid "number of livelihhods and basic needs male (raw)"
 msgstr "عدد العيش والحاجات الاساسية للذكور (خام)"
 
-#: api/models.py:1266
+#: models.py:1353
 msgid "number of livelihhods and basic needs people reached (raw)"
 msgstr ""
 "عدد الأشخاص الذين تم الوصول إليهم (الخام) من العيش والاحتياجات الأساسية"
 
-#: api/models.py:1268
+#: models.py:1355
 msgid "number of livelihhods and basic needs people targeted (raw)"
 msgstr "عدد الأشخاص المستهدفين بالعيش والاحتياجات الأساسية (الخام)"
 
-#: api/models.py:1270
+#: models.py:1357
 msgid "number of livelihhods and basic needs requirements (raw)"
 msgstr "عدد المواشي ومتطلبات الاحتياجات الأساسية (خام)"
 
-#: api/models.py:1271
+#: models.py:1358
 msgid "number of migration female (raw)"
 msgstr "عدد الإناث المهاجرات (الخام)"
 
-#: api/models.py:1272
+#: models.py:1359
 msgid "number of migration male (raw)"
 msgstr "عدد الذكور المهاجرين (الخام)"
 
-#: api/models.py:1274
+#: models.py:1361
 msgid "number of migration people reached (raw)"
 msgstr "عدد المهاجرين الذين وصلوا (خام)"
 
-#: api/models.py:1276
+#: models.py:1363
 msgid "number of migration people targeted (raw)"
 msgstr "عدد المهاجرين المستهدفين (الخام)"
 
-#: api/models.py:1277
+#: models.py:1364
 msgid "number of migration requirements (raw)"
 msgstr "عدد متطلبات الهجرة (الخام)"
 
-#: api/models.py:1279
+#: models.py:1366
 msgid "number of protection gender and inclusion female (raw)"
 msgstr "عدد نوع الحماية وإدماج الإناث (الخام)"
 
-#: api/models.py:1281
+#: models.py:1368
 msgid "number of protection gender and inclusion male (raw)"
 msgstr "عدد نوع الحماية والشمول ذكر (خام)"
 
-#: api/models.py:1283
+#: models.py:1370
 msgid "number of protection gender and inclusion people reached (raw)"
 msgstr "عدد الأشخاص الذين حصلوا على الحماية من النوع الاجتماعي والإدماج (خام)"
 
-#: api/models.py:1285
+#: models.py:1372
 msgid "number of protection gender and inclusion people targeted (raw)"
 msgstr "عدد الأشخاص المستهدفين للحماية والدمج (الخام)"
 
-#: api/models.py:1287
+#: models.py:1374
 msgid "number of protection gender and inclusion requirements (raw)"
 msgstr "عدد متطلبات نوع الحماية والإدماج (الخام)"
 
-#: api/models.py:1288
+#: models.py:1375
 msgid "number of shelter female (raw)"
 msgstr "عدد الإناث المأوى (الخام)"
 
-#: api/models.py:1289
+#: models.py:1376
 msgid "number of shelter male (raw)"
 msgstr "عدد مأوى الذكور (الخام)"
 
-#: api/models.py:1290
+#: models.py:1377
 msgid "number of shelter people reached (raw)"
 msgstr "عدد الأشخاص الذين وصلوا إلى المأوى (الخام)"
 
-#: api/models.py:1292
+#: models.py:1379
 msgid "number of shelter people targeted (raw)"
 msgstr "عدد الأشخاص المستهدفين في المأوى (الخام)"
 
-#: api/models.py:1293
+#: models.py:1380
 msgid "number of shelter requirements (raw)"
 msgstr "عدد متطلبات المأوى (الخام)"
 
-#: api/models.py:1295
+#: models.py:1382
 msgid "number of water sanitation and hygiene female (raw)"
 msgstr "عدد مياه الصرف الصحي والنظافة النسائية (الخام)"
 
-#: api/models.py:1297
+#: models.py:1384
 msgid "number of water sanitation and hygiene male (raw)"
 msgstr "عدد مياه الصرف الصحي والنظافة الذكور (الخام)"
 
-#: api/models.py:1299
+#: models.py:1386
 msgid "number of water sanitation and hygiene people reached (raw)"
 msgstr "عدد الأشخاص الذين وصلوا إلى خدمات الصرف الصحي والنظافة الصحية (الخام)"
 
-#: api/models.py:1301
+#: models.py:1388
 msgid "number of water sanitation and hygiene people targeted (raw)"
 msgstr "عدد الأشخاص المستهدفين الصرف الصحي والنظافة الصحية (الخام)"
 
-#: api/models.py:1303
+#: models.py:1390
 msgid "number of water sanitation and hygiene requirements (raw)"
 msgstr "عدد متطلبات المياه والصرف الصحي والنظافة (الخام)"
 
-#: api/models.py:1307
+#: models.py:1394
 msgid "appeal number"
 msgstr "رقم الاستئناف:"
 
-#: api/models.py:1308
+#: models.py:1395
 msgid "date of issue"
 msgstr "تاريخ الاصدار"
 
-#: api/models.py:1309
+#: models.py:1396
 msgid "glide number"
 msgstr "رقم الانزلاق"
 
-#: api/models.py:1310
+#: models.py:1397
 msgid "number of people affected"
 msgstr "عدد الأشخاص المتضررين"
 
-#: api/models.py:1311
+#: models.py:1398
 msgid "number of people to be assisted"
 msgstr "عدد الأشخاص الذين ستتم مساعدتهم"
 
-#: api/models.py:1312 api/models.py:1513
+#: models.py:1399 models.py:1600
 msgid "operation start date"
 msgstr "تاريخ بدء العملية"
 
-#: api/models.py:1314
+#: models.py:1401
 msgid "DREF allocated"
 msgstr "تخصيص DREF"
 
-#: api/models.py:1316
+#: models.py:1403
 msgid "number of disaster risk reduction female"
 msgstr "عدد الإناث الحد من مخاطر الكوارث"
 
-#: api/models.py:1318
+#: models.py:1405
 msgid "number of disaster risk reduction male"
 msgstr "عدد الذكور الحد من مخاطر الكوارث"
 
-#: api/models.py:1320
+#: models.py:1407
 msgid "number of disaster risk reduction people reached"
 msgstr "عدد الأشخاص الذين تم الوصول إليهم للحد من مخاطر الكوارث"
 
-#: api/models.py:1322
+#: models.py:1409
 msgid "number of disaster risk reduction people targeted"
 msgstr "عدد الأشخاص المستهدفين للحد من مخاطر الكوارث"
 
-#: api/models.py:1324
+#: models.py:1411
 msgid "number of disaster risk reduction people requirements"
 msgstr "عدد متطلبات الأفراد للحد من مخاطر الكوارث"
 
-#: api/models.py:1325
+#: models.py:1412
 msgid "number of health female"
 msgstr "عدد النساء الصحية"
 
-#: api/models.py:1326
+#: models.py:1413
 msgid "number of health male"
 msgstr "عدد الذكور الصحية"
 
-#: api/models.py:1327
+#: models.py:1414
 msgid "number of health people reached"
 msgstr "عدد الأشخاص الذين يتم الوصول إليهم"
 
-#: api/models.py:1328
+#: models.py:1415
 msgid "number of health people targeted"
 msgstr "عدد الأشخاص الصحيين المستهدفين"
 
-#: api/models.py:1329
+#: models.py:1416
 msgid "number of health requirements"
 msgstr "عدد المتطلبات الصحية"
 
-#: api/models.py:1331
+#: models.py:1418
 msgid "number of livelihhods and basic needs female"
 msgstr "عدد المعيشية والاحتياجات الأساسية للإناث"
 
-#: api/models.py:1333
+#: models.py:1420
 msgid "number of livelihhods and basic needs male"
 msgstr "عدد العيش والحاجات الأساسية للذكور"
 
-#: api/models.py:1335
+#: models.py:1422
 msgid "number of livelihhods and basic people reached"
 msgstr "تم الوصول إلى عدد من الأحياء والأشخاص الأساسيين"
 
-#: api/models.py:1337
+#: models.py:1424
 msgid "number of livelihhods and basic people targeted"
 msgstr "عدد المستهدفين من الأحياء والأشخاص الأساسيين"
 
-#: api/models.py:1339
+#: models.py:1426
 msgid "number of livelihhods and basic needs requirements"
 msgstr "عدد من متطلبات العيش والاحتياجات الأساسية"
 
-#: api/models.py:1340
+#: models.py:1427
 msgid "number of migration female"
 msgstr "عدد الإناث المهاجرات"
 
-#: api/models.py:1341
+#: models.py:1428
 msgid "number of migration male"
 msgstr "عدد الذكور المهاجرين"
 
-#: api/models.py:1342
+#: models.py:1429
 msgid "number of migration people reached"
 msgstr "عدد الأشخاص الذين تم الوصول إليهم"
 
-#: api/models.py:1343
+#: models.py:1430
 msgid "number of migration people targeted"
 msgstr "عدد المهاجرين المستهدفين"
 
-#: api/models.py:1344
+#: models.py:1431
 msgid "number of migration requirements"
 msgstr "عدد متطلبات الهجرة"
 
-#: api/models.py:1346
+#: models.py:1433
 msgid "number of protection gender and inclusion female"
 msgstr "عدد النوع الاجتماعي الحماية وإدماج الإناث"
 
-#: api/models.py:1348
+#: models.py:1435
 msgid "number of protection gender and inclusion male"
 msgstr "عدد الجنس الحماية وإدماج الذكور"
 
-#: api/models.py:1350
+#: models.py:1437
 msgid "number of protection gender and inclusion people reached"
 msgstr "عدد الأشخاص الذين تم الوصول إليهم في مجال الحماية والدمج بين الجنسين"
 
-#: api/models.py:1352
+#: models.py:1439
 msgid "number of protection gender and inclusion people targeted"
 msgstr "عدد الأشخاص المستهدفين في مجال الحماية والدمج بين الجنسين"
 
-#: api/models.py:1354
+#: models.py:1441
 msgid "number of protection gender and inclusion requirements"
 msgstr "عدد متطلبات نوع الحماية والإدماج"
 
-#: api/models.py:1355
+#: models.py:1442
 msgid "number of shelter female"
 msgstr "عدد الإناث المأوى"
 
-#: api/models.py:1356
+#: models.py:1443
 msgid "number of shelter male"
 msgstr "عدد الذكور المأوى"
 
-#: api/models.py:1357
+#: models.py:1444
 msgid "number of shelter people reached"
 msgstr "عدد الأشخاص الذين يتم الوصول إليهم"
 
-#: api/models.py:1358
+#: models.py:1445
 msgid "number of shelter people targeted"
 msgstr "عدد الأشخاص المستهدفين في المأوى"
 
-#: api/models.py:1359
+#: models.py:1446
 msgid "number of shelter people requirements"
 msgstr "عدد متطلبات المأوى"
 
-#: api/models.py:1361
+#: models.py:1448
 msgid "water sanitation and hygiene female"
 msgstr "المياه والصرف الصحي والنظافة الصحية"
 
-#: api/models.py:1363
+#: models.py:1450
 msgid "water sanitation and hygiene male"
 msgstr "المياه والصرف الصحي والنظافة الصحية"
 
-#: api/models.py:1365
+#: models.py:1452
 msgid "water sanitation and hygiene people reached"
 msgstr "تم الوصول إلى الناس في مجال المياه والصرف الصحي والنظافة"
 
-#: api/models.py:1367
+#: models.py:1454
 msgid "water sanitation and hygiene people targeted"
 msgstr "الأشخاص المستهدفون بالمياه والصرف الصحي والنظافة"
 
-#: api/models.py:1369
+#: models.py:1456
 msgid "water sanitation and hygiene requirements"
 msgstr "المياه والصرف الصحي والنظافة الصحية"
 
-#: api/models.py:1377 api/models.py:1463
+#: models.py:1464 models.py:1550
 msgid "appeal launch date (raw)"
 msgstr "تاريخ إطلاق الاستئناف (خام)"
 
-#: api/models.py:1378
+#: models.py:1465
 msgid "category allocated (raw)"
 msgstr "فئة مخصصة (خام)"
 
-#: api/models.py:1379
+#: models.py:1466
 msgid "expected end date (raw)"
 msgstr "تاريخ الانتهاء المتوقع (خام)"
 
-#: api/models.py:1380
+#: models.py:1467
 msgid "expected time frame (raw)"
 msgstr "الإطار الزمني المتوقع (خام)"
 
-#: api/models.py:1382
+#: models.py:1469
 msgid "number of eduction female (raw)"
 msgstr "عدد الإناث المثقفين (الخام)"
 
-#: api/models.py:1383
+#: models.py:1470
 msgid "number of eduction male (raw)"
 msgstr "عدد الذكور المثقفين (الخام)"
 
-#: api/models.py:1385
+#: models.py:1472
 msgid "number of eduction people reached (raw)"
 msgstr "عدد المتعلمين الذين تم الوصول إليهم (خام)"
 
-#: api/models.py:1387
+#: models.py:1474
 msgid "number of eduction people targeted (raw)"
 msgstr "عدد الأفراد المستهدفين (الخام)"
 
-#: api/models.py:1388
+#: models.py:1475
 msgid "number of eduction requirements (raw)"
 msgstr "عدد متطلبات التعليم (خام)"
 
-#: api/models.py:1394 api/models.py:1473
+#: models.py:1481 models.py:1560
 msgid "appeal launch date"
 msgstr "تاريخ إطلاق الاستئناف"
 
-#: api/models.py:1395
+#: models.py:1482
 msgid "category allocated"
 msgstr "الفئة المخصصة"
 
-#: api/models.py:1396
+#: models.py:1483
 msgid "expected end date"
 msgstr "تاريخ الانتهاء المتوقع"
 
-#: api/models.py:1397
+#: models.py:1484
 msgid "expected time frame"
 msgstr "الإطار الزمني المتوقع"
 
-#: api/models.py:1399
+#: models.py:1486
 msgid "number of eduction female"
 msgstr "عدد الإناث التعليم"
 
-#: api/models.py:1400
+#: models.py:1487
 msgid "number of eduction male"
 msgstr "عدد الذكور المثقفين"
 
-#: api/models.py:1401
+#: models.py:1488
 msgid "number of eduction people reached"
 msgstr "عدد الأشخاص الذين يتم الوصول إليهم"
 
-#: api/models.py:1402
+#: models.py:1489
 msgid "number of eduction people targeted"
 msgstr "عدد الأشخاص المستهدفين في مجال التعليم"
 
-#: api/models.py:1403
+#: models.py:1490
 msgid "number of eduction requirements"
 msgstr "عدد متطلبات التعليم"
 
-#: api/models.py:1409
+#: models.py:1496
 msgid "emergency operations dataset"
 msgstr "مجموعة بيانات عمليات الطوارئ"
 
-#: api/models.py:1410
+#: models.py:1497
 msgid "emergency operations datasets"
 msgstr "مجموعات بيانات عمليات الطوارئ"
 
-#: api/models.py:1418
+#: models.py:1505
 msgid "EPOA update number (raw)"
 msgstr "رقم تحديث EPOA (خام)"
 
-#: api/models.py:1419
+#: models.py:1506
 msgid "operation timeframe (raw)"
 msgstr "الإطار الزمني للعملية (خام)"
 
-#: api/models.py:1421
+#: models.py:1508
 msgid "time frame covered by update (raw)"
 msgstr "الإطار الزمني الذي يشمله التحديث (خام)"
 
-#: api/models.py:1436
+#: models.py:1523
 msgid "EPOA update number"
 msgstr "رقم تحديث EPOA"
 
-#: api/models.py:1437
+#: models.py:1524
 msgid "operation timeframe"
 msgstr "الإطار الزمني للعملية"
 
-#: api/models.py:1439
+#: models.py:1526
 msgid "time frame covered by update"
 msgstr "الإطار الزمني الذي يشمله التحديث"
 
-#: api/models.py:1454 api/models.py:1455
+#: models.py:1541 models.py:1542
 msgid "emergency operations people reached"
 msgstr "وصلت عمليات الطوارئ الناس"
 
-#: api/models.py:1462
+#: models.py:1549
 msgid "appeal ends (raw)"
 msgstr "ينتهي الاستئناف (خام)"
 
-#: api/models.py:1464
+#: models.py:1551
 msgid "current operation budget (raw)"
 msgstr "ميزانية العملية الحالية (خام)"
 
-#: api/models.py:1472
+#: models.py:1559
 msgid "appeal ends"
 msgstr "ينتهي الاستئناف"
 
-#: api/models.py:1474
+#: models.py:1561
 msgid "current operation budget"
 msgstr "ميزانية العملية الحالية"
 
-#: api/models.py:1482
+#: models.py:1569
 msgid "emergency operations emergency appeal"
 msgstr "نداء الطوارئ لعمليات الطوارئ"
 
-#: api/models.py:1483
+#: models.py:1570
 msgid "emergency operations emergency appeals"
 msgstr "نداءات الطوارئ عمليات الطوارئ"
 
-#: api/models.py:1490
+#: models.py:1577
 msgid "date of disaster (raw)"
 msgstr "تاريخ الكارثة (خام)"
 
-#: api/models.py:1492
+#: models.py:1579
 msgid "number of other partner involved (raw)"
 msgstr "عدد الشركاء الآخرين المعنيين (الخام)"
 
-#: api/models.py:1494
+#: models.py:1581
 msgid "number of NS partner involved (raw)"
 msgstr "عدد شركاء NS المشاركين (الخام)"
 
-#: api/models.py:1495
+#: models.py:1582
 msgid "operation end date (raw)"
 msgstr "تاريخ انتهاء العملية (خام)"
 
-#: api/models.py:1496
+#: models.py:1583
 msgid "overall operation budget (raw)"
 msgstr "ميزانية التشغيل الإجمالية (خام)"
 
-#: api/models.py:1509
+#: models.py:1596
 msgid "date of disaster"
 msgstr "تاريخ الكارثة"
 
-#: api/models.py:1510
+#: models.py:1597
 msgid "number of other partner involved"
 msgstr "عدد الشركاء الآخرين المعنيين"
 
-#: api/models.py:1511
+#: models.py:1598
 msgid "number of NS partner involved"
 msgstr "عدد شركاء NS المشاركين"
 
-#: api/models.py:1512
+#: models.py:1599
 msgid "operation end date"
 msgstr "تاريخ انتهاء العملية"
 
-#: api/models.py:1514
+#: models.py:1601
 msgid "overall operation budget"
 msgstr "ميزانية التشغيل الإجمالية"
 
-#: api/models.py:1527
+#: models.py:1614
 msgid "emergency operations final report"
 msgstr "التقرير النهائي لعمليات الطوارئ"
 
-#: api/models.py:1528
+#: models.py:1615
 msgid "emergency operations final reports"
 msgstr "التقارير النهائية لعمليات الطوارئ"
 
-#: api/models.py:1541
+#: models.py:1628
 msgid "Never run"
 msgstr "لا تهرب"
 
-#: api/models.py:1542
+#: models.py:1629
 msgid "Successfull"
 msgstr "نجح"
 
-#: api/models.py:1543
+#: models.py:1630
 msgid "Warned"
 msgstr "محذَّر"
 
-#: api/models.py:1544
+#: models.py:1631
 msgid "Erroneous"
 msgstr "خاطئ"
 
-#: api/models.py:1552
+#: models.py:1639
 msgid "message"
 msgstr "رسالة"
 
-#: api/models.py:1553
+#: models.py:1640
 msgid "number of results"
 msgstr "الحد الاقصى لعدد النتائج"
 
-#: api/models.py:1554
+#: models.py:1641
 msgid "storing days"
 msgstr "أيام التخزين"
 
-#: api/models.py:1556
+#: models.py:1643
 msgid "backend side"
 msgstr "الجانب الخلفي"
 
-#: api/models.py:1560
+#: models.py:1647
 msgid "cronjob log record"
 msgstr "سجل سجل cronjob"
 
-#: api/models.py:1561
+#: models.py:1648
 msgid "cronjob log records"
 msgstr "سجلات سجل cronjob"
 
-#: api/models.py:1623 api/models.py:1641
+#: models.py:1710 models.py:1728
 msgid "username"
 msgstr "رقم العضوية"
 
-#: api/models.py:1628
+#: models.py:1715
 msgid "auth log"
 msgstr "سجل المصادقة"
 
-#: api/models.py:1629
+#: models.py:1716
 msgid "auth logs"
 msgstr "Auth Logs"
 
-#: api/models.py:1642
+#: models.py:1729
 msgid "object id"
 msgstr "معرف الكائن"
 
-#: api/models.py:1643
+#: models.py:1730
 msgid "object name"
 msgstr "اسم الكائن"
 
-#: api/models.py:1644
+#: models.py:1731
 msgid "object type"
 msgstr "نوع الكائن"
 
-#: api/models.py:1647
+#: models.py:1734
 msgid "changed from"
 msgstr "تغير من"
 
-#: api/models.py:1651
+#: models.py:1738
 msgid "changed to"
 msgstr "تغيير  إلى"
 
-#: api/models.py:1655
+#: models.py:1742
 msgid "reversion difference log"
 msgstr "سجل فرق الارتداد"
 
-#: api/models.py:1656
+#: models.py:1743
 msgid "reversion difference logs"
 msgstr "سجلات فرق الارتداد"
 
-#: api/templates/admin/base.html:62
+#: templates/admin/base.html:74
 msgid "Welcome,"
 msgstr "اهلاً بك،"
 
-#: api/templates/admin/base.html:67
+#: templates/admin/base.html:79
 msgid "View site"
 msgstr "عرض الموقع"
 
-#: api/templates/admin/base.html:72
+#: templates/admin/base.html:84
 msgid "Documentation"
 msgstr "توثيق"
 
-#: api/templates/admin/base.html:76
+#: templates/admin/base.html:88
 msgid "Change password"
 msgstr "تغيير كلمة المرور"
 
-#: api/templates/admin/base.html:78
+#: templates/admin/base.html:90
 msgid "Log out"
 msgstr "تسجيل خروج"
 
-#: api/templates/admin/base.html:88 api/templates/admin/import_form.html:13
+#: templates/admin/base.html:100 templates/admin/import_form.html:13
 msgid "Home"
 msgstr "الرئيسية"
 
-#: api/templates/admin/base_site.html:5
+#: templates/admin/base_site.html:5
 msgid "Django site admin"
 msgstr "ادارة موقع Django"
 
-#: api/templates/admin/edit_inline/tabular.html:21
+#: templates/admin/edit_inline/tabular.html:21
 msgid "Delete?"
 msgstr "تريد الحذف؟"
 
-#: api/templates/admin/edit_inline/tabular.html:35
+#: templates/admin/edit_inline/tabular.html:35
 msgid "Change"
 msgstr "غيرها"
 
-#: api/templates/admin/edit_inline/tabular.html:37
+#: templates/admin/edit_inline/tabular.html:37
 msgid "View on site"
 msgstr "عرض في الموقع"
 
-#: api/templates/admin/submit_line.html:5
+#: templates/admin/submit_line.html:5
 msgid "Save"
 msgstr "حفظ"
 
-#: api/templates/admin/submit_line.html:9
+#: templates/admin/submit_line.html:9
 msgid "Delete the whole"
 msgstr "احذف الكل"
 
-#: api/templates/admin/submit_line.html:12
+#: templates/admin/submit_line.html:12
 msgid "Save as new"
 msgstr "حفظ كجديد"
 
-#: api/templates/admin/submit_line.html:13
+#: templates/admin/submit_line.html:13
 msgid "Save and add another"
 msgstr "احفظ وأضف آخر"
 
-#: api/templates/admin/submit_line.html:14
+#: templates/admin/submit_line.html:14
 msgid "Save and continue editing"
 msgstr "الحفظ ومواصلة التعديل"
 
-#: api/templates/admin/submit_line.html:14
+#: templates/admin/submit_line.html:14
 msgid "Save and view"
 msgstr "حفظ وعرض"
 
-#: api/templates/admin/submit_line.html:15
+#: templates/admin/submit_line.html:15
 msgid "Close"
 msgstr "إغلاق"
 
-#: api/utils.py:38
+#: utils.py:38
 msgid "slug should not start with a number"
 msgstr "لا ينبغي أن تبدأ سبيكة برقم"
+
+#~ msgid "number of cases (MOH)"
+#~ msgstr "مقاييس الأداء (عدد الحالات)"
+
+#~ msgid "number of suspected cases (MOH)"
+#~ msgstr "عدد الحالات المشتبه بها (وزارة الصحة)"
+
+#~ msgid "number of probabale cases (MOH)"
+#~ msgstr "عدد الحالات المحتملة (وزارة الصحة)"
+
+#~ msgid "number of confirmed cases (MOH)"
+#~ msgstr "عدد الحاﻻت المؤكدة"
+
+#~ msgid "number of dead (MOH)"
+#~ msgstr "عدد القتلى (وزارة الصحة)"
+
+#~ msgid "number of cases (WHO)"
+#~ msgstr "مقاييس الأداء (عدد الحالات)"
+
+#~ msgid "number of suspected cases (WHO)"
+#~ msgstr "عدد الحالات المشتبه بها (منظمة الصحة العالمية)"
+
+#~ msgid "number of probable cases (WHO)"
+#~ msgstr "عدد الحالات المحتملة (منظمة الصحة العالمية)"
+
+#~ msgid "number of confirmed cases (WHO)"
+#~ msgstr "عدد الحاﻻت المؤكدة"
+
+#~ msgid "number of number of dead (WHO)"
+#~ msgstr "عدد القتلى (منظمة الصحة العالمية)"
+
+#~ msgid "number of cases (other)"
+#~ msgstr "عدد الحالات (أخرى)"
+
+#~ msgid "number of suspected cases (other)"
+#~ msgstr "عدد الحالات المشتبه بها (أخرى)"
+
+#~ msgid "number of probable cases (other)"
+#~ msgstr "عدد الحالات المحتملة (أخرى)"
+
+#~ msgid "number of confirmed cases (other)"
+#~ msgstr "عدد الحالات المؤكدة (أخرى)"
+
+#~ msgid "number of cases"
+#~ msgstr "عدد الحالات"
+
+#~ msgid "number of suspected cases"
+#~ msgstr "عدد الحالات المشتبه فيها"
+
+#~ msgid "number of probable cases"
+#~ msgstr "عدد الحالات المحتملة"
+
+#~ msgid "number of confirmed cases"
+#~ msgstr "عدد الحاﻻت المؤكدة"
+
+#~ msgid "field report contact"
+#~ msgstr "تقرير ميداني"

--- a/api/locale/en/LC_MESSAGES/django.po
+++ b/api/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-24 07:55+0000\n"
+"POT-Creation-Date: 2020-11-30 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,2028 +18,2165 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: api/admin.py:51
-msgid "related emergency"
-msgstr "related emergency"
-
-#: api/admin.py:56
-msgid "Exists"
-msgstr "Exists"
-
-#: api/admin.py:57
-msgid "Needs confirmation"
-msgstr "Needs confirmation"
-
-#: api/admin.py:58
-msgid "None"
-msgstr "None"
-
-#: api/admin.py:71
-msgid "membership"
-msgstr "membership"
-
-#: api/admin.py:83 api/models.py:670
-msgid "appeal type"
-msgstr "appeal type"
-
-#: api/admin.py:95
-msgid "featured"
-msgstr "featured"
-
-#: api/admin.py:100
-msgid "Featured"
-msgstr "Featured"
-
-#: api/admin.py:101
-msgid "Not Featured"
-msgstr "Not Featured"
-
-#: api/admin.py:112 api/models.py:233 api/models.py:532 api/models.py:1175
-msgid "source"
-msgstr "source"
-
-#: api/admin.py:117
-msgid "Manual input"
-msgstr "Manual input"
-
-#: api/admin.py:118
-msgid "GDACs scraper"
-msgstr "GDACs scraper"
-
-#: api/admin.py:119
-msgid "WHO scraper"
-msgstr "WHO scraper"
-
-#: api/admin.py:120
-msgid "Field report ingest"
-msgstr "Field report ingest"
-
-#: api/admin.py:121
-msgid "Field report admin"
-msgstr "Field report admin"
-
-#: api/admin.py:122
-msgid "Appeals admin"
-msgstr "Appeals admin"
-
-#: api/admin.py:123
-msgid "Unknown automated"
-msgstr "Unknown automated"
-
-#: api/apps.py:6
-msgid "api"
-msgstr "api"
-
-#: api/forms.py:8 api/models.py:1114
-msgid "organizations"
-msgstr "organizations"
-
-#: api/forms.py:9 api/models.py:1118
-msgid "field report types"
-msgstr "field report types"
-
-#: api/models.py:38 api/models.py:67 api/models.py:125 api/models.py:178
-#: api/models.py:350 api/models.py:392 api/models.py:420 api/models.py:514
-#: api/models.py:585 api/models.py:668 api/models.py:773 api/models.py:1053
-#: api/models.py:1111 api/models.py:1156 api/models.py:1549
-msgid "name"
-msgstr "name"
-
-#: api/models.py:39 api/models.py:414 api/models.py:835 api/models.py:1141
-msgid "summary"
-msgstr "summary"
-
-#: api/models.py:43 api/models.py:403 api/models.py:669 api/models.py:837
-msgid "disaster type"
-msgstr "disaster type"
-
-#: api/models.py:44
-msgid "disaster types"
-msgstr "disaster types"
-
-#: api/models.py:58
-msgid "Africa"
-msgstr "Africa"
-
-#: api/models.py:59
-msgid "Americas"
-msgstr "Americas"
-
-#: api/models.py:60
-msgid "Asia Pacific"
-msgstr "Asia Pacific"
-
-#: api/models.py:61
-msgid "Europe"
-msgstr "Europe"
-
-#: api/models.py:62
-msgid "Middle East & North Africa"
-msgstr "Middle East & North Africa"
-
-#: api/models.py:85 api/models.py:132 api/models.py:246 api/models.py:288
-#: api/models.py:333 api/models.py:363 api/models.py:692
-msgid "region"
-msgstr "region"
-
-#: api/models.py:86 api/models.py:406 api/models.py:843
-msgid "regions"
-msgstr "regions"
-
-#: api/models.py:110
-msgid "Country"
-msgstr "Country"
-
-#: api/models.py:111
-msgid "Cluster"
-msgstr "Cluster"
-
-#: api/models.py:112
-msgid "Region"
-msgstr "Region"
-
-#: api/models.py:113
-msgid "Country Office"
-msgstr "Country Office"
-
-#: api/models.py:114
-msgid "Representative Office"
-msgstr "Representative Office"
-
-#: api/models.py:126 api/models.py:349 api/models.py:513 api/models.py:565
-#: api/models.py:593 api/models.py:1052 api/models.py:1168
-msgid "type"
-msgstr "type"
-
-#: api/models.py:126
-msgid "Type of entity"
-msgstr "Type of entity"
-
-#: api/models.py:127
-msgid "ISO"
-msgstr "ISO"
-
-#: api/models.py:128
-msgid "ISO3"
-msgstr "ISO3"
-
-#: api/models.py:129
-msgid "society name"
-msgstr "society name"
-
-#: api/models.py:130
-msgid "URL - Society"
-msgstr "URL - Society"
-
-#: api/models.py:131
-msgid "URL - IFRC"
-msgstr "URL - IFRC"
-
-#: api/models.py:133
-msgid "overview"
-msgstr "overview"
-
-#: api/models.py:134
-msgid "key priorities"
-msgstr "key priorities"
-
-#: api/models.py:135
-msgid "inform score"
-msgstr "inform score"
-
-#: api/models.py:137
-msgid "logo"
-msgstr "logo"
-
-#: api/models.py:143 api/models.py:189
-msgid "WB population"
-msgstr "WB population"
-
-#: api/models.py:143 api/models.py:189
-msgid "population data from WB API"
-msgstr "population data from WB API"
-
-#: api/models.py:146
-msgid "WB Year"
-msgstr "WB Year"
-
-#: api/models.py:146 api/models.py:192
-msgid "population data year from WB API"
-msgstr "population data year from WB API"
-
-#: api/models.py:168 api/models.py:180 api/models.py:254 api/models.py:306
-#: api/models.py:341 api/models.py:371 api/models.py:691 api/models.py:1207
-msgid "country"
-msgstr "country"
-
-#: api/models.py:169 api/models.py:405 api/models.py:627 api/models.py:842
-msgid "countries"
-msgstr "countries"
-
-#: api/models.py:179 api/models.py:673
-msgid "code"
-msgstr "code"
-
-#: api/models.py:181
-msgid "country ISO3"
-msgstr "country ISO3"
-
-#: api/models.py:182
-msgid "country name"
-msgstr "country name"
-
-#: api/models.py:184
-msgid "is enclave?"
-msgstr "is enclave?"
-
-#: api/models.py:184
-msgid "Is it an enclave away from parent country?"
-msgstr "Is it an enclave away from parent country?"
-
-#: api/models.py:192
-msgid "WB year"
-msgstr "WB year"
-
-#: api/models.py:197
-msgid "district"
-msgstr "district"
-
-#: api/models.py:198 api/models.py:404 api/models.py:841
-msgid "districts"
-msgstr "districts"
-
-#: api/models.py:210 api/models.py:222
-msgid "Membership"
-msgstr "Membership"
-
-#: api/models.py:211 api/models.py:223
-msgid "IFRC Only"
-msgstr "IFRC Only"
-
-#: api/models.py:212 api/models.py:224
-msgid "Public"
-msgstr "Public"
-
-#: api/models.py:231
-msgid "figure"
-msgstr "figure"
-
-#: api/models.py:232 api/models.py:531
-msgid "deck"
-msgstr "deck"
-
-#: api/models.py:234 api/models.py:293 api/models.py:311 api/models.py:550
-#: api/models.py:595 api/models.py:934
-msgid "visibility"
-msgstr "visibility"
-
-#: api/models.py:238
-msgid "admin key figure"
-msgstr "admin key figure"
-
-#: api/models.py:239
-msgid "admin key figures"
-msgstr "admin key figures"
-
-#: api/models.py:249
-msgid "region key figure"
-msgstr "region key figure"
-
-#: api/models.py:250
-msgid "region key figures"
-msgstr "region key figures"
-
-#: api/models.py:257
-msgid "country key figure"
-msgstr "country key figure"
-
-#: api/models.py:258
-msgid "country key figures"
-msgstr "country key figures"
-
-#: api/models.py:269
-msgid "Top"
-msgstr "Top"
-
-#: api/models.py:270
-msgid "High"
-msgstr "High"
-
-#: api/models.py:271
-msgid "Middle"
-msgstr "Middle"
-
-#: api/models.py:272
-msgid "Low"
-msgstr "Low"
-
-#: api/models.py:273
-msgid "Bottom"
-msgstr "Bottom"
-
-#: api/models.py:282
-msgid "Tab 1"
-msgstr "Tab 1"
-
-#: api/models.py:283
-msgid "Tab 2"
-msgstr "Tab 2"
-
-#: api/models.py:284
-msgid "Tab 3"
-msgstr "Tab 3"
-
-#: api/models.py:289 api/models.py:307 api/models.py:545 api/models.py:556
-msgid "snippet"
-msgstr "snippet"
-
-#: api/models.py:291 api/models.py:309 api/models.py:547 api/models.py:612
-msgid "image"
-msgstr "image"
-
-#: api/models.py:294 api/models.py:312 api/models.py:551 api/models.py:1215
-msgid "position"
-msgstr "position"
-
-#: api/models.py:298
-msgid "region snippet"
-msgstr "region snippet"
-
-#: api/models.py:299
-msgid "region snippets"
-msgstr "region snippets"
-
-#: api/models.py:316
-msgid "country snippet"
-msgstr "country snippet"
-
-#: api/models.py:317
-msgid "country snippets"
-msgstr "country snippets"
-
-#: api/models.py:324 api/models.py:351 api/models.py:515 api/models.py:610
-#: api/models.py:1054
-msgid "title"
-msgstr "title"
-
-#: api/models.py:325
-msgid "url"
-msgstr "url"
-
-#: api/models.py:328
-msgid "admin link"
-msgstr "admin link"
-
-#: api/models.py:329
-msgid "admin links"
-msgstr "admin links"
-
-#: api/models.py:336
-msgid "region link"
-msgstr "region link"
-
-#: api/models.py:337
-msgid "region links"
-msgstr "region links"
-
-#: api/models.py:344
-msgid "country link"
-msgstr "country link"
-
-#: api/models.py:345
-msgid "country links"
-msgstr "country links"
-
-#: api/models.py:352 api/models.py:516 api/models.py:1055
-msgid "email"
-msgstr "email"
-
-#: api/models.py:355
-msgid "admin contact"
-msgstr "admin contact"
-
-#: api/models.py:356
-msgid "admin contacts"
-msgstr "admin contacts"
-
-#: api/models.py:366
-msgid "region contact"
-msgstr "region contact"
-
-#: api/models.py:367
-msgid "region contacts"
-msgstr "region contacts"
-
-#: api/models.py:374
-msgid "country contact"
-msgstr "country contact"
-
-#: api/models.py:375
-msgid "country contacts"
-msgstr "country contacts"
-
-#: api/models.py:384
-msgid "Green"
-msgstr "Green"
-
-#: api/models.py:385
-msgid "Orange"
-msgstr "Orange"
-
-#: api/models.py:386
-msgid "Red"
-msgstr "Red"
-
-#: api/models.py:395
-msgid "slug"
-msgstr "slug"
-
-#: api/models.py:398
-msgid ""
-"Optional string for a clean URL. For example, "
-"go.ifrc.org/emergencies/hurricane-katrina-2019. The string cannot start with"
-" a number and is forced to be lowercase. Recommend using hyphens over "
-"underscores. Special characters like # is not allowed."
-msgstr ""
-"Optional string for a clean URL. For example, "
-"go.ifrc.org/emergencies/hurricane-katrina-2019. The string cannot start with"
-" a number and is forced to be lowercase. Recommend using hyphens over "
-"underscores. Special characters like # is not allowed."
-
-#: api/models.py:408
-msgid "Parent Emergency"
-msgstr "Parent Emergency"
-
-#: api/models.py:410
-msgid ""
-"If needed, you have to change the connected Appeals', Field Reports', etc to"
-" point to the parent Emergency manually."
-msgstr ""
-"If needed, you have to change the connected Appeals', Field Reports', etc to"
-" point to the parent Emergency manually."
-
-#: api/models.py:416 api/models.py:848
-msgid "number of injured"
-msgstr "number of injured"
-
-#: api/models.py:417 api/models.py:849
-msgid "number of dead"
-msgstr "number of dead"
-
-#: api/models.py:418 api/models.py:850
-msgid "number of missing"
-msgstr "number of missing"
-
-#: api/models.py:419 api/models.py:851
-msgid "number of affected"
-msgstr "number of affected"
-
-#: api/models.py:422
-msgid "IFRC Severity level"
-msgstr "IFRC Severity level"
-
-#: api/models.py:423
-msgid "glide"
-msgstr "glide"
-
-#: api/models.py:425
-msgid "disaster start date"
-msgstr "disaster start date"
-
-#: api/models.py:426 api/models.py:584 api/models.py:682 api/models.py:772
-#: api/models.py:994 api/models.py:1551 api/models.py:1624 api/models.py:1639
-msgid "created at"
-msgstr "created at"
-
-#: api/models.py:427 api/models.py:995
-msgid "updated at"
-msgstr "updated at"
-
-#: api/models.py:428 api/models.py:684
-msgid "previous update"
-msgstr "previous update"
-
-#: api/models.py:430
-msgid "auto generated"
-msgstr "auto generated"
-
-#: api/models.py:432
-msgid "auto generated source"
-msgstr "auto generated source"
-
-#: api/models.py:436
-msgid "is featured on home page"
-msgstr "is featured on home page"
-
-#: api/models.py:439
-msgid "is featured on region page"
-msgstr "is featured on region page"
-
-#: api/models.py:441
-msgid "hide attached field reports?"
-msgstr "hide attached field reports?"
-
-#: api/models.py:445
-msgid "tab one title"
-msgstr "tab one title"
-
-#: api/models.py:447
-msgid "tab two title"
-msgstr "tab two title"
-
-#: api/models.py:448
-msgid "tab three title"
-msgstr "tab three title"
-
-#: api/models.py:452
-msgid "emergency"
-msgstr "emergency"
-
-#: api/models.py:453
-msgid "emergencies"
-msgstr "emergencies"
-
-#: api/models.py:517 api/models.py:1056
-msgid "phone"
-msgstr "phone"
-
-#: api/models.py:518 api/models.py:529 api/models.py:549 api/models.py:591
-#: api/models.py:688 api/models.py:839
-msgid "event"
-msgstr "event"
-
-#: api/models.py:521
-msgid "event contact"
-msgstr "event contact"
-
-#: api/models.py:522
-msgid "event contacts"
-msgstr "event contacts"
-
-#: api/models.py:530
-msgid "number"
-msgstr "number"
-
-#: api/models.py:530
-msgid "key figure metric"
-msgstr "key figure metric"
-
-#: api/models.py:531
-msgid "key figure units"
-msgstr "key figure units"
-
-#: api/models.py:532
-msgid "key figure website link, publication"
-msgstr "key figure website link, publication"
-
-#: api/models.py:535
-msgid "key figure"
-msgstr "key figure"
-
-#: api/models.py:536
-msgid "key figures"
-msgstr "key figures"
-
-#: api/models.py:552
-msgid "tab"
-msgstr "tab"
-
-#: api/models.py:557
-msgid "snippets"
-msgstr "snippets"
-
-#: api/models.py:567
-msgid "is primary?"
-msgstr "is primary?"
-
-#: api/models.py:568
-msgid "Ensure this type gets precedence over others that are empty"
-msgstr "Ensure this type gets precedence over others that are empty"
-
-#: api/models.py:572
-msgid "situation report type"
-msgstr "situation report type"
-
-#: api/models.py:573
-msgid "situation report types"
-msgstr "situation report types"
-
-#: api/models.py:587 api/models.py:775
-msgid "document"
-msgstr "document"
-
-#: api/models.py:589 api/models.py:777
-msgid "document url"
-msgstr "document url"
-
-#: api/models.py:596
-msgid "is pinned?"
-msgstr "is pinned?"
-
-#: api/models.py:596
-msgid "pin this report at the top"
-msgstr "pin this report at the top"
-
-#: api/models.py:599
-msgid "situation report"
-msgstr "situation report"
-
-#: api/models.py:600
-msgid "situation reports"
-msgstr "situation reports"
-
-#: api/models.py:609
-msgid "event id"
-msgstr "event id"
-
-#: api/models.py:611 api/models.py:836
-msgid "description"
-msgstr "description"
-
-#: api/models.py:613
-msgid "report"
-msgstr "report"
-
-#: api/models.py:614
-msgid "publication date"
-msgstr "publication date"
-
-#: api/models.py:615
-msgid "year"
-msgstr "year"
-
-#: api/models.py:616
-msgid "latitude"
-msgstr "latitude"
-
-#: api/models.py:617
-msgid "longitude"
-msgstr "longitude"
-
-#: api/models.py:618
-msgid "event type"
-msgstr "event type"
-
-#: api/models.py:619
-msgid "alert level"
-msgstr "alert level"
-
-#: api/models.py:620
-msgid "alert score"
-msgstr "alert score"
-
-#: api/models.py:621
-msgid "severity"
-msgstr "severity"
-
-#: api/models.py:622
-msgid "severity unit"
-msgstr "severity unit"
-
-#: api/models.py:623
-msgid "severity value"
-msgstr "severity value"
-
-#: api/models.py:624
-msgid "population unit"
-msgstr "population unit"
-
-#: api/models.py:625
-msgid "population value"
-msgstr "population value"
-
-#: api/models.py:626
-msgid "vulnerability"
-msgstr "vulnerability"
-
-#: api/models.py:628
-msgid "country text"
-msgstr "country text"
-
-#: api/models.py:631
-msgid "gdacs event"
-msgstr "gdacs event"
-
-#: api/models.py:632
-msgid "gdacs events"
-msgstr "gdacs events"
-
-#: api/models.py:645 api/models.py:938
-msgid "DREF"
-msgstr "DREF"
-
-#: api/models.py:646
-msgid "Emergency Appeal"
-msgstr "Emergency Appeal"
-
-#: api/models.py:647
-msgid "International Appeal"
-msgstr "International Appeal"
-
-#: api/models.py:657
-msgid "Active"
-msgstr "Active"
-
-#: api/models.py:658
-msgid "Closed"
-msgstr "Closed"
-
-#: api/models.py:659
-msgid "Frozen"
-msgstr "Frozen"
-
-#: api/models.py:660
-msgid "Archived"
-msgstr "Archived"
-
-#: api/models.py:667
-msgid "appeal ID"
-msgstr "appeal ID"
-
-#: api/models.py:672 api/models.py:844 api/models.py:1550
-msgid "status"
-msgstr "status"
-
-#: api/models.py:674
-msgid "sector"
-msgstr "sector"
-
-#: api/models.py:676
-msgid "number of beneficiaries"
-msgstr "number of beneficiaries"
-
-#: api/models.py:677
-msgid "amount requested"
-msgstr "amount requested"
-
-#: api/models.py:678
-msgid "amount funded"
-msgstr "amount funded"
-
-#: api/models.py:680 api/models.py:988
-msgid "start date"
-msgstr "start date"
-
-#: api/models.py:681
-msgid "end date"
-msgstr "end date"
-
-#: api/models.py:683
-msgid "modified at"
-msgstr "modified at"
-
-#: api/models.py:685
-msgid "real data update"
-msgstr "real data update"
-
-#: api/models.py:690
-msgid "needs confirmation?"
-msgstr "needs confirmation?"
-
-#: api/models.py:733 api/models.py:779 api/models.py:940
-msgid "appeal"
-msgstr "appeal"
-
-#: api/models.py:734
-msgid "appeals"
-msgstr "appeals"
-
-#: api/models.py:782
-msgid "appeal document"
-msgstr "appeal document"
-
-#: api/models.py:783
-msgid "appeal documents"
-msgstr "appeal documents"
-
-#: api/models.py:802
-msgid "No"
-msgstr "No"
-
-#: api/models.py:803
-msgid "Requested"
-msgstr "Requested"
-
-#: api/models.py:804
-msgid "Planned"
-msgstr "Planned"
-
-#: api/models.py:805
-msgid "Complete"
-msgstr "Complete"
-
-#: api/models.py:814
-msgid "Ministry of health"
-msgstr "Ministry of health"
-
-#: api/models.py:815
-msgid "WHO"
-msgstr "WHO"
-
-#: api/models.py:816
-msgid "OTHER"
-msgstr "OTHER"
-
-#: api/models.py:823 api/models.py:1200
-msgid "user"
-msgstr "user"
-
-#: api/models.py:828
-msgid "is covid report?"
-msgstr "is covid report?"
-
-#: api/models.py:830
-msgid "Is this a Field Report specific to the COVID-19 emergency?"
-msgstr "Is this a Field Report specific to the COVID-19 emergency?"
-
-#: api/models.py:834
-msgid "r id"
-msgstr "r id"
-
-#: api/models.py:845
-msgid "request assistance"
-msgstr "request assistance"
-
-#: api/models.py:846
-msgid "NS request assistance"
-msgstr "NS request assistance"
-
-#: api/models.py:852
-msgid "number of displaced"
-msgstr "number of displaced"
-
-#: api/models.py:853
-msgid "number of assisted"
-msgstr "number of assisted"
-
-#: api/models.py:854
-msgid "number of localstaff"
-msgstr "number of localstaff"
-
-#: api/models.py:855
-msgid "number of volunteers"
-msgstr "number of volunteers"
-
-#: api/models.py:856
-msgid "number of expatriate delegates"
-msgstr "number of expatriate delegates"
-
-#: api/models.py:859
-msgid "number of potentially affected"
-msgstr "number of potentially affected"
-
-#: api/models.py:860
-msgid "number of highest risk"
-msgstr "number of highest risk"
-
-#: api/models.py:861
-msgid "affected population centres"
-msgstr "affected population centres"
-
-#: api/models.py:863
-msgid "number of injured (goverment)"
-msgstr "number of injured (goverment)"
-
-#: api/models.py:864
-msgid "number of dead (goverment)"
-msgstr "number of dead (goverment)"
-
-#: api/models.py:865
-msgid "number of missing (goverment)"
-msgstr "number of missing (goverment)"
-
-#: api/models.py:866
-msgid "number of affected (goverment)"
-msgstr "number of affected (goverment)"
-
-#: api/models.py:867
-msgid "number of displaced (goverment)"
-msgstr "number of displaced (goverment)"
-
-#: api/models.py:868
-msgid "number of assisted (goverment)"
-msgstr "number of assisted (goverment)"
-
-#: api/models.py:871
-msgid "number of cases (epidemic)"
-msgstr "number of cases (epidemic)"
-
-#: api/models.py:872
-msgid "number of suspected cases (epidemic)"
-msgstr "number of suspected cases (epidemic)"
-
-#: api/models.py:873
-msgid "number of probable cases (epidemic)"
-msgstr "number of probable cases (epidemic)"
-
-#: api/models.py:874
-msgid "number of confirmed cases (epidemic)"
-msgstr "number of confirmed cases (epidemic)"
-
-#: api/models.py:875
-msgid "number of dead (epidemic)"
-msgstr "number of dead (epidemic)"
-
-#: api/models.py:876
-msgid "figures source (epidemic)"
-msgstr "figures source (epidemic)"
-
-#: api/models.py:878
-msgid "number of cases (MOH)"
-msgstr "number of cases (MOH)"
-
-#: api/models.py:879
-msgid "number of suspected cases (MOH)"
-msgstr "number of suspected cases (MOH)"
-
-#: api/models.py:880
-msgid "number of probabale cases (MOH)"
-msgstr "number of probabale cases (MOH)"
-
-#: api/models.py:881
-msgid "number of confirmed cases (MOH)"
-msgstr "number of confirmed cases (MOH)"
-
-#: api/models.py:882
-msgid "number of dead (MOH)"
-msgstr "number of dead (MOH)"
-
-#: api/models.py:884
-msgid "number of cases (WHO)"
-msgstr "number of cases (WHO)"
-
-#: api/models.py:885
-msgid "number of suspected cases (WHO)"
-msgstr "number of suspected cases (WHO)"
-
-#: api/models.py:886
-msgid "number of probable cases (WHO)"
-msgstr "number of probable cases (WHO)"
-
-#: api/models.py:887
-msgid "number of confirmed cases (WHO)"
-msgstr "number of confirmed cases (WHO)"
-
-#: api/models.py:888
-msgid "number of number of dead (WHO)"
-msgstr "number of number of dead (WHO)"
-
-#: api/models.py:890
-msgid "number of cases (other)"
-msgstr "number of cases (other)"
-
-#: api/models.py:891
-msgid "number of suspected cases (other)"
-msgstr "number of suspected cases (other)"
-
-#: api/models.py:892
-msgid "number of probable cases (other)"
-msgstr "number of probable cases (other)"
-
-#: api/models.py:893
-msgid "number of confirmed cases (other)"
-msgstr "number of confirmed cases (other)"
-
-#: api/models.py:895 api/models.py:896
-msgid "number of assisted (who)"
-msgstr "number of assisted (who)"
-
-#: api/models.py:899
-msgid "potentially affected (goverment)"
-msgstr "potentially affected (goverment)"
-
-#: api/models.py:900
-msgid "people at highest risk (goverment)"
-msgstr "people at highest risk (goverment)"
-
-#: api/models.py:902
-msgid "affected population centres (goverment)"
-msgstr "affected population centres (goverment)"
-
-#: api/models.py:904
-msgid "number of injured (other)"
-msgstr "number of injured (other)"
-
-#: api/models.py:905
-msgid "number of dead (other)"
-msgstr "number of dead (other)"
-
-#: api/models.py:906
-msgid "number of missing (other)"
-msgstr "number of missing (other)"
-
-#: api/models.py:907
-msgid "number of affected (other)"
-msgstr "number of affected (other)"
-
-#: api/models.py:908
-msgid "number of displace (other)"
-msgstr "number of displace (other)"
-
-#: api/models.py:909
-msgid "number of assisted (other)"
-msgstr "number of assisted (other)"
-
-#: api/models.py:913
-msgid "number of potentially affected (other)"
-msgstr "number of potentially affected (other)"
-
-#: api/models.py:914
-msgid "number of highest risk (other)"
-msgstr "number of highest risk (other)"
-
-#: api/models.py:916
-msgid "number of affected population centres (other)"
-msgstr "number of affected population centres (other)"
-
-#: api/models.py:919
-msgid "number of cases"
-msgstr "number of cases"
-
-#: api/models.py:920
-msgid "number of suspected cases"
-msgstr "number of suspected cases"
-
-#: api/models.py:921
-msgid "number of probable cases"
-msgstr "number of probable cases"
-
-#: api/models.py:922
-msgid "number of confirmed cases"
-msgstr "number of confirmed cases"
-
-#: api/models.py:925
-msgid "situation fields date"
-msgstr "situation fields date"
-
-#: api/models.py:928
-msgid "sources (other)"
-msgstr "sources (other)"
-
-#: api/models.py:931
-msgid "actions taken (others)"
-msgstr "actions taken (others)"
-
-#: api/models.py:937
-msgid "bullentin"
-msgstr "bullentin"
-
-#: api/models.py:939
-msgid "DREF amount"
-msgstr "DREF amount"
-
-#: api/models.py:941
-msgid "appeal amount"
-msgstr "appeal amount"
-
-#: api/models.py:942
-msgid "imminent dref"
-msgstr "imminent dref"
-
-#: api/models.py:943
-msgid "imminent dref amount"
-msgstr "imminent dref amount"
-
-#: api/models.py:944
-msgid "forecast based action"
-msgstr "forecast based action"
-
-#: api/models.py:946
-msgid "forecast based action amount"
-msgstr "forecast based action amount"
-
-#: api/models.py:949
-msgid "RDRT"
-msgstr "RDRT"
-
-#: api/models.py:950
-msgid "number of RDRT"
-msgstr "number of RDRT"
-
-#: api/models.py:951
-msgid "fact"
-msgstr "fact"
-
-#: api/models.py:952
-msgid "number of fact"
-msgstr "number of fact"
-
-#: api/models.py:953
-msgid "IFRC staff"
-msgstr "IFRC staff"
-
-#: api/models.py:954
-msgid "number of IFRC staff"
-msgstr "number of IFRC staff"
-
-#: api/models.py:957
-msgid "ERU base camp"
-msgstr "ERU base camp"
-
-#: api/models.py:958
-msgid "ERU base camp units"
-msgstr "ERU base camp units"
-
-#: api/models.py:960
-msgid "ERU basic health care"
-msgstr "ERU basic health care"
-
-#: api/models.py:961
-msgid "ERU basic health units"
-msgstr "ERU basic health units"
-
-#: api/models.py:963
-msgid "ERU IT telecom"
-msgstr "ERU IT telecom"
-
-#: api/models.py:964
-msgid "ERU IT telecom units"
-msgstr "ERU IT telecom units"
-
-#: api/models.py:966
-msgid "ERU logistics"
-msgstr "ERU logistics"
-
-#: api/models.py:967
-msgid "ERU logistics units"
-msgstr "ERU logistics units"
-
-#: api/models.py:969
-msgid "ERU deployment hospital"
-msgstr "ERU deployment hospital"
-
-#: api/models.py:970
-msgid "ERU deployment hospital units"
-msgstr "ERU deployment hospital units"
-
-#: api/models.py:972
-msgid "ERU referral hospital"
-msgstr "ERU referral hospital"
-
-#: api/models.py:973
-msgid "ERU referral hospital units"
-msgstr "ERU referral hospital units"
-
-#: api/models.py:975
-msgid "ERU relief"
-msgstr "ERU relief"
-
-#: api/models.py:976
-msgid "ERU relief units"
-msgstr "ERU relief units"
-
-#: api/models.py:978
-msgid "ERU water sanitaion M15"
-msgstr "ERU water sanitaion M15"
-
-#: api/models.py:979
-msgid "ERU water sanitaion M15 units"
-msgstr "ERU water sanitaion M15 units"
-
-#: api/models.py:981
-msgid "ERU water sanitaion M40"
-msgstr "ERU water sanitaion M40"
-
-#: api/models.py:982
-msgid "ERU water sanitaion M40 units"
-msgstr "ERU water sanitaion M40 units"
-
-#: api/models.py:984
-msgid "ERU water sanitaion MSM20"
-msgstr "ERU water sanitaion MSM20"
-
-#: api/models.py:985
-msgid "ERU water sanitaion MSM20 units"
-msgstr "ERU water sanitaion MSM20 units"
-
-#: api/models.py:993
-msgid "report date"
-msgstr "report date"
-
-#: api/models.py:996
-msgid "previous updated at"
-msgstr "previous updated at"
-
-#: api/models.py:1000 api/models.py:1058 api/models.py:1143 api/models.py:1171
-msgid "field report"
-msgstr "field report"
-
-#: api/models.py:1001
-msgid "field reports"
-msgstr "field reports"
-
-#: api/models.py:1062
-msgid "field report contact"
-msgstr "field report contact"
-
-#: api/models.py:1063
-msgid "field report contacts"
-msgstr "field report contacts"
-
-#: api/models.py:1075 api/models.py:1191
-msgid "National Society"
-msgstr "National Society"
-
-#: api/models.py:1076
-msgid "Foreign Society"
-msgstr "Foreign Society"
-
-#: api/models.py:1077
-msgid "Federation"
-msgstr "Federation"
-
-#: api/models.py:1088
-msgid "Event"
-msgstr "Event"
-
-#: api/models.py:1089
-msgid "Early Warning"
-msgstr "Early Warning"
-
-#: api/models.py:1090
-msgid "Epidemic"
-msgstr "Epidemic"
-
-#: api/models.py:1091
-msgid "COVID-19"
-msgstr "COVID-19"
-
-#: api/models.py:1102
-msgid "General"
-msgstr "General"
-
-#: api/models.py:1103
-msgid "Health"
-msgstr "Health"
-
-#: api/models.py:1104
-msgid "NS Institutional Strengthening"
-msgstr "NS Institutional Strengthening"
-
-#: api/models.py:1105
-msgid "Socioeconomic Interventions"
-msgstr "Socioeconomic Interventions"
-
-#: api/models.py:1121
-msgid "category"
-msgstr "category"
-
-#: api/models.py:1123
-msgid "is disabled?"
-msgstr "is disabled?"
-
-#: api/models.py:1123
-msgid "Disable in form"
-msgstr "Disable in form"
-
-#: api/models.py:1126 api/models.py:1622 api/models.py:1640
-msgid "action"
-msgstr "action"
-
-#: api/models.py:1127 api/models.py:1140
-msgid "actions"
-msgstr "actions"
-
-#: api/models.py:1138 api/models.py:1211
-msgid "organization"
-msgstr "organization"
-
-#: api/models.py:1147
-msgid "actions taken"
-msgstr "actions taken"
-
-#: api/models.py:1148
-msgid "all actions taken"
-msgstr "all actions taken"
-
-#: api/models.py:1159
-msgid "source type"
-msgstr "source type"
-
-#: api/models.py:1160
-msgid "source types"
-msgstr "source types"
-
-#: api/models.py:1169
-msgid "spec"
-msgstr "spec"
-
-#: api/models.py:1176
-msgid "sources"
-msgstr "sources"
-
-#: api/models.py:1192
-msgid "Delegation"
-msgstr "Delegation"
-
-#: api/models.py:1193
-msgid "Secretariat"
-msgstr "Secretariat"
-
-#: api/models.py:1194
-msgid "ICRC"
-msgstr "ICRC"
-
-#: api/models.py:1195
-msgid "Other"
-msgstr "Other"
-
-#: api/models.py:1212
-msgid "organization type"
-msgstr "organization type"
-
-#: api/models.py:1213
-msgid "city"
-msgstr "city"
-
-#: api/models.py:1214
-msgid "department"
-msgstr "department"
-
-#: api/models.py:1216
-msgid "phone number"
-msgstr "phone number"
-
-#: api/models.py:1219
+#: admin.py:32 models.py:1306
 msgid "user profile"
 msgstr "user profile"
 
-#: api/models.py:1220
+#: admin.py:67
+msgid "related emergency"
+msgstr "related emergency"
+
+#: admin.py:72
+msgid "Exists"
+msgstr "Exists"
+
+#: admin.py:73
+msgid "Needs confirmation"
+msgstr "Needs confirmation"
+
+#: admin.py:74
+msgid "None"
+msgstr "None"
+
+#: admin.py:87
+msgid "membership"
+msgstr "membership"
+
+#: admin.py:99 models.py:779
+msgid "appeal type"
+msgstr "appeal type"
+
+#: admin.py:111
+msgid "featured"
+msgstr "featured"
+
+#: admin.py:116
+msgid "Featured"
+msgstr "Featured"
+
+#: admin.py:117
+msgid "Not Featured"
+msgstr "Not Featured"
+
+#: admin.py:128 models.py:285 models.py:641 models.py:1261
+msgid "source"
+msgstr "source"
+
+#: admin.py:133
+msgid "Manual input"
+msgstr "Manual input"
+
+#: admin.py:134
+msgid "GDACs scraper"
+msgstr "GDACs scraper"
+
+#: admin.py:135
+msgid "WHO scraper"
+msgstr "WHO scraper"
+
+#: admin.py:136
+msgid "Field report ingest"
+msgstr "Field report ingest"
+
+#: admin.py:137
+msgid "Field report admin"
+msgstr "Field report admin"
+
+#: admin.py:138
+msgid "Appeals admin"
+msgstr "Appeals admin"
+
+#: admin.py:139
+msgid "Unknown automated"
+msgstr "Unknown automated"
+
+#: apps.py:6
+msgid "api"
+msgstr "api"
+
+#: forms.py:8 models.py:1200
+msgid "organizations"
+msgstr "organizations"
+
+#: forms.py:9 models.py:1204
+msgid "field report types"
+msgstr "field report types"
+
+#: models.py:39 models.py:68 models.py:136 models.py:225 models.py:459
+#: models.py:501 models.py:623 models.py:694 models.py:777 models.py:882
+#: models.py:1139 models.py:1197 models.py:1242 models.py:1636
+msgid "name"
+msgstr "name"
+
+#: models.py:40 models.py:523 models.py:944 models.py:1227
+msgid "summary"
+msgstr "summary"
+
+#: models.py:44 models.py:512 models.py:778 models.py:946
+msgid "disaster type"
+msgstr "disaster type"
+
+#: models.py:45
+msgid "disaster types"
+msgstr "disaster types"
+
+#: models.py:59
+msgid "Africa"
+msgstr "Africa"
+
+#: models.py:60
+msgid "Americas"
+msgstr "Americas"
+
+#: models.py:61
+msgid "Asia Pacific"
+msgstr "Asia Pacific"
+
+#: models.py:62
+msgid "Europe"
+msgstr "Europe"
+
+#: models.py:63
+msgid "Middle East & North Africa"
+msgstr "Middle East & North Africa"
+
+#: models.py:70
+#, fuzzy
+#| msgid "number of highest risk"
+msgid "name of the region"
+msgstr "number of highest risk"
+
+#: models.py:95 models.py:144 models.py:298 models.py:340 models.py:358
+#: models.py:374 models.py:390 models.py:441 models.py:472 models.py:801
+msgid "region"
+msgstr "region"
+
+#: models.py:96 models.py:515 models.py:952
+msgid "regions"
+msgstr "regions"
+
+#: models.py:120
+msgid "Country"
+msgstr "Country"
+
+#: models.py:121
+msgid "Cluster"
+msgstr "Cluster"
+
+#: models.py:122
+msgid "Region"
+msgstr "Region"
+
+#: models.py:123
+msgid "Country Office"
+msgstr "Country Office"
+
+#: models.py:124
+msgid "Representative Office"
+msgstr "Representative Office"
+
+#: models.py:137 models.py:458 models.py:622 models.py:674 models.py:702
+#: models.py:1138 models.py:1254
+msgid "type"
+msgstr "type"
+
+#: models.py:137
+msgid "Type of entity"
+msgstr "Type of entity"
+
+#: models.py:138
+msgid "ISO"
+msgstr "ISO"
+
+#: models.py:139
+msgid "ISO3"
+msgstr "ISO3"
+
+#: models.py:140
+msgid "FDRS"
+msgstr ""
+
+#: models.py:141
+msgid "society name"
+msgstr "society name"
+
+#: models.py:142
+msgid "URL - Society"
+msgstr "URL - Society"
+
+#: models.py:143
+msgid "URL - IFRC"
+msgstr "URL - IFRC"
+
+#: models.py:145
+msgid "overview"
+msgstr "overview"
+
+#: models.py:146
+msgid "key priorities"
+msgstr "key priorities"
+
+#: models.py:147
+msgid "inform score"
+msgstr "inform score"
+
+#: models.py:149
+msgid "logo"
+msgstr "logo"
+
+#: models.py:156
+#, fuzzy
+#| msgid "Is it an enclave away from parent country?"
+msgid "Is this an independent country?"
+msgstr "Is it an enclave away from parent country?"
+
+#: models.py:159
+msgid "Is this an active, valid country?"
+msgstr ""
+
+#: models.py:164 models.py:241
+msgid "WB population"
+msgstr "WB population"
+
+#: models.py:164 models.py:241
+msgid "population data from WB API"
+msgstr "population data from WB API"
+
+#: models.py:167
+msgid "WB Year"
+msgstr "WB Year"
+
+#: models.py:167 models.py:244
+msgid "population data year from WB API"
+msgstr "population data year from WB API"
+
+#: models.py:169
+msgid "Label for Additional Tab"
+msgstr ""
+
+#: models.py:172
+msgid "Income (CHF)"
+msgstr ""
+
+#: models.py:173
+msgid "Expenditures (CHF)"
+msgstr ""
+
+#: models.py:174
+msgid "Branches"
+msgstr ""
+
+#: models.py:175
+msgid "Staff"
+msgstr ""
+
+#: models.py:176
+#, fuzzy
+#| msgid "number of volunteers"
+msgid "Volunteers"
+msgstr "number of volunteers"
+
+#: models.py:177
+msgid "Youth - 6-19 Yrs"
+msgstr ""
+
+#: models.py:178
+msgid "Trained in First Aid"
+msgstr ""
+
+#: models.py:179
+msgid "Gov Financial Support"
+msgstr ""
+
+#: models.py:180
+msgid ">50% Domestically Generated Income"
+msgstr ""
+
+#: models.py:181
+msgid "Annual Reporting to FDRS"
+msgstr ""
+
+#: models.py:182
+msgid "Your Policy / Programme Implementation"
+msgstr ""
+
+#: models.py:183
+msgid "Risk Management Framework"
+msgstr ""
+
+#: models.py:184
+msgid "Complying with CMC Dashboard"
+msgstr ""
+
+#: models.py:187
+msgid "Total WASH Staff"
+msgstr ""
+
+#: models.py:188
+msgid "WASH Kit2"
+msgstr ""
+
+#: models.py:189
+msgid "WASH Kit5"
+msgstr ""
+
+#: models.py:190
+msgid "WASH Kit10"
+msgstr ""
+
+#: models.py:191
+msgid "WASH Staff at HQ"
+msgstr ""
+
+#: models.py:192
+msgid "WASH Staff at Branch"
+msgstr ""
+
+#: models.py:193
+msgid "NDRT Trained"
+msgstr ""
+
+#: models.py:194
+msgid "RDRT Trained"
+msgstr ""
+
+#: models.py:215 models.py:227 models.py:306 models.py:414 models.py:450
+#: models.py:480 models.py:800 models.py:1293
+msgid "country"
+msgstr "country"
+
+#: models.py:216 models.py:514 models.py:736 models.py:951
+msgid "countries"
+msgstr "countries"
+
+#: models.py:226 models.py:782
+msgid "code"
+msgstr "code"
+
+#: models.py:228
+#, fuzzy
+#| msgid "country ISO3"
+msgid "country ISO2"
+msgstr "country ISO3"
+
+#: models.py:229
+msgid "country name"
+msgstr "country name"
+
+#: models.py:231
+msgid "is enclave?"
+msgstr "is enclave?"
+
+#: models.py:231
+msgid "Is it an enclave away from parent country?"
+msgstr "Is it an enclave away from parent country?"
+
+#: models.py:237
+msgid "Is this an active, valid district?"
+msgstr ""
+
+#: models.py:244
+msgid "WB year"
+msgstr "WB year"
+
+#: models.py:249
+msgid "district"
+msgstr "district"
+
+#: models.py:250 models.py:513 models.py:950
+msgid "districts"
+msgstr "districts"
+
+#: models.py:262 models.py:274
+msgid "Membership"
+msgstr "Membership"
+
+#: models.py:263 models.py:275
+msgid "IFRC Only"
+msgstr "IFRC Only"
+
+#: models.py:264 models.py:276
+msgid "Public"
+msgstr "Public"
+
+#: models.py:283
+msgid "figure"
+msgstr "figure"
+
+#: models.py:284 models.py:640
+msgid "deck"
+msgstr "deck"
+
+#: models.py:286 models.py:345 models.py:419 models.py:659 models.py:704
+#: models.py:1020
+msgid "visibility"
+msgstr "visibility"
+
+#: models.py:290
+msgid "admin key figure"
+msgstr "admin key figure"
+
+#: models.py:291
+msgid "admin key figures"
+msgstr "admin key figures"
+
+#: models.py:301
+msgid "region key figure"
+msgstr "region key figure"
+
+#: models.py:302
+msgid "region key figures"
+msgstr "region key figures"
+
+#: models.py:309
+msgid "country key figure"
+msgstr "country key figure"
+
+#: models.py:310
+msgid "country key figures"
+msgstr "country key figures"
+
+#: models.py:321
+msgid "Top"
+msgstr "Top"
+
+#: models.py:322
+msgid "High"
+msgstr "High"
+
+#: models.py:323
+msgid "Middle"
+msgstr "Middle"
+
+#: models.py:324
+msgid "Low"
+msgstr "Low"
+
+#: models.py:325
+msgid "Bottom"
+msgstr "Bottom"
+
+#: models.py:334
+msgid "Tab 1"
+msgstr "Tab 1"
+
+#: models.py:335
+msgid "Tab 2"
+msgstr "Tab 2"
+
+#: models.py:336
+msgid "Tab 3"
+msgstr "Tab 3"
+
+#: models.py:341 models.py:360 models.py:376 models.py:392 models.py:415
+#: models.py:654 models.py:665
+msgid "snippet"
+msgstr "snippet"
+
+#: models.py:343 models.py:417 models.py:656 models.py:721
+msgid "image"
+msgstr "image"
+
+#: models.py:346 models.py:362 models.py:378 models.py:394 models.py:420
+#: models.py:660 models.py:1301
+msgid "position"
+msgstr "position"
+
+#: models.py:350
+msgid "region snippet"
+msgstr "region snippet"
+
+#: models.py:351
+msgid "region snippets"
+msgstr "region snippets"
+
+#: models.py:366
+#, fuzzy
+#| msgid "region snippet"
+msgid "region emergencies snippet"
+msgstr "region snippet"
+
+#: models.py:367
+#, fuzzy
+#| msgid "region snippets"
+msgid "region emergencies snippets"
+msgstr "region snippets"
+
+#: models.py:382
+#, fuzzy
+#| msgid "region snippet"
+msgid "region preparedness snippet"
+msgstr "region snippet"
+
+#: models.py:383
+#, fuzzy
+#| msgid "region snippets"
+msgid "region preparedness snippets"
+msgstr "region snippets"
+
+#: models.py:398
+#, fuzzy
+#| msgid "region snippet"
+msgid "region profile snippet"
+msgstr "region snippet"
+
+#: models.py:399
+#, fuzzy
+#| msgid "region snippets"
+msgid "region profile snippets"
+msgstr "region snippets"
+
+#: models.py:424
+msgid "country snippet"
+msgstr "country snippet"
+
+#: models.py:425
+msgid "country snippets"
+msgstr "country snippets"
+
+#: models.py:432 models.py:460 models.py:624 models.py:719 models.py:1140
+msgid "title"
+msgstr "title"
+
+#: models.py:433
+msgid "url"
+msgstr "url"
+
+#: models.py:436
+msgid "admin link"
+msgstr "admin link"
+
+#: models.py:437
+msgid "admin links"
+msgstr "admin links"
+
+#: models.py:445
+msgid "region link"
+msgstr "region link"
+
+#: models.py:446
+msgid "region links"
+msgstr "region links"
+
+#: models.py:453
+msgid "country link"
+msgstr "country link"
+
+#: models.py:454
+msgid "country links"
+msgstr "country links"
+
+#: models.py:461 models.py:625 models.py:1141
+msgid "email"
+msgstr "email"
+
+#: models.py:464
+msgid "admin contact"
+msgstr "admin contact"
+
+#: models.py:465
+msgid "admin contacts"
+msgstr "admin contacts"
+
+#: models.py:475
+msgid "region contact"
+msgstr "region contact"
+
+#: models.py:476
+msgid "region contacts"
+msgstr "region contacts"
+
+#: models.py:483
+msgid "country contact"
+msgstr "country contact"
+
+#: models.py:484
+msgid "country contacts"
+msgstr "country contacts"
+
+#: models.py:493
+msgid "Green"
+msgstr "Green"
+
+#: models.py:494
+msgid "Orange"
+msgstr "Orange"
+
+#: models.py:495
+msgid "Red"
+msgstr "Red"
+
+#: models.py:504
+msgid "slug"
+msgstr "slug"
+
+#: models.py:507
+msgid ""
+"Optional string for a clean URL. For example, go.ifrc.org/emergencies/"
+"hurricane-katrina-2019. The string cannot start with a number and is forced "
+"to be lowercase. Recommend using hyphens over underscores. Special "
+"characters like # is not allowed."
+msgstr ""
+"Optional string for a clean URL. For example, go.ifrc.org/emergencies/"
+"hurricane-katrina-2019. The string cannot start with a number and is forced "
+"to be lowercase. Recommend using hyphens over underscores. Special "
+"characters like # is not allowed."
+
+#: models.py:517
+msgid "Parent Emergency"
+msgstr "Parent Emergency"
+
+#: models.py:519
+msgid ""
+"If needed, you have to change the connected Appeals', Field Reports', etc to "
+"point to the parent Emergency manually."
+msgstr ""
+"If needed, you have to change the connected Appeals', Field Reports', etc to "
+"point to the parent Emergency manually."
+
+#: models.py:525 models.py:957
+msgid "number of injured"
+msgstr "number of injured"
+
+#: models.py:526 models.py:958
+msgid "number of dead"
+msgstr "number of dead"
+
+#: models.py:527 models.py:959
+msgid "number of missing"
+msgstr "number of missing"
+
+#: models.py:528 models.py:960
+msgid "number of affected"
+msgstr "number of affected"
+
+#: models.py:529 models.py:961
+msgid "number of displaced"
+msgstr "number of displaced"
+
+#: models.py:531
+msgid "IFRC Severity level"
+msgstr "IFRC Severity level"
+
+#: models.py:532
+msgid "glide"
+msgstr "glide"
+
+#: models.py:534
+msgid "disaster start date"
+msgstr "disaster start date"
+
+#: models.py:535 models.py:693 models.py:791 models.py:881 models.py:1080
+#: models.py:1638 models.py:1711 models.py:1726
+msgid "created at"
+msgstr "created at"
+
+#: models.py:536 models.py:1081
+msgid "updated at"
+msgstr "updated at"
+
+#: models.py:537 models.py:793
+msgid "previous update"
+msgstr "previous update"
+
+#: models.py:539
+msgid "auto generated"
+msgstr "auto generated"
+
+#: models.py:541
+msgid "auto generated source"
+msgstr "auto generated source"
+
+#: models.py:545
+msgid "is featured on home page"
+msgstr "is featured on home page"
+
+#: models.py:548
+msgid "is featured on region page"
+msgstr "is featured on region page"
+
+#: models.py:550
+msgid "hide attached field reports?"
+msgstr "hide attached field reports?"
+
+#: models.py:554
+msgid "tab one title"
+msgstr "tab one title"
+
+#: models.py:556
+msgid "tab two title"
+msgstr "tab two title"
+
+#: models.py:557
+msgid "tab three title"
+msgstr "tab three title"
+
+#: models.py:561
+msgid "emergency"
+msgstr "emergency"
+
+#: models.py:562
+msgid "emergencies"
+msgstr "emergencies"
+
+#: models.py:626 models.py:1142
+msgid "phone"
+msgstr "phone"
+
+#: models.py:627 models.py:638 models.py:658 models.py:700 models.py:797
+#: models.py:948
+msgid "event"
+msgstr "event"
+
+#: models.py:630
+msgid "event contact"
+msgstr "event contact"
+
+#: models.py:631
+msgid "event contacts"
+msgstr "event contacts"
+
+#: models.py:639
+msgid "number"
+msgstr "number"
+
+#: models.py:639
+msgid "key figure metric"
+msgstr "key figure metric"
+
+#: models.py:640
+msgid "key figure units"
+msgstr "key figure units"
+
+#: models.py:641
+msgid "key figure website link, publication"
+msgstr "key figure website link, publication"
+
+#: models.py:644
+msgid "key figure"
+msgstr "key figure"
+
+#: models.py:645
+msgid "key figures"
+msgstr "key figures"
+
+#: models.py:661
+msgid "tab"
+msgstr "tab"
+
+#: models.py:666
+msgid "snippets"
+msgstr "snippets"
+
+#: models.py:676
+msgid "is primary?"
+msgstr "is primary?"
+
+#: models.py:677
+msgid "Ensure this type gets precedence over others that are empty"
+msgstr "Ensure this type gets precedence over others that are empty"
+
+#: models.py:681
+msgid "situation report type"
+msgstr "situation report type"
+
+#: models.py:682
+msgid "situation report types"
+msgstr "situation report types"
+
+#: models.py:696 models.py:884
+msgid "document"
+msgstr "document"
+
+#: models.py:698 models.py:886
+msgid "document url"
+msgstr "document url"
+
+#: models.py:705
+msgid "is pinned?"
+msgstr "is pinned?"
+
+#: models.py:705
+msgid "pin this report at the top"
+msgstr "pin this report at the top"
+
+#: models.py:708
+msgid "situation report"
+msgstr "situation report"
+
+#: models.py:709
+msgid "situation reports"
+msgstr "situation reports"
+
+#: models.py:718
+msgid "event id"
+msgstr "event id"
+
+#: models.py:720 models.py:945
+msgid "description"
+msgstr "description"
+
+#: models.py:722
+msgid "report"
+msgstr "report"
+
+#: models.py:723
+msgid "publication date"
+msgstr "publication date"
+
+#: models.py:724
+msgid "year"
+msgstr "year"
+
+#: models.py:725
+msgid "latitude"
+msgstr "latitude"
+
+#: models.py:726
+msgid "longitude"
+msgstr "longitude"
+
+#: models.py:727
+msgid "event type"
+msgstr "event type"
+
+#: models.py:728
+msgid "alert level"
+msgstr "alert level"
+
+#: models.py:729
+msgid "alert score"
+msgstr "alert score"
+
+#: models.py:730
+msgid "severity"
+msgstr "severity"
+
+#: models.py:731
+msgid "severity unit"
+msgstr "severity unit"
+
+#: models.py:732
+msgid "severity value"
+msgstr "severity value"
+
+#: models.py:733
+msgid "population unit"
+msgstr "population unit"
+
+#: models.py:734
+msgid "population value"
+msgstr "population value"
+
+#: models.py:735
+msgid "vulnerability"
+msgstr "vulnerability"
+
+#: models.py:737
+msgid "country text"
+msgstr "country text"
+
+#: models.py:740
+msgid "gdacs event"
+msgstr "gdacs event"
+
+#: models.py:741
+msgid "gdacs events"
+msgstr "gdacs events"
+
+#: models.py:754 models.py:1024
+msgid "DREF"
+msgstr "DREF"
+
+#: models.py:755
+msgid "Emergency Appeal"
+msgstr "Emergency Appeal"
+
+#: models.py:756
+msgid "International Appeal"
+msgstr "International Appeal"
+
+#: models.py:766
+msgid "Active"
+msgstr "Active"
+
+#: models.py:767
+msgid "Closed"
+msgstr "Closed"
+
+#: models.py:768
+msgid "Frozen"
+msgstr "Frozen"
+
+#: models.py:769
+msgid "Archived"
+msgstr "Archived"
+
+#: models.py:776
+msgid "appeal ID"
+msgstr "appeal ID"
+
+#: models.py:781 models.py:953 models.py:1637
+msgid "status"
+msgstr "status"
+
+#: models.py:783
+msgid "sector"
+msgstr "sector"
+
+#: models.py:785
+msgid "number of beneficiaries"
+msgstr "number of beneficiaries"
+
+#: models.py:786
+msgid "amount requested"
+msgstr "amount requested"
+
+#: models.py:787
+msgid "amount funded"
+msgstr "amount funded"
+
+#: models.py:789 models.py:1074
+msgid "start date"
+msgstr "start date"
+
+#: models.py:790
+msgid "end date"
+msgstr "end date"
+
+#: models.py:792
+msgid "modified at"
+msgstr "modified at"
+
+#: models.py:794
+msgid "real data update"
+msgstr "real data update"
+
+#: models.py:799
+msgid "needs confirmation?"
+msgstr "needs confirmation?"
+
+#: models.py:842 models.py:888 models.py:1026
+msgid "appeal"
+msgstr "appeal"
+
+#: models.py:843
+msgid "appeals"
+msgstr "appeals"
+
+#: models.py:891
+msgid "appeal document"
+msgstr "appeal document"
+
+#: models.py:892
+msgid "appeal documents"
+msgstr "appeal documents"
+
+#: models.py:911
+msgid "No"
+msgstr "No"
+
+#: models.py:912
+msgid "Requested"
+msgstr "Requested"
+
+#: models.py:913
+msgid "Planned"
+msgstr "Planned"
+
+#: models.py:914
+msgid "Complete"
+msgstr "Complete"
+
+#: models.py:923
+msgid "Ministry of health"
+msgstr "Ministry of health"
+
+#: models.py:924
+msgid "WHO"
+msgstr "WHO"
+
+#: models.py:925
+msgid "OTHER"
+msgstr "OTHER"
+
+#: models.py:932 models.py:1286
+msgid "user"
+msgstr "user"
+
+#: models.py:937
+msgid "is covid report?"
+msgstr "is covid report?"
+
+#: models.py:939
+msgid "Is this a Field Report specific to the COVID-19 emergency?"
+msgstr "Is this a Field Report specific to the COVID-19 emergency?"
+
+#: models.py:943
+msgid "r id"
+msgstr "r id"
+
+#: models.py:954
+msgid "request assistance"
+msgstr "request assistance"
+
+#: models.py:955
+msgid "NS request assistance"
+msgstr "NS request assistance"
+
+#: models.py:962
+msgid "number of assisted"
+msgstr "number of assisted"
+
+#: models.py:963
+msgid "number of localstaff"
+msgstr "number of localstaff"
+
+#: models.py:964
+msgid "number of volunteers"
+msgstr "number of volunteers"
+
+#: models.py:965
+msgid "number of expatriate delegates"
+msgstr "number of expatriate delegates"
+
+#: models.py:968
+msgid "number of potentially affected"
+msgstr "number of potentially affected"
+
+#: models.py:969
+msgid "number of highest risk"
+msgstr "number of highest risk"
+
+#: models.py:970
+msgid "affected population centres"
+msgstr "affected population centres"
+
+#: models.py:972
+msgid "number of injured (goverment)"
+msgstr "number of injured (goverment)"
+
+#: models.py:973
+msgid "number of dead (goverment)"
+msgstr "number of dead (goverment)"
+
+#: models.py:974
+msgid "number of missing (goverment)"
+msgstr "number of missing (goverment)"
+
+#: models.py:975
+msgid "number of affected (goverment)"
+msgstr "number of affected (goverment)"
+
+#: models.py:976
+msgid "number of displaced (goverment)"
+msgstr "number of displaced (goverment)"
+
+#: models.py:977
+msgid "number of assisted (goverment)"
+msgstr "number of assisted (goverment)"
+
+#: models.py:980
+msgid "number of cases (epidemic)"
+msgstr "number of cases (epidemic)"
+
+#: models.py:981
+msgid "number of suspected cases (epidemic)"
+msgstr "number of suspected cases (epidemic)"
+
+#: models.py:982
+msgid "number of probable cases (epidemic)"
+msgstr "number of probable cases (epidemic)"
+
+#: models.py:983
+msgid "number of confirmed cases (epidemic)"
+msgstr "number of confirmed cases (epidemic)"
+
+#: models.py:984
+msgid "number of dead (epidemic)"
+msgstr "number of dead (epidemic)"
+
+#: models.py:985
+msgid "figures source (epidemic)"
+msgstr "figures source (epidemic)"
+
+#: models.py:987 models.py:988
+msgid "number of assisted (who)"
+msgstr "number of assisted (who)"
+
+#: models.py:991
+msgid "potentially affected (goverment)"
+msgstr "potentially affected (goverment)"
+
+#: models.py:992
+msgid "people at highest risk (goverment)"
+msgstr "people at highest risk (goverment)"
+
+#: models.py:994
+msgid "affected population centres (goverment)"
+msgstr "affected population centres (goverment)"
+
+#: models.py:996
+msgid "number of injured (other)"
+msgstr "number of injured (other)"
+
+#: models.py:997
+msgid "number of dead (other)"
+msgstr "number of dead (other)"
+
+#: models.py:998
+msgid "number of missing (other)"
+msgstr "number of missing (other)"
+
+#: models.py:999
+msgid "number of affected (other)"
+msgstr "number of affected (other)"
+
+#: models.py:1000
+msgid "number of displace (other)"
+msgstr "number of displace (other)"
+
+#: models.py:1001
+msgid "number of assisted (other)"
+msgstr "number of assisted (other)"
+
+#: models.py:1005
+msgid "number of potentially affected (other)"
+msgstr "number of potentially affected (other)"
+
+#: models.py:1006
+msgid "number of highest risk (other)"
+msgstr "number of highest risk (other)"
+
+#: models.py:1008
+msgid "number of affected population centres (other)"
+msgstr "number of affected population centres (other)"
+
+#: models.py:1011
+msgid "situation fields date"
+msgstr "situation fields date"
+
+#: models.py:1014
+msgid "sources (other)"
+msgstr "sources (other)"
+
+#: models.py:1017
+msgid "actions taken (others)"
+msgstr "actions taken (others)"
+
+#: models.py:1023
+msgid "bullentin"
+msgstr "bullentin"
+
+#: models.py:1025
+msgid "DREF amount"
+msgstr "DREF amount"
+
+#: models.py:1027
+msgid "appeal amount"
+msgstr "appeal amount"
+
+#: models.py:1028
+msgid "imminent dref"
+msgstr "imminent dref"
+
+#: models.py:1029
+msgid "imminent dref amount"
+msgstr "imminent dref amount"
+
+#: models.py:1030
+msgid "forecast based action"
+msgstr "forecast based action"
+
+#: models.py:1032
+msgid "forecast based action amount"
+msgstr "forecast based action amount"
+
+#: models.py:1035
+msgid "RDRT"
+msgstr "RDRT"
+
+#: models.py:1036
+msgid "number of RDRT"
+msgstr "number of RDRT"
+
+#: models.py:1037
+msgid "fact"
+msgstr "fact"
+
+#: models.py:1038
+msgid "number of fact"
+msgstr "number of fact"
+
+#: models.py:1039
+msgid "IFRC staff"
+msgstr "IFRC staff"
+
+#: models.py:1040
+msgid "number of IFRC staff"
+msgstr "number of IFRC staff"
+
+#: models.py:1043
+msgid "ERU base camp"
+msgstr "ERU base camp"
+
+#: models.py:1044
+msgid "ERU base camp units"
+msgstr "ERU base camp units"
+
+#: models.py:1046
+msgid "ERU basic health care"
+msgstr "ERU basic health care"
+
+#: models.py:1047
+msgid "ERU basic health units"
+msgstr "ERU basic health units"
+
+#: models.py:1049
+msgid "ERU IT telecom"
+msgstr "ERU IT telecom"
+
+#: models.py:1050
+msgid "ERU IT telecom units"
+msgstr "ERU IT telecom units"
+
+#: models.py:1052
+msgid "ERU logistics"
+msgstr "ERU logistics"
+
+#: models.py:1053
+msgid "ERU logistics units"
+msgstr "ERU logistics units"
+
+#: models.py:1055
+msgid "ERU deployment hospital"
+msgstr "ERU deployment hospital"
+
+#: models.py:1056
+msgid "ERU deployment hospital units"
+msgstr "ERU deployment hospital units"
+
+#: models.py:1058
+msgid "ERU referral hospital"
+msgstr "ERU referral hospital"
+
+#: models.py:1059
+msgid "ERU referral hospital units"
+msgstr "ERU referral hospital units"
+
+#: models.py:1061
+msgid "ERU relief"
+msgstr "ERU relief"
+
+#: models.py:1062
+msgid "ERU relief units"
+msgstr "ERU relief units"
+
+#: models.py:1064
+msgid "ERU water sanitaion M15"
+msgstr "ERU water sanitaion M15"
+
+#: models.py:1065
+msgid "ERU water sanitaion M15 units"
+msgstr "ERU water sanitaion M15 units"
+
+#: models.py:1067
+msgid "ERU water sanitaion M40"
+msgstr "ERU water sanitaion M40"
+
+#: models.py:1068
+msgid "ERU water sanitaion M40 units"
+msgstr "ERU water sanitaion M40 units"
+
+#: models.py:1070
+msgid "ERU water sanitaion MSM20"
+msgstr "ERU water sanitaion MSM20"
+
+#: models.py:1071
+msgid "ERU water sanitaion MSM20 units"
+msgstr "ERU water sanitaion MSM20 units"
+
+#: models.py:1079
+msgid "report date"
+msgstr "report date"
+
+#: models.py:1082
+msgid "previous updated at"
+msgstr "previous updated at"
+
+#: models.py:1086 models.py:1144 models.py:1229 models.py:1257
+msgid "field report"
+msgstr "field report"
+
+#: models.py:1087
+msgid "field reports"
+msgstr "field reports"
+
+#: models.py:1148 models.py:1149
+msgid "field report contacts"
+msgstr "field report contacts"
+
+#: models.py:1161 models.py:1277
+msgid "National Society"
+msgstr "National Society"
+
+#: models.py:1162
+msgid "Foreign Society"
+msgstr "Foreign Society"
+
+#: models.py:1163
+msgid "Federation"
+msgstr "Federation"
+
+#: models.py:1174
+msgid "Event"
+msgstr "Event"
+
+#: models.py:1175
+msgid "Early Warning"
+msgstr "Early Warning"
+
+#: models.py:1176
+msgid "Epidemic"
+msgstr "Epidemic"
+
+#: models.py:1177
+msgid "COVID-19"
+msgstr "COVID-19"
+
+#: models.py:1188
+msgid "General"
+msgstr "General"
+
+#: models.py:1189
+msgid "Health"
+msgstr "Health"
+
+#: models.py:1190
+msgid "NS Institutional Strengthening"
+msgstr "NS Institutional Strengthening"
+
+#: models.py:1191
+msgid "Socioeconomic Interventions"
+msgstr "Socioeconomic Interventions"
+
+#: models.py:1207
+msgid "category"
+msgstr "category"
+
+#: models.py:1209
+msgid "is disabled?"
+msgstr "is disabled?"
+
+#: models.py:1209
+msgid "Disable in form"
+msgstr "Disable in form"
+
+#: models.py:1212 models.py:1709 models.py:1727
+msgid "action"
+msgstr "action"
+
+#: models.py:1213 models.py:1226
+msgid "actions"
+msgstr "actions"
+
+#: models.py:1224 models.py:1297
+msgid "organization"
+msgstr "organization"
+
+#: models.py:1233
+msgid "actions taken"
+msgstr "actions taken"
+
+#: models.py:1234
+msgid "all actions taken"
+msgstr "all actions taken"
+
+#: models.py:1245
+msgid "source type"
+msgstr "source type"
+
+#: models.py:1246
+msgid "source types"
+msgstr "source types"
+
+#: models.py:1255
+msgid "spec"
+msgstr "spec"
+
+#: models.py:1262
+msgid "sources"
+msgstr "sources"
+
+#: models.py:1278
+msgid "Delegation"
+msgstr "Delegation"
+
+#: models.py:1279
+msgid "Secretariat"
+msgstr "Secretariat"
+
+#: models.py:1280
+msgid "ICRC"
+msgstr "ICRC"
+
+#: models.py:1281
+msgid "Other"
+msgstr "Other"
+
+#: models.py:1298
+msgid "organization type"
+msgstr "organization type"
+
+#: models.py:1299
+msgid "city"
+msgstr "city"
+
+#: models.py:1300
+msgid "department"
+msgstr "department"
+
+#: models.py:1302
+msgid "phone number"
+msgstr "phone number"
+
+#: models.py:1303
+msgid "last frontend login"
+msgstr ""
+
+#: models.py:1307
 msgid "user profiles"
 msgstr "user profiles"
 
-#: api/models.py:1229
+#: models.py:1316
 msgid "is validated?"
 msgstr "is validated?"
 
-#: api/models.py:1229
+#: models.py:1316
 msgid "Did anyone check the editable data?"
 msgstr "Did anyone check the editable data?"
 
-#: api/models.py:1231
+#: models.py:1318
 msgid "created_at"
 msgstr "created_at"
 
-#: api/models.py:1232
+#: models.py:1319
 msgid "modified_at"
 msgstr "modified_at"
 
-#: api/models.py:1237
+#: models.py:1324
 msgid "appeal number (raw)"
 msgstr "appeal number (raw)"
 
-#: api/models.py:1238
+#: models.py:1325
 msgid "date of issue (raw)"
 msgstr "date of issue (raw)"
 
-#: api/models.py:1239
+#: models.py:1326
 msgid "glide number (raw)"
 msgstr "glide number (raw)"
 
-#: api/models.py:1241
+#: models.py:1328
 msgid "number of people to be assisted (raw)"
 msgstr "number of people to be assisted (raw)"
 
-#: api/models.py:1242
+#: models.py:1329
 msgid "number of people affected (raw)"
 msgstr "number of people affected (raw)"
 
-#: api/models.py:1247
+#: models.py:1334
 msgid "number of disaster risk reduction female (raw)"
 msgstr "number of disaster risk reduction female (raw)"
 
-#: api/models.py:1249
+#: models.py:1336
 msgid "number of disaster risk reduction male (raw)"
 msgstr "number of disaster risk reduction male (raw)"
 
-#: api/models.py:1251
+#: models.py:1338
 msgid "number of disaster risk reduction people reached (raw)"
 msgstr "number of disaster risk reduction people reached (raw)"
 
-#: api/models.py:1253
+#: models.py:1340
 msgid "number of disaster risk reduction people targeted (raw)"
 msgstr "number of disaster risk reduction people targeted (raw)"
 
-#: api/models.py:1255
+#: models.py:1342
 msgid "number of disaster risk reduction requirements (raw)"
 msgstr "number of disaster risk reduction requirements (raw)"
 
-#: api/models.py:1256
+#: models.py:1343
 msgid "health female (raw)"
 msgstr "health female (raw)"
 
-#: api/models.py:1257
+#: models.py:1344
 msgid "health male (raw)"
 msgstr "health male (raw)"
 
-#: api/models.py:1258
+#: models.py:1345
 msgid "health people reached (raw)"
 msgstr "health people reached (raw)"
 
-#: api/models.py:1259
+#: models.py:1346
 msgid "health people targeted (raw)"
 msgstr "health people targeted (raw)"
 
-#: api/models.py:1260
+#: models.py:1347
 msgid "health requirements (raw)"
 msgstr "health requirements (raw)"
 
-#: api/models.py:1262
+#: models.py:1349
 msgid "number of livelihhods and basic needs female (raw)"
 msgstr "number of livelihhods and basic needs female (raw)"
 
-#: api/models.py:1264
+#: models.py:1351
 msgid "number of livelihhods and basic needs male (raw)"
 msgstr "number of livelihhods and basic needs male (raw)"
 
-#: api/models.py:1266
+#: models.py:1353
 msgid "number of livelihhods and basic needs people reached (raw)"
 msgstr "number of livelihhods and basic needs people reached (raw)"
 
-#: api/models.py:1268
+#: models.py:1355
 msgid "number of livelihhods and basic needs people targeted (raw)"
 msgstr "number of livelihhods and basic needs people targeted (raw)"
 
-#: api/models.py:1270
+#: models.py:1357
 msgid "number of livelihhods and basic needs requirements (raw)"
 msgstr "number of livelihhods and basic needs requirements (raw)"
 
-#: api/models.py:1271
+#: models.py:1358
 msgid "number of migration female (raw)"
 msgstr "number of migration female (raw)"
 
-#: api/models.py:1272
+#: models.py:1359
 msgid "number of migration male (raw)"
 msgstr "number of migration male (raw)"
 
-#: api/models.py:1274
+#: models.py:1361
 msgid "number of migration people reached (raw)"
 msgstr "number of migration people reached (raw)"
 
-#: api/models.py:1276
+#: models.py:1363
 msgid "number of migration people targeted (raw)"
 msgstr "number of migration people targeted (raw)"
 
-#: api/models.py:1277
+#: models.py:1364
 msgid "number of migration requirements (raw)"
 msgstr "number of migration requirements (raw)"
 
-#: api/models.py:1279
+#: models.py:1366
 msgid "number of protection gender and inclusion female (raw)"
 msgstr "number of protection gender and inclusion female (raw)"
 
-#: api/models.py:1281
+#: models.py:1368
 msgid "number of protection gender and inclusion male (raw)"
 msgstr "number of protection gender and inclusion male (raw)"
 
-#: api/models.py:1283
+#: models.py:1370
 msgid "number of protection gender and inclusion people reached (raw)"
 msgstr "number of protection gender and inclusion people reached (raw)"
 
-#: api/models.py:1285
+#: models.py:1372
 msgid "number of protection gender and inclusion people targeted (raw)"
 msgstr "number of protection gender and inclusion people targeted (raw)"
 
-#: api/models.py:1287
+#: models.py:1374
 msgid "number of protection gender and inclusion requirements (raw)"
 msgstr "number of protection gender and inclusion requirements (raw)"
 
-#: api/models.py:1288
+#: models.py:1375
 msgid "number of shelter female (raw)"
 msgstr "number of shelter female (raw)"
 
-#: api/models.py:1289
+#: models.py:1376
 msgid "number of shelter male (raw)"
 msgstr "number of shelter male (raw)"
 
-#: api/models.py:1290
+#: models.py:1377
 msgid "number of shelter people reached (raw)"
 msgstr "number of shelter people reached (raw)"
 
-#: api/models.py:1292
+#: models.py:1379
 msgid "number of shelter people targeted (raw)"
 msgstr "number of shelter people targeted (raw)"
 
-#: api/models.py:1293
+#: models.py:1380
 msgid "number of shelter requirements (raw)"
 msgstr "number of shelter requirements (raw)"
 
-#: api/models.py:1295
+#: models.py:1382
 msgid "number of water sanitation and hygiene female (raw)"
 msgstr "number of water sanitation and hygiene female (raw)"
 
-#: api/models.py:1297
+#: models.py:1384
 msgid "number of water sanitation and hygiene male (raw)"
 msgstr "number of water sanitation and hygiene male (raw)"
 
-#: api/models.py:1299
+#: models.py:1386
 msgid "number of water sanitation and hygiene people reached (raw)"
 msgstr "number of water sanitation and hygiene people reached (raw)"
 
-#: api/models.py:1301
+#: models.py:1388
 msgid "number of water sanitation and hygiene people targeted (raw)"
 msgstr "number of water sanitation and hygiene people targeted (raw)"
 
-#: api/models.py:1303
+#: models.py:1390
 msgid "number of water sanitation and hygiene requirements (raw)"
 msgstr "number of water sanitation and hygiene requirements (raw)"
 
-#: api/models.py:1307
+#: models.py:1394
 msgid "appeal number"
 msgstr "appeal number"
 
-#: api/models.py:1308
+#: models.py:1395
 msgid "date of issue"
 msgstr "date of issue"
 
-#: api/models.py:1309
+#: models.py:1396
 msgid "glide number"
 msgstr "glide number"
 
-#: api/models.py:1310
+#: models.py:1397
 msgid "number of people affected"
 msgstr "number of people affected"
 
-#: api/models.py:1311
+#: models.py:1398
 msgid "number of people to be assisted"
 msgstr "number of people to be assisted"
 
-#: api/models.py:1312 api/models.py:1513
+#: models.py:1399 models.py:1600
 msgid "operation start date"
 msgstr "operation start date"
 
-#: api/models.py:1314
+#: models.py:1401
 msgid "DREF allocated"
 msgstr "DREF allocated"
 
-#: api/models.py:1316
+#: models.py:1403
 msgid "number of disaster risk reduction female"
 msgstr "number of disaster risk reduction female"
 
-#: api/models.py:1318
+#: models.py:1405
 msgid "number of disaster risk reduction male"
 msgstr "number of disaster risk reduction male"
 
-#: api/models.py:1320
+#: models.py:1407
 msgid "number of disaster risk reduction people reached"
 msgstr "number of disaster risk reduction people reached"
 
-#: api/models.py:1322
+#: models.py:1409
 msgid "number of disaster risk reduction people targeted"
 msgstr "number of disaster risk reduction people targeted"
 
-#: api/models.py:1324
+#: models.py:1411
 msgid "number of disaster risk reduction people requirements"
 msgstr "number of disaster risk reduction people requirements"
 
-#: api/models.py:1325
+#: models.py:1412
 msgid "number of health female"
 msgstr "number of health female"
 
-#: api/models.py:1326
+#: models.py:1413
 msgid "number of health male"
 msgstr "number of health male"
 
-#: api/models.py:1327
+#: models.py:1414
 msgid "number of health people reached"
 msgstr "number of health people reached"
 
-#: api/models.py:1328
+#: models.py:1415
 msgid "number of health people targeted"
 msgstr "number of health people targeted"
 
-#: api/models.py:1329
+#: models.py:1416
 msgid "number of health requirements"
 msgstr "number of health requirements"
 
-#: api/models.py:1331
+#: models.py:1418
 msgid "number of livelihhods and basic needs female"
 msgstr "number of livelihhods and basic needs female"
 
-#: api/models.py:1333
+#: models.py:1420
 msgid "number of livelihhods and basic needs male"
 msgstr "number of livelihhods and basic needs male"
 
-#: api/models.py:1335
+#: models.py:1422
 msgid "number of livelihhods and basic people reached"
 msgstr "number of livelihhods and basic people reached"
 
-#: api/models.py:1337
+#: models.py:1424
 msgid "number of livelihhods and basic people targeted"
 msgstr "number of livelihhods and basic people targeted"
 
-#: api/models.py:1339
+#: models.py:1426
 msgid "number of livelihhods and basic needs requirements"
 msgstr "number of livelihhods and basic needs requirements"
 
-#: api/models.py:1340
+#: models.py:1427
 msgid "number of migration female"
 msgstr "number of migration female"
 
-#: api/models.py:1341
+#: models.py:1428
 msgid "number of migration male"
 msgstr "number of migration male"
 
-#: api/models.py:1342
+#: models.py:1429
 msgid "number of migration people reached"
 msgstr "number of migration people reached"
 
-#: api/models.py:1343
+#: models.py:1430
 msgid "number of migration people targeted"
 msgstr "number of migration people targeted"
 
-#: api/models.py:1344
+#: models.py:1431
 msgid "number of migration requirements"
 msgstr "number of migration requirements"
 
-#: api/models.py:1346
+#: models.py:1433
 msgid "number of protection gender and inclusion female"
 msgstr "number of protection gender and inclusion female"
 
-#: api/models.py:1348
+#: models.py:1435
 msgid "number of protection gender and inclusion male"
 msgstr "number of protection gender and inclusion male"
 
-#: api/models.py:1350
+#: models.py:1437
 msgid "number of protection gender and inclusion people reached"
 msgstr "number of protection gender and inclusion people reached"
 
-#: api/models.py:1352
+#: models.py:1439
 msgid "number of protection gender and inclusion people targeted"
 msgstr "number of protection gender and inclusion people targeted"
 
-#: api/models.py:1354
+#: models.py:1441
 msgid "number of protection gender and inclusion requirements"
 msgstr "number of protection gender and inclusion requirements"
 
-#: api/models.py:1355
+#: models.py:1442
 msgid "number of shelter female"
 msgstr "number of shelter female"
 
-#: api/models.py:1356
+#: models.py:1443
 msgid "number of shelter male"
 msgstr "number of shelter male"
 
-#: api/models.py:1357
+#: models.py:1444
 msgid "number of shelter people reached"
 msgstr "number of shelter people reached"
 
-#: api/models.py:1358
+#: models.py:1445
 msgid "number of shelter people targeted"
 msgstr "number of shelter people targeted"
 
-#: api/models.py:1359
+#: models.py:1446
 msgid "number of shelter people requirements"
 msgstr "number of shelter people requirements"
 
-#: api/models.py:1361
+#: models.py:1448
 msgid "water sanitation and hygiene female"
 msgstr "water sanitation and hygiene female"
 
-#: api/models.py:1363
+#: models.py:1450
 msgid "water sanitation and hygiene male"
 msgstr "water sanitation and hygiene male"
 
-#: api/models.py:1365
+#: models.py:1452
 msgid "water sanitation and hygiene people reached"
 msgstr "water sanitation and hygiene people reached"
 
-#: api/models.py:1367
+#: models.py:1454
 msgid "water sanitation and hygiene people targeted"
 msgstr "water sanitation and hygiene people targeted"
 
-#: api/models.py:1369
+#: models.py:1456
 msgid "water sanitation and hygiene requirements"
 msgstr "water sanitation and hygiene requirements"
 
-#: api/models.py:1377 api/models.py:1463
+#: models.py:1464 models.py:1550
 msgid "appeal launch date (raw)"
 msgstr "appeal launch date (raw)"
 
-#: api/models.py:1378
+#: models.py:1465
 msgid "category allocated (raw)"
 msgstr "category allocated (raw)"
 
-#: api/models.py:1379
+#: models.py:1466
 msgid "expected end date (raw)"
 msgstr "expected end date (raw)"
 
-#: api/models.py:1380
+#: models.py:1467
 msgid "expected time frame (raw)"
 msgstr "expected time frame (raw)"
 
-#: api/models.py:1382
+#: models.py:1469
 msgid "number of eduction female (raw)"
 msgstr "number of eduction female (raw)"
 
-#: api/models.py:1383
+#: models.py:1470
 msgid "number of eduction male (raw)"
 msgstr "number of eduction male (raw)"
 
-#: api/models.py:1385
+#: models.py:1472
 msgid "number of eduction people reached (raw)"
 msgstr "number of eduction people reached (raw)"
 
-#: api/models.py:1387
+#: models.py:1474
 msgid "number of eduction people targeted (raw)"
 msgstr "number of eduction people targeted (raw)"
 
-#: api/models.py:1388
+#: models.py:1475
 msgid "number of eduction requirements (raw)"
 msgstr "number of eduction requirements (raw)"
 
-#: api/models.py:1394 api/models.py:1473
+#: models.py:1481 models.py:1560
 msgid "appeal launch date"
 msgstr "appeal launch date"
 
-#: api/models.py:1395
+#: models.py:1482
 msgid "category allocated"
 msgstr "category allocated"
 
-#: api/models.py:1396
+#: models.py:1483
 msgid "expected end date"
 msgstr "expected end date"
 
-#: api/models.py:1397
+#: models.py:1484
 msgid "expected time frame"
 msgstr "expected time frame"
 
-#: api/models.py:1399
+#: models.py:1486
 msgid "number of eduction female"
 msgstr "number of eduction female"
 
-#: api/models.py:1400
+#: models.py:1487
 msgid "number of eduction male"
 msgstr "number of eduction male"
 
-#: api/models.py:1401
+#: models.py:1488
 msgid "number of eduction people reached"
 msgstr "number of eduction people reached"
 
-#: api/models.py:1402
+#: models.py:1489
 msgid "number of eduction people targeted"
 msgstr "number of eduction people targeted"
 
-#: api/models.py:1403
+#: models.py:1490
 msgid "number of eduction requirements"
 msgstr "number of eduction requirements"
 
-#: api/models.py:1409
+#: models.py:1496
 msgid "emergency operations dataset"
 msgstr "emergency operations dataset"
 
-#: api/models.py:1410
+#: models.py:1497
 msgid "emergency operations datasets"
 msgstr "emergency operations datasets"
 
-#: api/models.py:1418
+#: models.py:1505
 msgid "EPOA update number (raw)"
 msgstr "EPOA update number (raw)"
 
-#: api/models.py:1419
+#: models.py:1506
 msgid "operation timeframe (raw)"
 msgstr "operation timeframe (raw)"
 
-#: api/models.py:1421
+#: models.py:1508
 msgid "time frame covered by update (raw)"
 msgstr "time frame covered by update (raw)"
 
-#: api/models.py:1436
+#: models.py:1523
 msgid "EPOA update number"
 msgstr "EPOA update number"
 
-#: api/models.py:1437
+#: models.py:1524
 msgid "operation timeframe"
 msgstr "operation timeframe"
 
-#: api/models.py:1439
+#: models.py:1526
 msgid "time frame covered by update"
 msgstr "time frame covered by update"
 
-#: api/models.py:1454 api/models.py:1455
+#: models.py:1541 models.py:1542
 msgid "emergency operations people reached"
 msgstr "emergency operations people reached"
 
-#: api/models.py:1462
+#: models.py:1549
 msgid "appeal ends (raw)"
 msgstr "appeal ends (raw)"
 
-#: api/models.py:1464
+#: models.py:1551
 msgid "current operation budget (raw)"
 msgstr "current operation budget (raw)"
 
-#: api/models.py:1472
+#: models.py:1559
 msgid "appeal ends"
 msgstr "appeal ends"
 
-#: api/models.py:1474
+#: models.py:1561
 msgid "current operation budget"
 msgstr "current operation budget"
 
-#: api/models.py:1482
+#: models.py:1569
 msgid "emergency operations emergency appeal"
 msgstr "emergency operations emergency appeal"
 
-#: api/models.py:1483
+#: models.py:1570
 msgid "emergency operations emergency appeals"
 msgstr "emergency operations emergency appeals"
 
-#: api/models.py:1490
+#: models.py:1577
 msgid "date of disaster (raw)"
 msgstr "date of disaster (raw)"
 
-#: api/models.py:1492
+#: models.py:1579
 msgid "number of other partner involved (raw)"
 msgstr "number of other partner involved (raw)"
 
-#: api/models.py:1494
+#: models.py:1581
 msgid "number of NS partner involved (raw)"
 msgstr "number of NS partner involved (raw)"
 
-#: api/models.py:1495
+#: models.py:1582
 msgid "operation end date (raw)"
 msgstr "operation end date (raw)"
 
-#: api/models.py:1496
+#: models.py:1583
 msgid "overall operation budget (raw)"
 msgstr "overall operation budget (raw)"
 
-#: api/models.py:1509
+#: models.py:1596
 msgid "date of disaster"
 msgstr "date of disaster"
 
-#: api/models.py:1510
+#: models.py:1597
 msgid "number of other partner involved"
 msgstr "number of other partner involved"
 
-#: api/models.py:1511
+#: models.py:1598
 msgid "number of NS partner involved"
 msgstr "number of NS partner involved"
 
-#: api/models.py:1512
+#: models.py:1599
 msgid "operation end date"
 msgstr "operation end date"
 
-#: api/models.py:1514
+#: models.py:1601
 msgid "overall operation budget"
 msgstr "overall operation budget"
 
-#: api/models.py:1527
+#: models.py:1614
 msgid "emergency operations final report"
 msgstr "emergency operations final report"
 
-#: api/models.py:1528
+#: models.py:1615
 msgid "emergency operations final reports"
 msgstr "emergency operations final reports"
 
-#: api/models.py:1541
+#: models.py:1628
 msgid "Never run"
 msgstr "Never run"
 
-#: api/models.py:1542
+#: models.py:1629
 msgid "Successfull"
 msgstr "Successfull"
 
-#: api/models.py:1543
+#: models.py:1630
 msgid "Warned"
 msgstr "Warned"
 
-#: api/models.py:1544
+#: models.py:1631
 msgid "Erroneous"
 msgstr "Erroneous"
 
-#: api/models.py:1552
+#: models.py:1639
 msgid "message"
 msgstr "message"
 
-#: api/models.py:1553
+#: models.py:1640
 msgid "number of results"
 msgstr "number of results"
 
-#: api/models.py:1554
+#: models.py:1641
 msgid "storing days"
 msgstr "storing days"
 
-#: api/models.py:1556
+#: models.py:1643
 msgid "backend side"
 msgstr "backend side"
 
-#: api/models.py:1560
+#: models.py:1647
 msgid "cronjob log record"
 msgstr "cronjob log record"
 
-#: api/models.py:1561
+#: models.py:1648
 msgid "cronjob log records"
 msgstr "cronjob log records"
 
-#: api/models.py:1623 api/models.py:1641
+#: models.py:1710 models.py:1728
 msgid "username"
 msgstr "username"
 
-#: api/models.py:1628
+#: models.py:1715
 msgid "auth log"
 msgstr "auth log"
 
-#: api/models.py:1629
+#: models.py:1716
 msgid "auth logs"
 msgstr "auth logs"
 
-#: api/models.py:1642
+#: models.py:1729
 msgid "object id"
 msgstr "object id"
 
-#: api/models.py:1643
+#: models.py:1730
 msgid "object name"
 msgstr "object name"
 
-#: api/models.py:1644
+#: models.py:1731
 msgid "object type"
 msgstr "object type"
 
-#: api/models.py:1647
+#: models.py:1734
 msgid "changed from"
 msgstr "changed from"
 
-#: api/models.py:1651
+#: models.py:1738
 msgid "changed to"
 msgstr "changed to"
 
-#: api/models.py:1655
+#: models.py:1742
 msgid "reversion difference log"
 msgstr "reversion difference log"
 
-#: api/models.py:1656
+#: models.py:1743
 msgid "reversion difference logs"
 msgstr "reversion difference logs"
 
-#: api/templates/admin/base.html:62
+#: templates/admin/base.html:74
 msgid "Welcome,"
 msgstr "Welcome,"
 
-#: api/templates/admin/base.html:67
+#: templates/admin/base.html:79
 msgid "View site"
 msgstr "View site"
 
-#: api/templates/admin/base.html:72
+#: templates/admin/base.html:84
 msgid "Documentation"
 msgstr "Documentation"
 
-#: api/templates/admin/base.html:76
+#: templates/admin/base.html:88
 msgid "Change password"
 msgstr "Change password"
 
-#: api/templates/admin/base.html:78
+#: templates/admin/base.html:90
 msgid "Log out"
 msgstr "Log out"
 
-#: api/templates/admin/base.html:88 api/templates/admin/import_form.html:13
+#: templates/admin/base.html:100 templates/admin/import_form.html:13
 msgid "Home"
 msgstr "Home"
 
-#: api/templates/admin/base_site.html:5
+#: templates/admin/base_site.html:5
 msgid "Django site admin"
 msgstr "Django site admin"
 
-#: api/templates/admin/edit_inline/tabular.html:21
+#: templates/admin/edit_inline/tabular.html:21
 msgid "Delete?"
 msgstr "Delete?"
 
-#: api/templates/admin/edit_inline/tabular.html:35
+#: templates/admin/edit_inline/tabular.html:35
 msgid "Change"
 msgstr "Change"
 
-#: api/templates/admin/edit_inline/tabular.html:37
+#: templates/admin/edit_inline/tabular.html:37
 msgid "View on site"
 msgstr "View on site"
 
-#: api/templates/admin/submit_line.html:5
+#: templates/admin/submit_line.html:5
 msgid "Save"
 msgstr "Save"
 
-#: api/templates/admin/submit_line.html:9
+#: templates/admin/submit_line.html:9
 msgid "Delete the whole"
 msgstr "Delete the whole"
 
-#: api/templates/admin/submit_line.html:12
+#: templates/admin/submit_line.html:12
 msgid "Save as new"
 msgstr "Save as new"
 
-#: api/templates/admin/submit_line.html:13
+#: templates/admin/submit_line.html:13
 msgid "Save and add another"
 msgstr "Save and add another"
 
-#: api/templates/admin/submit_line.html:14
+#: templates/admin/submit_line.html:14
 msgid "Save and continue editing"
 msgstr "Save and continue editing"
 
-#: api/templates/admin/submit_line.html:14
+#: templates/admin/submit_line.html:14
 msgid "Save and view"
 msgstr "Save and view"
 
-#: api/templates/admin/submit_line.html:15
+#: templates/admin/submit_line.html:15
 msgid "Close"
 msgstr "Close"
 
-#: api/utils.py:38
+#: utils.py:38
 msgid "slug should not start with a number"
 msgstr "slug should not start with a number"
+
+#~ msgid "number of cases (MOH)"
+#~ msgstr "number of cases (MOH)"
+
+#~ msgid "number of suspected cases (MOH)"
+#~ msgstr "number of suspected cases (MOH)"
+
+#~ msgid "number of probabale cases (MOH)"
+#~ msgstr "number of probabale cases (MOH)"
+
+#~ msgid "number of confirmed cases (MOH)"
+#~ msgstr "number of confirmed cases (MOH)"
+
+#~ msgid "number of dead (MOH)"
+#~ msgstr "number of dead (MOH)"
+
+#~ msgid "number of cases (WHO)"
+#~ msgstr "number of cases (WHO)"
+
+#~ msgid "number of suspected cases (WHO)"
+#~ msgstr "number of suspected cases (WHO)"
+
+#~ msgid "number of probable cases (WHO)"
+#~ msgstr "number of probable cases (WHO)"
+
+#~ msgid "number of confirmed cases (WHO)"
+#~ msgstr "number of confirmed cases (WHO)"
+
+#~ msgid "number of number of dead (WHO)"
+#~ msgstr "number of number of dead (WHO)"
+
+#~ msgid "number of cases (other)"
+#~ msgstr "number of cases (other)"
+
+#~ msgid "number of suspected cases (other)"
+#~ msgstr "number of suspected cases (other)"
+
+#~ msgid "number of probable cases (other)"
+#~ msgstr "number of probable cases (other)"
+
+#~ msgid "number of confirmed cases (other)"
+#~ msgstr "number of confirmed cases (other)"
+
+#~ msgid "number of cases"
+#~ msgstr "number of cases"
+
+#~ msgid "number of suspected cases"
+#~ msgstr "number of suspected cases"
+
+#~ msgid "number of probable cases"
+#~ msgstr "number of probable cases"
+
+#~ msgid "number of confirmed cases"
+#~ msgstr "number of confirmed cases"
+
+#~ msgid "field report contact"
+#~ msgstr "field report contact"

--- a/api/locale/es/LC_MESSAGES/django.po
+++ b/api/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-24 07:55+0000\n"
+"POT-Creation-Date: 2020-11-30 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,2059 +18,2193 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: api/admin.py:51
+#: admin.py:32 models.py:1306
+msgid "user profile"
+msgstr "perfil de usuario"
+
+#: admin.py:67
 msgid "related emergency"
 msgstr "emergencia relacionada"
 
-#: api/admin.py:56
+#: admin.py:72
 msgid "Exists"
 msgstr "Existe"
 
-#: api/admin.py:57
+#: admin.py:73
 msgid "Needs confirmation"
 msgstr "Necesita confirmación"
 
-#: api/admin.py:58
+#: admin.py:74
 msgid "None"
 msgstr "Ninguno"
 
-#: api/admin.py:71
+#: admin.py:87
 msgid "membership"
 msgstr "membresía"
 
-#: api/admin.py:83 api/models.py:670
+#: admin.py:99 models.py:779
 msgid "appeal type"
 msgstr "tipo de llamamiento"
 
-#: api/admin.py:95
+#: admin.py:111
 msgid "featured"
 msgstr "destacado"
 
-#: api/admin.py:100
+#: admin.py:116
 msgid "Featured"
 msgstr "Destacado"
 
-#: api/admin.py:101
+#: admin.py:117
 msgid "Not Featured"
 msgstr "No destacado"
 
-#: api/admin.py:112 api/models.py:233 api/models.py:532 api/models.py:1175
+#: admin.py:128 models.py:285 models.py:641 models.py:1261
 msgid "source"
 msgstr "fuente"
 
-#: api/admin.py:117
+#: admin.py:133
 msgid "Manual input"
 msgstr "Entrada manual"
 
-#: api/admin.py:118
+#: admin.py:134
 msgid "GDACs scraper"
 msgstr "Extracción de información de GDACs"
 
-#: api/admin.py:119
+#: admin.py:135
 msgid "WHO scraper"
 msgstr "Extracción de información de OMS"
 
-#: api/admin.py:120
+#: admin.py:136
 msgid "Field report ingest"
 msgstr "Ingreso de informes de campo"
 
-#: api/admin.py:121
+#: admin.py:137
 msgid "Field report admin"
 msgstr "Administración de los informes de campo"
 
-#: api/admin.py:122
+#: admin.py:138
 msgid "Appeals admin"
 msgstr "Administración de los llamamientos"
 
-#: api/admin.py:123
+#: admin.py:139
 msgid "Unknown automated"
 msgstr "Automatización desconocida"
 
-#: api/apps.py:6
+#: apps.py:6
 msgid "api"
 msgstr "api"
 
-#: api/forms.py:8 api/models.py:1114
+#: forms.py:8 models.py:1200
 msgid "organizations"
 msgstr "organizaciones"
 
-#: api/forms.py:9 api/models.py:1118
+#: forms.py:9 models.py:1204
 msgid "field report types"
 msgstr "tipos de informes de campo"
 
-#: api/models.py:38 api/models.py:67 api/models.py:125 api/models.py:178
-#: api/models.py:350 api/models.py:392 api/models.py:420 api/models.py:514
-#: api/models.py:585 api/models.py:668 api/models.py:773 api/models.py:1053
-#: api/models.py:1111 api/models.py:1156 api/models.py:1549
+#: models.py:39 models.py:68 models.py:136 models.py:225 models.py:459
+#: models.py:501 models.py:623 models.py:694 models.py:777 models.py:882
+#: models.py:1139 models.py:1197 models.py:1242 models.py:1636
 msgid "name"
 msgstr "nombre"
 
-#: api/models.py:39 api/models.py:414 api/models.py:835 api/models.py:1141
+#: models.py:40 models.py:523 models.py:944 models.py:1227
 msgid "summary"
 msgstr "resumen"
 
-#: api/models.py:43 api/models.py:403 api/models.py:669 api/models.py:837
+#: models.py:44 models.py:512 models.py:778 models.py:946
 msgid "disaster type"
 msgstr "tipo de desastre"
 
-#: api/models.py:44
+#: models.py:45
 msgid "disaster types"
 msgstr "tipos de desastre"
 
-#: api/models.py:58
+#: models.py:59
 msgid "Africa"
 msgstr "África"
 
-#: api/models.py:59
+#: models.py:60
 msgid "Americas"
 msgstr "América"
 
-#: api/models.py:60
+#: models.py:61
 msgid "Asia Pacific"
 msgstr "Asia-Pacífico"
 
-#: api/models.py:61
+#: models.py:62
 msgid "Europe"
 msgstr "Europa"
 
-#: api/models.py:62
+#: models.py:63
 msgid "Middle East & North Africa"
 msgstr "Medio Oriente y África del Norte"
 
-#: api/models.py:85 api/models.py:132 api/models.py:246 api/models.py:288
-#: api/models.py:333 api/models.py:363 api/models.py:692
+#: models.py:70
+#, fuzzy
+#| msgid "number of highest risk"
+msgid "name of the region"
+msgstr "número de alto riesgo"
+
+#: models.py:95 models.py:144 models.py:298 models.py:340 models.py:358
+#: models.py:374 models.py:390 models.py:441 models.py:472 models.py:801
 msgid "region"
 msgstr "región"
 
-#: api/models.py:86 api/models.py:406 api/models.py:843
+#: models.py:96 models.py:515 models.py:952
 msgid "regions"
 msgstr "regiones"
 
-#: api/models.py:110
+#: models.py:120
 msgid "Country"
 msgstr "País"
 
-#: api/models.py:111
+#: models.py:121
 msgid "Cluster"
 msgstr "Cluster"
 
-#: api/models.py:112
+#: models.py:122
 msgid "Region"
 msgstr "Región"
 
-#: api/models.py:113
+#: models.py:123
 msgid "Country Office"
 msgstr "Oficina de País"
 
-#: api/models.py:114
+#: models.py:124
 msgid "Representative Office"
 msgstr "Oficina de Representación"
 
-#: api/models.py:126 api/models.py:349 api/models.py:513 api/models.py:565
-#: api/models.py:593 api/models.py:1052 api/models.py:1168
+#: models.py:137 models.py:458 models.py:622 models.py:674 models.py:702
+#: models.py:1138 models.py:1254
 msgid "type"
 msgstr "tipo"
 
-#: api/models.py:126
+#: models.py:137
 msgid "Type of entity"
 msgstr "Tipo de entidad"
 
-#: api/models.py:127
+#: models.py:138
 msgid "ISO"
 msgstr "ISO"
 
-#: api/models.py:128
+#: models.py:139
 msgid "ISO3"
 msgstr "ISO3"
 
-#: api/models.py:129
+#: models.py:140
+msgid "FDRS"
+msgstr ""
+
+#: models.py:141
 msgid "society name"
 msgstr "nombre de la sociedad"
 
-#: api/models.py:130
+#: models.py:142
 msgid "URL - Society"
 msgstr "URL - Sociedad"
 
-#: api/models.py:131
+#: models.py:143
 msgid "URL - IFRC"
 msgstr "URL - IFRC"
 
-#: api/models.py:133
+#: models.py:145
 msgid "overview"
 msgstr "resumen"
 
-#: api/models.py:134
+#: models.py:146
 msgid "key priorities"
 msgstr "prioridades clave"
 
-#: api/models.py:135
+#: models.py:147
 msgid "inform score"
 msgstr "puntuación de inform"
 
-#: api/models.py:137
+#: models.py:149
 msgid "logo"
 msgstr "logotipo"
 
-#: api/models.py:143 api/models.py:189
+#: models.py:156
+#, fuzzy
+#| msgid "Is it an enclave away from parent country?"
+msgid "Is this an independent country?"
+msgstr "¿Es un enclave alejado del país de origen?"
+
+#: models.py:159
+msgid "Is this an active, valid country?"
+msgstr ""
+
+#: models.py:164 models.py:241
 msgid "WB population"
 msgstr "Población BM"
 
-#: api/models.py:143 api/models.py:189
+#: models.py:164 models.py:241
 msgid "population data from WB API"
 msgstr "Datos de población de la API de BM"
 
-#: api/models.py:146
+#: models.py:167
 msgid "WB Year"
 msgstr "Año BM"
 
-#: api/models.py:146 api/models.py:192
+#: models.py:167 models.py:244
 msgid "population data year from WB API"
 msgstr "año  de los datos de población de API de BM"
 
-#: api/models.py:168 api/models.py:180 api/models.py:254 api/models.py:306
-#: api/models.py:341 api/models.py:371 api/models.py:691 api/models.py:1207
+#: models.py:169
+msgid "Label for Additional Tab"
+msgstr ""
+
+#: models.py:172
+msgid "Income (CHF)"
+msgstr ""
+
+#: models.py:173
+msgid "Expenditures (CHF)"
+msgstr ""
+
+#: models.py:174
+msgid "Branches"
+msgstr ""
+
+#: models.py:175
+msgid "Staff"
+msgstr ""
+
+#: models.py:176
+#, fuzzy
+#| msgid "number of volunteers"
+msgid "Volunteers"
+msgstr "número de voluntarios"
+
+#: models.py:177
+msgid "Youth - 6-19 Yrs"
+msgstr ""
+
+#: models.py:178
+msgid "Trained in First Aid"
+msgstr ""
+
+#: models.py:179
+msgid "Gov Financial Support"
+msgstr ""
+
+#: models.py:180
+msgid ">50% Domestically Generated Income"
+msgstr ""
+
+#: models.py:181
+msgid "Annual Reporting to FDRS"
+msgstr ""
+
+#: models.py:182
+msgid "Your Policy / Programme Implementation"
+msgstr ""
+
+#: models.py:183
+msgid "Risk Management Framework"
+msgstr ""
+
+#: models.py:184
+msgid "Complying with CMC Dashboard"
+msgstr ""
+
+#: models.py:187
+msgid "Total WASH Staff"
+msgstr ""
+
+#: models.py:188
+msgid "WASH Kit2"
+msgstr ""
+
+#: models.py:189
+msgid "WASH Kit5"
+msgstr ""
+
+#: models.py:190
+msgid "WASH Kit10"
+msgstr ""
+
+#: models.py:191
+msgid "WASH Staff at HQ"
+msgstr ""
+
+#: models.py:192
+msgid "WASH Staff at Branch"
+msgstr ""
+
+#: models.py:193
+msgid "NDRT Trained"
+msgstr ""
+
+#: models.py:194
+msgid "RDRT Trained"
+msgstr ""
+
+#: models.py:215 models.py:227 models.py:306 models.py:414 models.py:450
+#: models.py:480 models.py:800 models.py:1293
 msgid "country"
 msgstr "país"
 
-#: api/models.py:169 api/models.py:405 api/models.py:627 api/models.py:842
+#: models.py:216 models.py:514 models.py:736 models.py:951
 msgid "countries"
 msgstr "países"
 
-#: api/models.py:179 api/models.py:673
+#: models.py:226 models.py:782
 msgid "code"
 msgstr "código"
 
-#: api/models.py:181
-msgid "country ISO3"
+#: models.py:228
+#, fuzzy
+#| msgid "country ISO3"
+msgid "country ISO2"
 msgstr "país ISO3"
 
-#: api/models.py:182
+#: models.py:229
 msgid "country name"
 msgstr "nombre del país"
 
-#: api/models.py:184
+#: models.py:231
 msgid "is enclave?"
 msgstr "¿Es enclave?"
 
-#: api/models.py:184
+#: models.py:231
 msgid "Is it an enclave away from parent country?"
 msgstr "¿Es un enclave alejado del país de origen?"
 
-#: api/models.py:192
+#: models.py:237
+msgid "Is this an active, valid district?"
+msgstr ""
+
+#: models.py:244
 msgid "WB year"
 msgstr "Año WB"
 
-#: api/models.py:197
+#: models.py:249
 msgid "district"
 msgstr "distrito"
 
-#: api/models.py:198 api/models.py:404 api/models.py:841
+#: models.py:250 models.py:513 models.py:950
 msgid "districts"
 msgstr "distritos"
 
-#: api/models.py:210 api/models.py:222
+#: models.py:262 models.py:274
 msgid "Membership"
 msgstr "Membresía"
 
-#: api/models.py:211 api/models.py:223
+#: models.py:263 models.py:275
 msgid "IFRC Only"
 msgstr "Solo IFRC"
 
-#: api/models.py:212 api/models.py:224
+#: models.py:264 models.py:276
 msgid "Public"
 msgstr "Público"
 
-#: api/models.py:231
+#: models.py:283
 msgid "figure"
 msgstr "cifra"
 
-#: api/models.py:232 api/models.py:531
+#: models.py:284 models.py:640
 msgid "deck"
 msgstr "instructivo"
 
-#: api/models.py:234 api/models.py:293 api/models.py:311 api/models.py:550
-#: api/models.py:595 api/models.py:934
+#: models.py:286 models.py:345 models.py:419 models.py:659 models.py:704
+#: models.py:1020
 msgid "visibility"
 msgstr "visibilidad"
 
-#: api/models.py:238
+#: models.py:290
 msgid "admin key figure"
 msgstr "admin cifra clave "
 
-#: api/models.py:239
+#: models.py:291
 msgid "admin key figures"
 msgstr "admin cifras clave"
 
-#: api/models.py:249
+#: models.py:301
 msgid "region key figure"
 msgstr "región cifra clave"
 
-#: api/models.py:250
+#: models.py:302
 msgid "region key figures"
 msgstr "región cifras clave"
 
-#: api/models.py:257
+#: models.py:309
 msgid "country key figure"
 msgstr "país cifra clave"
 
-#: api/models.py:258
+#: models.py:310
 msgid "country key figures"
 msgstr "país cifras clave"
 
-#: api/models.py:269
+#: models.py:321
 msgid "Top"
 msgstr "Superior"
 
-#: api/models.py:270
+#: models.py:322
 msgid "High"
 msgstr "Alto"
 
-#: api/models.py:271
+#: models.py:323
 msgid "Middle"
 msgstr "Medio"
 
-#: api/models.py:272
+#: models.py:324
 msgid "Low"
 msgstr "Bajo"
 
-#: api/models.py:273
+#: models.py:325
 msgid "Bottom"
 msgstr "Fondo"
 
-#: api/models.py:282
+#: models.py:334
 msgid "Tab 1"
 msgstr "Pestaña 1"
 
-#: api/models.py:283
+#: models.py:335
 msgid "Tab 2"
 msgstr "Pestaña 2"
 
-#: api/models.py:284
+#: models.py:336
 msgid "Tab 3"
 msgstr "Pestaña 3"
 
-#: api/models.py:289 api/models.py:307 api/models.py:545 api/models.py:556
+#: models.py:341 models.py:360 models.py:376 models.py:392 models.py:415
+#: models.py:654 models.py:665
 msgid "snippet"
 msgstr "fragmento"
 
-#: api/models.py:291 api/models.py:309 api/models.py:547 api/models.py:612
+#: models.py:343 models.py:417 models.py:656 models.py:721
 msgid "image"
 msgstr "imagen"
 
-#: api/models.py:294 api/models.py:312 api/models.py:551 api/models.py:1215
+#: models.py:346 models.py:362 models.py:378 models.py:394 models.py:420
+#: models.py:660 models.py:1301
 msgid "position"
 msgstr "posición"
 
-#: api/models.py:298
+#: models.py:350
 msgid "region snippet"
 msgstr "fragmento de la región"
 
-#: api/models.py:299
+#: models.py:351
 msgid "region snippets"
 msgstr "fragmentos de la región"
 
-#: api/models.py:316
+#: models.py:366
+#, fuzzy
+#| msgid "region snippet"
+msgid "region emergencies snippet"
+msgstr "fragmento de la región"
+
+#: models.py:367
+#, fuzzy
+#| msgid "region snippets"
+msgid "region emergencies snippets"
+msgstr "fragmentos de la región"
+
+#: models.py:382
+#, fuzzy
+#| msgid "region snippet"
+msgid "region preparedness snippet"
+msgstr "fragmento de la región"
+
+#: models.py:383
+#, fuzzy
+#| msgid "region snippets"
+msgid "region preparedness snippets"
+msgstr "fragmentos de la región"
+
+#: models.py:398
+#, fuzzy
+#| msgid "region snippet"
+msgid "region profile snippet"
+msgstr "fragmento de la región"
+
+#: models.py:399
+#, fuzzy
+#| msgid "region snippets"
+msgid "region profile snippets"
+msgstr "fragmentos de la región"
+
+#: models.py:424
 msgid "country snippet"
 msgstr "fragmento del país"
 
-#: api/models.py:317
+#: models.py:425
 msgid "country snippets"
 msgstr "fragmentos del país"
 
-#: api/models.py:324 api/models.py:351 api/models.py:515 api/models.py:610
-#: api/models.py:1054
+#: models.py:432 models.py:460 models.py:624 models.py:719 models.py:1140
 msgid "title"
 msgstr "título"
 
-#: api/models.py:325
+#: models.py:433
 msgid "url"
 msgstr "url"
 
-#: api/models.py:328
+#: models.py:436
 msgid "admin link"
 msgstr "enlace de admin"
 
-#: api/models.py:329
+#: models.py:437
 msgid "admin links"
 msgstr "enlaces de admin"
 
-#: api/models.py:336
+#: models.py:445
 msgid "region link"
 msgstr "enlace de región"
 
-#: api/models.py:337
+#: models.py:446
 msgid "region links"
 msgstr "enlaces de región"
 
-#: api/models.py:344
+#: models.py:453
 msgid "country link"
 msgstr "enlace del país"
 
-#: api/models.py:345
+#: models.py:454
 msgid "country links"
 msgstr "enlaces del país"
 
-#: api/models.py:352 api/models.py:516 api/models.py:1055
+#: models.py:461 models.py:625 models.py:1141
 msgid "email"
 msgstr "correo electrónico"
 
-#: api/models.py:355
+#: models.py:464
 msgid "admin contact"
 msgstr "contacto de admin"
 
-#: api/models.py:356
+#: models.py:465
 msgid "admin contacts"
 msgstr "contactos de admin"
 
-#: api/models.py:366
+#: models.py:475
 msgid "region contact"
 msgstr "contacto de región"
 
-#: api/models.py:367
+#: models.py:476
 msgid "region contacts"
 msgstr "contactos de región"
 
-#: api/models.py:374
+#: models.py:483
 msgid "country contact"
 msgstr "contacto de país"
 
-#: api/models.py:375
+#: models.py:484
 msgid "country contacts"
 msgstr "contactos de país"
 
-#: api/models.py:384
+#: models.py:493
 msgid "Green"
 msgstr "Verde"
 
-#: api/models.py:385
+#: models.py:494
 msgid "Orange"
 msgstr "Naranja"
 
-#: api/models.py:386
+#: models.py:495
 msgid "Red"
 msgstr "Rojo"
 
-#: api/models.py:395
+#: models.py:504
 msgid "slug"
 msgstr "indicación"
 
-#: api/models.py:398
+#: models.py:507
 msgid ""
-"Optional string for a clean URL. For example, "
-"go.ifrc.org/emergencies/hurricane-katrina-2019. The string cannot start with"
-" a number and is forced to be lowercase. Recommend using hyphens over "
-"underscores. Special characters like # is not allowed."
+"Optional string for a clean URL. For example, go.ifrc.org/emergencies/"
+"hurricane-katrina-2019. The string cannot start with a number and is forced "
+"to be lowercase. Recommend using hyphens over underscores. Special "
+"characters like # is not allowed."
 msgstr ""
 "Cadena opcional para una URL vacía Por ejemplo,\n"
-"go.ifrc.org/emergencies/hurricane-katrina-2019. La cadena no puede empezar con un número y debe estar en minúscula. Se recomienda utilizar guiones en lugar de barra baja. Los caracteres especiales como # no están permitidos."
+"go.ifrc.org/emergencies/hurricane-katrina-2019. La cadena no puede empezar "
+"con un número y debe estar en minúscula. Se recomienda utilizar guiones en "
+"lugar de barra baja. Los caracteres especiales como # no están permitidos."
 
-#: api/models.py:408
+#: models.py:517
 msgid "Parent Emergency"
 msgstr "Emergencia principal"
 
-#: api/models.py:410
+#: models.py:519
 msgid ""
-"If needed, you have to change the connected Appeals', Field Reports', etc to"
-" point to the parent Emergency manually."
+"If needed, you have to change the connected Appeals', Field Reports', etc to "
+"point to the parent Emergency manually."
 msgstr ""
 "Si es necesario, debe cambiar los «Llamamientos» «informes de campo», etc. "
 "para apuntar a la Emergencia principal manualmente."
 
-#: api/models.py:416 api/models.py:848
+#: models.py:525 models.py:957
 msgid "number of injured"
 msgstr "número de heridos"
 
-#: api/models.py:417 api/models.py:849
+#: models.py:526 models.py:958
 msgid "number of dead"
 msgstr "número de muertos"
 
-#: api/models.py:418 api/models.py:850
+#: models.py:527 models.py:959
 msgid "number of missing"
 msgstr "número de desaparecidos"
 
-#: api/models.py:419 api/models.py:851
+#: models.py:528 models.py:960
 msgid "number of affected"
 msgstr "número de afectados"
 
-#: api/models.py:422
+#: models.py:529 models.py:961
+msgid "number of displaced"
+msgstr "número de desplazados"
+
+#: models.py:531
 msgid "IFRC Severity level"
 msgstr "Nivel de gravedad de IFRC"
 
-#: api/models.py:423
+#: models.py:532
 msgid "glide"
 msgstr "glide"
 
-#: api/models.py:425
+#: models.py:534
 msgid "disaster start date"
 msgstr "fecha de inicio del desastre"
 
-#: api/models.py:426 api/models.py:584 api/models.py:682 api/models.py:772
-#: api/models.py:994 api/models.py:1551 api/models.py:1624 api/models.py:1639
+#: models.py:535 models.py:693 models.py:791 models.py:881 models.py:1080
+#: models.py:1638 models.py:1711 models.py:1726
 msgid "created at"
 msgstr "creado el"
 
-#: api/models.py:427 api/models.py:995
+#: models.py:536 models.py:1081
 msgid "updated at"
 msgstr "actualizado el"
 
-#: api/models.py:428 api/models.py:684
+#: models.py:537 models.py:793
 msgid "previous update"
 msgstr "actualización anterior"
 
-#: api/models.py:430
+#: models.py:539
 msgid "auto generated"
 msgstr "autogenerado"
 
-#: api/models.py:432
+#: models.py:541
 msgid "auto generated source"
 msgstr "fuente autogenerada"
 
-#: api/models.py:436
+#: models.py:545
 msgid "is featured on home page"
 msgstr "aparece en la página de inicio"
 
-#: api/models.py:439
+#: models.py:548
 msgid "is featured on region page"
 msgstr "aparece en la página de región"
 
-#: api/models.py:441
+#: models.py:550
 msgid "hide attached field reports?"
 msgstr "¿Ocultar informes de campo adjuntos?"
 
-#: api/models.py:445
+#: models.py:554
 msgid "tab one title"
 msgstr "título de la pestaña uno"
 
-#: api/models.py:447
+#: models.py:556
 msgid "tab two title"
 msgstr "título de la pestaña dos"
 
-#: api/models.py:448
+#: models.py:557
 msgid "tab three title"
 msgstr "título de la pestaña tres"
 
-#: api/models.py:452
+#: models.py:561
 msgid "emergency"
 msgstr "emergencia"
 
-#: api/models.py:453
+#: models.py:562
 msgid "emergencies"
 msgstr "emergencias"
 
-#: api/models.py:517 api/models.py:1056
+#: models.py:626 models.py:1142
 msgid "phone"
 msgstr "teléfono"
 
-#: api/models.py:518 api/models.py:529 api/models.py:549 api/models.py:591
-#: api/models.py:688 api/models.py:839
+#: models.py:627 models.py:638 models.py:658 models.py:700 models.py:797
+#: models.py:948
 msgid "event"
 msgstr "evento"
 
-#: api/models.py:521
+#: models.py:630
 msgid "event contact"
 msgstr "contacto del evento"
 
-#: api/models.py:522
+#: models.py:631
 msgid "event contacts"
 msgstr "contactos del evento"
 
-#: api/models.py:530
+#: models.py:639
 msgid "number"
 msgstr "número"
 
-#: api/models.py:530
+#: models.py:639
 msgid "key figure metric"
 msgstr "métrica de cifras clave"
 
-#: api/models.py:531
+#: models.py:640
 msgid "key figure units"
 msgstr "unidades de cifras clave"
 
-#: api/models.py:532
+#: models.py:641
 msgid "key figure website link, publication"
 msgstr "publicación, enlace al sitio web de las cifras clave"
 
-#: api/models.py:535
+#: models.py:644
 msgid "key figure"
 msgstr "cifra clave"
 
-#: api/models.py:536
+#: models.py:645
 msgid "key figures"
 msgstr "cifras clave"
 
-#: api/models.py:552
+#: models.py:661
 msgid "tab"
 msgstr "pestaña"
 
-#: api/models.py:557
+#: models.py:666
 msgid "snippets"
 msgstr "fragmentos"
 
-#: api/models.py:567
+#: models.py:676
 msgid "is primary?"
 msgstr "¿es primario?"
 
-#: api/models.py:568
+#: models.py:677
 msgid "Ensure this type gets precedence over others that are empty"
 msgstr ""
 "Asegúrese que este type tiene precedencia sobre el resto que esté vacío"
 
-#: api/models.py:572
+#: models.py:681
 msgid "situation report type"
 msgstr "tipo de informe de situación"
 
-#: api/models.py:573
+#: models.py:682
 msgid "situation report types"
 msgstr "tipos de informes de situación"
 
-#: api/models.py:587 api/models.py:775
+#: models.py:696 models.py:884
 msgid "document"
 msgstr "documento"
 
-#: api/models.py:589 api/models.py:777
+#: models.py:698 models.py:886
 msgid "document url"
 msgstr "url del documento"
 
-#: api/models.py:596
+#: models.py:705
 msgid "is pinned?"
 msgstr "¿está fijado?"
 
-#: api/models.py:596
+#: models.py:705
 msgid "pin this report at the top"
 msgstr "fijar este informe en la parte superior"
 
-#: api/models.py:599
+#: models.py:708
 msgid "situation report"
 msgstr "informe de situación"
 
-#: api/models.py:600
+#: models.py:709
 msgid "situation reports"
 msgstr "informes de situación"
 
-#: api/models.py:609
+#: models.py:718
 msgid "event id"
 msgstr "id del evento"
 
-#: api/models.py:611 api/models.py:836
+#: models.py:720 models.py:945
 msgid "description"
 msgstr "descripción"
 
-#: api/models.py:613
+#: models.py:722
 msgid "report"
 msgstr "informe"
 
-#: api/models.py:614
+#: models.py:723
 msgid "publication date"
 msgstr "fecha de publicación"
 
-#: api/models.py:615
+#: models.py:724
 msgid "year"
 msgstr "año"
 
-#: api/models.py:616
+#: models.py:725
 msgid "latitude"
 msgstr "latitud"
 
-#: api/models.py:617
+#: models.py:726
 msgid "longitude"
 msgstr "longitud"
 
-#: api/models.py:618
+#: models.py:727
 msgid "event type"
 msgstr "tipo de evento"
 
-#: api/models.py:619
+#: models.py:728
 msgid "alert level"
 msgstr "nivel de alerta"
 
-#: api/models.py:620
+#: models.py:729
 msgid "alert score"
 msgstr "puntuación de alerta"
 
-#: api/models.py:621
+#: models.py:730
 msgid "severity"
 msgstr "gravedad"
 
-#: api/models.py:622
+#: models.py:731
 msgid "severity unit"
 msgstr "unidad de gravedad"
 
-#: api/models.py:623
+#: models.py:732
 msgid "severity value"
 msgstr "valor de la gravedad"
 
-#: api/models.py:624
+#: models.py:733
 msgid "population unit"
 msgstr "unidad de población"
 
-#: api/models.py:625
+#: models.py:734
 msgid "population value"
 msgstr "valor de población"
 
-#: api/models.py:626
+#: models.py:735
 msgid "vulnerability"
 msgstr "vulnerabilidad"
 
-#: api/models.py:628
+#: models.py:737
 msgid "country text"
 msgstr "texto del país"
 
-#: api/models.py:631
+#: models.py:740
 msgid "gdacs event"
 msgstr "evento de gdacs"
 
-#: api/models.py:632
+#: models.py:741
 msgid "gdacs events"
 msgstr "eventos de gdacs"
 
-#: api/models.py:645 api/models.py:938
+#: models.py:754 models.py:1024
 msgid "DREF"
 msgstr "DREF"
 
-#: api/models.py:646
+#: models.py:755
 msgid "Emergency Appeal"
 msgstr "Llamamiento de Emergencia"
 
-#: api/models.py:647
+#: models.py:756
 msgid "International Appeal"
 msgstr "Llamamiento Internacional"
 
-#: api/models.py:657
+#: models.py:766
 msgid "Active"
 msgstr "Activo"
 
-#: api/models.py:658
+#: models.py:767
 msgid "Closed"
 msgstr "Cerrado"
 
-#: api/models.py:659
+#: models.py:768
 msgid "Frozen"
 msgstr "Bloqueado"
 
-#: api/models.py:660
+#: models.py:769
 msgid "Archived"
 msgstr "Archivado"
 
-#: api/models.py:667
+#: models.py:776
 msgid "appeal ID"
 msgstr "ID del llamamiento"
 
-#: api/models.py:672 api/models.py:844 api/models.py:1550
+#: models.py:781 models.py:953 models.py:1637
 msgid "status"
 msgstr "estado"
 
-#: api/models.py:674
+#: models.py:783
 msgid "sector"
 msgstr "sector"
 
-#: api/models.py:676
+#: models.py:785
 msgid "number of beneficiaries"
 msgstr "número de beneficiarios"
 
-#: api/models.py:677
+#: models.py:786
 msgid "amount requested"
 msgstr "cantidad solicitada"
 
-#: api/models.py:678
+#: models.py:787
 msgid "amount funded"
 msgstr "cantidad financiada"
 
-#: api/models.py:680 api/models.py:988
+#: models.py:789 models.py:1074
 msgid "start date"
 msgstr "fecha de inicio"
 
-#: api/models.py:681
+#: models.py:790
 msgid "end date"
 msgstr "fecha de finalización"
 
-#: api/models.py:683
+#: models.py:792
 msgid "modified at"
 msgstr "modificado el"
 
-#: api/models.py:685
+#: models.py:794
 msgid "real data update"
 msgstr "actualización de datos reales"
 
-#: api/models.py:690
+#: models.py:799
 msgid "needs confirmation?"
 msgstr "¿se necesita confirmación?"
 
-#: api/models.py:733 api/models.py:779 api/models.py:940
+#: models.py:842 models.py:888 models.py:1026
 msgid "appeal"
 msgstr "llamamiento"
 
-#: api/models.py:734
+#: models.py:843
 msgid "appeals"
 msgstr "llamamientos"
 
-#: api/models.py:782
+#: models.py:891
 msgid "appeal document"
 msgstr "documento de llamamiento"
 
-#: api/models.py:783
+#: models.py:892
 msgid "appeal documents"
 msgstr "documentos de llamamiento"
 
-#: api/models.py:802
+#: models.py:911
 msgid "No"
 msgstr "No"
 
-#: api/models.py:803
+#: models.py:912
 msgid "Requested"
 msgstr "Solicitado"
 
-#: api/models.py:804
+#: models.py:913
 msgid "Planned"
 msgstr "Planificado"
 
-#: api/models.py:805
+#: models.py:914
 msgid "Complete"
 msgstr "Completo"
 
-#: api/models.py:814
+#: models.py:923
 msgid "Ministry of health"
 msgstr "Ministerio de salud"
 
-#: api/models.py:815
+#: models.py:924
 msgid "WHO"
 msgstr "OMS"
 
-#: api/models.py:816
+#: models.py:925
 msgid "OTHER"
 msgstr "OTRO"
 
-#: api/models.py:823 api/models.py:1200
+#: models.py:932 models.py:1286
 msgid "user"
 msgstr "usuario"
 
-#: api/models.py:828
+#: models.py:937
 msgid "is covid report?"
 msgstr "¿es un informe de covid-19?"
 
-#: api/models.py:830
+#: models.py:939
 msgid "Is this a Field Report specific to the COVID-19 emergency?"
 msgstr "¿Es el informe de campo específico de una emergencia por COVID-19?"
 
-#: api/models.py:834
+#: models.py:943
 msgid "r id"
 msgstr "identificador r"
 
-#: api/models.py:845
+#: models.py:954
 msgid "request assistance"
 msgstr "asistencia solicitada"
 
-#: api/models.py:846
+#: models.py:955
 msgid "NS request assistance"
 msgstr "La SN solicita asistencia"
 
-#: api/models.py:852
-msgid "number of displaced"
-msgstr "número de desplazados"
-
-#: api/models.py:853
+#: models.py:962
 msgid "number of assisted"
 msgstr "número de asistidos"
 
-#: api/models.py:854
+#: models.py:963
 msgid "number of localstaff"
 msgstr "número de personal local"
 
-#: api/models.py:855
+#: models.py:964
 msgid "number of volunteers"
 msgstr "número de voluntarios"
 
-#: api/models.py:856
+#: models.py:965
 msgid "number of expatriate delegates"
 msgstr "número de delegados expatriados"
 
-#: api/models.py:859
+#: models.py:968
 msgid "number of potentially affected"
 msgstr "número de posibles afectados"
 
-#: api/models.py:860
+#: models.py:969
 msgid "number of highest risk"
 msgstr "número de alto riesgo"
 
-#: api/models.py:861
+#: models.py:970
 msgid "affected population centres"
 msgstr "centros de población afectados"
 
-#: api/models.py:863
+#: models.py:972
 msgid "number of injured (goverment)"
 msgstr "número de heridos (gobierno)"
 
-#: api/models.py:864
+#: models.py:973
 msgid "number of dead (goverment)"
 msgstr "número de muertos (gobierno)"
 
-#: api/models.py:865
+#: models.py:974
 msgid "number of missing (goverment)"
 msgstr "número de desaparecidos (gobierno)"
 
-#: api/models.py:866
+#: models.py:975
 msgid "number of affected (goverment)"
 msgstr "número de afectados (gobierno)"
 
-#: api/models.py:867
+#: models.py:976
 msgid "number of displaced (goverment)"
 msgstr "número de desplazados (gobierno)"
 
-#: api/models.py:868
+#: models.py:977
 msgid "number of assisted (goverment)"
 msgstr "número de asistidos (gobierno)"
 
-#: api/models.py:871
+#: models.py:980
 msgid "number of cases (epidemic)"
 msgstr "número de casos (epidemia)"
 
-#: api/models.py:872
+#: models.py:981
 msgid "number of suspected cases (epidemic)"
 msgstr "número de casos sospechosos (epidemia)"
 
-#: api/models.py:873
+#: models.py:982
 msgid "number of probable cases (epidemic)"
 msgstr "número de casos probables (epidemia)"
 
-#: api/models.py:874
+#: models.py:983
 msgid "number of confirmed cases (epidemic)"
 msgstr "número de casos confirmados (epidemia)"
 
-#: api/models.py:875
+#: models.py:984
 msgid "number of dead (epidemic)"
 msgstr "número de muertos (epidemia)"
 
-#: api/models.py:876
+#: models.py:985
 msgid "figures source (epidemic)"
 msgstr "fuente de las cifras (epidemia)"
 
-#: api/models.py:878
-msgid "number of cases (MOH)"
-msgstr "número de casos (Ministerio de Salud)"
-
-#: api/models.py:879
-msgid "number of suspected cases (MOH)"
-msgstr "número de casos sospechosos (Ministerio de Salud)"
-
-#: api/models.py:880
-msgid "number of probabale cases (MOH)"
-msgstr "número de casos probables (Ministerio de Salud)"
-
-#: api/models.py:881
-msgid "number of confirmed cases (MOH)"
-msgstr "número de casos confirmados (Ministerio de Salud)"
-
-#: api/models.py:882
-msgid "number of dead (MOH)"
-msgstr "número de muertos (Ministerio de Salud)"
-
-#: api/models.py:884
-msgid "number of cases (WHO)"
-msgstr "número de casos (OMS)"
-
-#: api/models.py:885
-msgid "number of suspected cases (WHO)"
-msgstr "número de casos sospechosos (OMS)"
-
-#: api/models.py:886
-msgid "number of probable cases (WHO)"
-msgstr "número de casos probables (OMS)"
-
-#: api/models.py:887
-msgid "number of confirmed cases (WHO)"
-msgstr "número de casos confirmados (OMS)"
-
-#: api/models.py:888
-msgid "number of number of dead (WHO)"
-msgstr "número de muertos (OMS)"
-
-#: api/models.py:890
-msgid "number of cases (other)"
-msgstr "número de casos (otro)"
-
-#: api/models.py:891
-msgid "number of suspected cases (other)"
-msgstr "número de casos sospechosos (otro)"
-
-#: api/models.py:892
-msgid "number of probable cases (other)"
-msgstr "número de posibles probables (otro)"
-
-#: api/models.py:893
-msgid "number of confirmed cases (other)"
-msgstr "número de casos confirmados (otro)"
-
-#: api/models.py:895 api/models.py:896
+#: models.py:987 models.py:988
 msgid "number of assisted (who)"
 msgstr "número de asistidos (OMS)"
 
-#: api/models.py:899
+#: models.py:991
 msgid "potentially affected (goverment)"
 msgstr "potencialmente afectados (gobierno)"
 
-#: api/models.py:900
+#: models.py:992
 msgid "people at highest risk (goverment)"
 msgstr "personas expuestas a riesgo alto (gobierno)"
 
-#: api/models.py:902
+#: models.py:994
 msgid "affected population centres (goverment)"
 msgstr "centros de población afectados (gobierno)"
 
-#: api/models.py:904
+#: models.py:996
 msgid "number of injured (other)"
 msgstr "número de heridos (otro)"
 
-#: api/models.py:905
+#: models.py:997
 msgid "number of dead (other)"
 msgstr "número de muertos (otro)"
 
-#: api/models.py:906
+#: models.py:998
 msgid "number of missing (other)"
 msgstr "número de desaparecidos (otro)"
 
-#: api/models.py:907
+#: models.py:999
 msgid "number of affected (other)"
 msgstr "número de afectados (otro)"
 
-#: api/models.py:908
+#: models.py:1000
 msgid "number of displace (other)"
 msgstr "número de desplazados (otro)"
 
-#: api/models.py:909
+#: models.py:1001
 msgid "number of assisted (other)"
 msgstr "número de asistidos (otro)"
 
-#: api/models.py:913
+#: models.py:1005
 msgid "number of potentially affected (other)"
 msgstr "número de posibles afectados (otro)"
 
-#: api/models.py:914
+#: models.py:1006
 msgid "number of highest risk (other)"
 msgstr "números de alto riesgo (otro)"
 
-#: api/models.py:916
+#: models.py:1008
 msgid "number of affected population centres (other)"
 msgstr "número de centros de población afectados (otro)"
 
-#: api/models.py:919
-msgid "number of cases"
-msgstr "número de casos "
-
-#: api/models.py:920
-msgid "number of suspected cases"
-msgstr "número de presuntos casos "
-
-#: api/models.py:921
-msgid "number of probable cases"
-msgstr "número de casos sospechosos"
-
-#: api/models.py:922
-msgid "number of confirmed cases"
-msgstr "número de casos confirmados "
-
-#: api/models.py:925
+#: models.py:1011
 msgid "situation fields date"
 msgstr "situación en el campo (fecha)"
 
-#: api/models.py:928
+#: models.py:1014
 msgid "sources (other)"
 msgstr "fuentes (otro)"
 
-#: api/models.py:931
+#: models.py:1017
 msgid "actions taken (others)"
 msgstr "acciones tomadas (otros)"
 
-#: api/models.py:937
+#: models.py:1023
 msgid "bullentin"
 msgstr "boletín"
 
-#: api/models.py:939
+#: models.py:1025
 msgid "DREF amount"
 msgstr "cantidad DREF"
 
-#: api/models.py:941
+#: models.py:1027
 msgid "appeal amount"
 msgstr "cantidad de llamamiento"
 
-#: api/models.py:942
+#: models.py:1028
 msgid "imminent dref"
 msgstr "dref inminente"
 
-#: api/models.py:943
+#: models.py:1029
 msgid "imminent dref amount"
 msgstr "cantidad de dref inminente"
 
-#: api/models.py:944
+#: models.py:1030
 msgid "forecast based action"
 msgstr "acciones basadas en pronóstico"
 
-#: api/models.py:946
+#: models.py:1032
 msgid "forecast based action amount"
 msgstr "cantidad - acciones basadas en pronóstico"
 
-#: api/models.py:949
+#: models.py:1035
 msgid "RDRT"
 msgstr "RIT"
 
-#: api/models.py:950
+#: models.py:1036
 msgid "number of RDRT"
 msgstr "número de RIT"
 
-#: api/models.py:951
+#: models.py:1037
 msgid "fact"
 msgstr "fact"
 
-#: api/models.py:952
+#: models.py:1038
 msgid "number of fact"
 msgstr "número de fact"
 
-#: api/models.py:953
+#: models.py:1039
 msgid "IFRC staff"
 msgstr "personal de IFRC"
 
-#: api/models.py:954
+#: models.py:1040
 msgid "number of IFRC staff"
 msgstr "número de personal de IFRC"
 
-#: api/models.py:957
+#: models.py:1043
 msgid "ERU base camp"
 msgstr "ERU base camp"
 
-#: api/models.py:958
+#: models.py:1044
 msgid "ERU base camp units"
 msgstr "unidades de ERU base camp"
 
-#: api/models.py:960
+#: models.py:1046
 msgid "ERU basic health care"
 msgstr "ERU atención sanitaria básica"
 
-#: api/models.py:961
+#: models.py:1047
 msgid "ERU basic health units"
 msgstr "unidades de ERU atención sanitaria básica"
 
-#: api/models.py:963
+#: models.py:1049
 msgid "ERU IT telecom"
 msgstr "ERU IT telecom"
 
-#: api/models.py:964
+#: models.py:1050
 msgid "ERU IT telecom units"
 msgstr "unidades de ERU IT telecom"
 
-#: api/models.py:966
+#: models.py:1052
 msgid "ERU logistics"
 msgstr "ERU de logística"
 
-#: api/models.py:967
+#: models.py:1053
 msgid "ERU logistics units"
 msgstr "unidades de ERU de logística"
 
-#: api/models.py:969
+#: models.py:1055
 msgid "ERU deployment hospital"
 msgstr "ERU hospital"
 
-#: api/models.py:970
+#: models.py:1056
 msgid "ERU deployment hospital units"
 msgstr "unidades de ERU hospital"
 
-#: api/models.py:972
+#: models.py:1058
 msgid "ERU referral hospital"
 msgstr "ERU de hospital de referencia"
 
-#: api/models.py:973
+#: models.py:1059
 msgid "ERU referral hospital units"
 msgstr "unidades ERU de hospital de referencia"
 
-#: api/models.py:975
+#: models.py:1061
 msgid "ERU relief"
 msgstr "ERU relief"
 
-#: api/models.py:976
+#: models.py:1062
 msgid "ERU relief units"
 msgstr "unidades de ERU relief"
 
-#: api/models.py:978
+#: models.py:1064
 msgid "ERU water sanitaion M15"
 msgstr "ERU de agua y saneamiento M15"
 
-#: api/models.py:979
+#: models.py:1065
 msgid "ERU water sanitaion M15 units"
 msgstr "unidades de ERU de agua y saneamiento M15"
 
-#: api/models.py:981
+#: models.py:1067
 msgid "ERU water sanitaion M40"
 msgstr "ERU de agua y saneamiento M40"
 
-#: api/models.py:982
+#: models.py:1068
 msgid "ERU water sanitaion M40 units"
 msgstr "unidades de ERU de agua y saneamiento M40"
 
-#: api/models.py:984
+#: models.py:1070
 msgid "ERU water sanitaion MSM20"
 msgstr "ERU de agua y saneamiento MSM20"
 
-#: api/models.py:985
+#: models.py:1071
 msgid "ERU water sanitaion MSM20 units"
 msgstr "unidades de ERU de agua y saneamiento MSM20"
 
-#: api/models.py:993
+#: models.py:1079
 msgid "report date"
 msgstr "fecha de informe"
 
-#: api/models.py:996
+#: models.py:1082
 msgid "previous updated at"
 msgstr "actualización anterior el"
 
-#: api/models.py:1000 api/models.py:1058 api/models.py:1143 api/models.py:1171
+#: models.py:1086 models.py:1144 models.py:1229 models.py:1257
 msgid "field report"
 msgstr "informe de campo"
 
-#: api/models.py:1001
+#: models.py:1087
 msgid "field reports"
 msgstr "informes de campo"
 
-#: api/models.py:1062
-msgid "field report contact"
-msgstr "contact de informe de campo"
-
-#: api/models.py:1063
+#: models.py:1148 models.py:1149
 msgid "field report contacts"
 msgstr "contacts de informe de campo"
 
-#: api/models.py:1075 api/models.py:1191
+#: models.py:1161 models.py:1277
 msgid "National Society"
 msgstr "Sociedad nacional"
 
-#: api/models.py:1076
+#: models.py:1162
 msgid "Foreign Society"
 msgstr "Sociedad Nacional extranjera"
 
-#: api/models.py:1077
+#: models.py:1163
 msgid "Federation"
 msgstr "Federación"
 
-#: api/models.py:1088
+#: models.py:1174
 msgid "Event"
 msgstr "Evento"
 
-#: api/models.py:1089
+#: models.py:1175
 msgid "Early Warning"
 msgstr "Alerta Temprana"
 
-#: api/models.py:1090
+#: models.py:1176
 msgid "Epidemic"
 msgstr "Epidemia"
 
-#: api/models.py:1091
+#: models.py:1177
 msgid "COVID-19"
 msgstr "COVID-19"
 
-#: api/models.py:1102
+#: models.py:1188
 msgid "General"
 msgstr "General"
 
-#: api/models.py:1103
+#: models.py:1189
 msgid "Health"
 msgstr "Salud"
 
-#: api/models.py:1104
+#: models.py:1190
 msgid "NS Institutional Strengthening"
 msgstr "Fortalecimiento Institucional de SN"
 
-#: api/models.py:1105
+#: models.py:1191
 msgid "Socioeconomic Interventions"
 msgstr "Intervenciones Socieconómicas"
 
-#: api/models.py:1121
+#: models.py:1207
 msgid "category"
 msgstr "categoría"
 
-#: api/models.py:1123
+#: models.py:1209
 msgid "is disabled?"
 msgstr "¿está desactivado?"
 
-#: api/models.py:1123
+#: models.py:1209
 msgid "Disable in form"
 msgstr "Desactivar en el formulario"
 
-#: api/models.py:1126 api/models.py:1622 api/models.py:1640
+#: models.py:1212 models.py:1709 models.py:1727
 msgid "action"
 msgstr "acción"
 
-#: api/models.py:1127 api/models.py:1140
+#: models.py:1213 models.py:1226
 msgid "actions"
 msgstr "acciones"
 
-#: api/models.py:1138 api/models.py:1211
+#: models.py:1224 models.py:1297
 msgid "organization"
 msgstr "organización"
 
-#: api/models.py:1147
+#: models.py:1233
 msgid "actions taken"
 msgstr "acciones tomadas"
 
-#: api/models.py:1148
+#: models.py:1234
 msgid "all actions taken"
 msgstr "todas las acciones tomadas"
 
-#: api/models.py:1159
+#: models.py:1245
 msgid "source type"
 msgstr "tipo de fuente"
 
-#: api/models.py:1160
+#: models.py:1246
 msgid "source types"
 msgstr "tipos de fuente"
 
-#: api/models.py:1169
+#: models.py:1255
 msgid "spec"
 msgstr "especificaciones"
 
-#: api/models.py:1176
+#: models.py:1262
 msgid "sources"
 msgstr "fuentes"
 
-#: api/models.py:1192
+#: models.py:1278
 msgid "Delegation"
 msgstr "Delegación"
 
-#: api/models.py:1193
+#: models.py:1279
 msgid "Secretariat"
 msgstr "Secretariado"
 
-#: api/models.py:1194
+#: models.py:1280
 msgid "ICRC"
 msgstr "CICR"
 
-#: api/models.py:1195
+#: models.py:1281
 msgid "Other"
 msgstr "Otro"
 
-#: api/models.py:1212
+#: models.py:1298
 msgid "organization type"
 msgstr "tipo de organización"
 
-#: api/models.py:1213
+#: models.py:1299
 msgid "city"
 msgstr "ciudad"
 
-#: api/models.py:1214
+#: models.py:1300
 msgid "department"
 msgstr "departamento"
 
-#: api/models.py:1216
+#: models.py:1302
 msgid "phone number"
 msgstr "número de teléfono"
 
-#: api/models.py:1219
-msgid "user profile"
-msgstr "perfil de usuario"
+#: models.py:1303
+msgid "last frontend login"
+msgstr ""
 
-#: api/models.py:1220
+#: models.py:1307
 msgid "user profiles"
 msgstr "perfiles de usuario"
 
-#: api/models.py:1229
+#: models.py:1316
 msgid "is validated?"
 msgstr "¿es validado?"
 
-#: api/models.py:1229
+#: models.py:1316
 msgid "Did anyone check the editable data?"
 msgstr "¿Alguien ha comprobado los datos editables?"
 
-#: api/models.py:1231
+#: models.py:1318
 msgid "created_at"
 msgstr "creado_el"
 
-#: api/models.py:1232
+#: models.py:1319
 msgid "modified_at"
 msgstr "modificado_el"
 
-#: api/models.py:1237
+#: models.py:1324
 msgid "appeal number (raw)"
 msgstr "número de llamamiento (datos sin procesar)"
 
-#: api/models.py:1238
+#: models.py:1325
 msgid "date of issue (raw)"
 msgstr "fecha de emisión (datos sin procesar)"
 
-#: api/models.py:1239
+#: models.py:1326
 msgid "glide number (raw)"
 msgstr "número glide (datos sin procesar)"
 
-#: api/models.py:1241
+#: models.py:1328
 msgid "number of people to be assisted (raw)"
 msgstr "número de personas a asistir (datos sin procesar)"
 
-#: api/models.py:1242
+#: models.py:1329
 msgid "number of people affected (raw)"
 msgstr "número de personas afectadas (datos sin procesar)"
 
-#: api/models.py:1247
+#: models.py:1334
 msgid "number of disaster risk reduction female (raw)"
 msgstr ""
 "número de mujeres - reducción de riesgo a desastres (datos sin procesar)"
 
-#: api/models.py:1249
+#: models.py:1336
 msgid "number of disaster risk reduction male (raw)"
 msgstr ""
 "número de hombres - reducción de riesgo a desastres (datos sin procesar)"
 
-#: api/models.py:1251
+#: models.py:1338
 msgid "number of disaster risk reduction people reached (raw)"
 msgstr ""
 "número de personas alcanzadas - reducción de riesgo a desastres (datos sin "
 "procesar)"
 
-#: api/models.py:1253
+#: models.py:1340
 msgid "number of disaster risk reduction people targeted (raw)"
 msgstr ""
 "número de personas a alcanzar - reducción de riesgo a desastres (datos sin "
 "procesar)"
 
-#: api/models.py:1255
+#: models.py:1342
 msgid "number of disaster risk reduction requirements (raw)"
 msgstr ""
 "número de requisitos - reducción de riesgo a desastres (datos sin procesar)"
 
-#: api/models.py:1256
+#: models.py:1343
 msgid "health female (raw)"
 msgstr "mujeres - salud (datos sin procesar)"
 
-#: api/models.py:1257
+#: models.py:1344
 msgid "health male (raw)"
 msgstr "hombres - salud (datos sin procesar)"
 
-#: api/models.py:1258
+#: models.py:1345
 msgid "health people reached (raw)"
 msgstr "personas alcanzadas - salud (datos sin procesar)"
 
-#: api/models.py:1259
+#: models.py:1346
 msgid "health people targeted (raw)"
 msgstr "personas a alcanzar - salud (datos sin procesar)"
 
-#: api/models.py:1260
+#: models.py:1347
 msgid "health requirements (raw)"
 msgstr "requisitos - salud (datos sin procesar)"
 
-#: api/models.py:1262
+#: models.py:1349
 msgid "number of livelihhods and basic needs female (raw)"
 msgstr ""
-"número de mujeres - medios de vida y necesidades básicas (datos sin "
-"procesar)"
+"número de mujeres - medios de vida y necesidades básicas (datos sin procesar)"
 
-#: api/models.py:1264
+#: models.py:1351
 msgid "number of livelihhods and basic needs male (raw)"
 msgstr ""
-"número de hombres - medios de vida y necesidades básicas (datos sin "
-"procesar)"
+"número de hombres - medios de vida y necesidades básicas (datos sin procesar)"
 
-#: api/models.py:1266
+#: models.py:1353
 msgid "number of livelihhods and basic needs people reached (raw)"
 msgstr ""
 "número de personas alcanzadas - medios de vida y necesidades básicas (datos "
 "sin procesar)"
 
-#: api/models.py:1268
+#: models.py:1355
 msgid "number of livelihhods and basic needs people targeted (raw)"
 msgstr ""
 "número de personas a alcanzar - medios de vida y necesidades básicas (datos "
 "sin procesar)"
 
-#: api/models.py:1270
+#: models.py:1357
 msgid "number of livelihhods and basic needs requirements (raw)"
 msgstr ""
 "número de requisitos - medios de vida y necesidades básicas (datos sin "
 "procesar)"
 
-#: api/models.py:1271
+#: models.py:1358
 msgid "number of migration female (raw)"
 msgstr "número de mujeres - migración (datos sin procesar)"
 
-#: api/models.py:1272
+#: models.py:1359
 msgid "number of migration male (raw)"
 msgstr "número de hombres - migración (datos sin procesar)"
 
-#: api/models.py:1274
+#: models.py:1361
 msgid "number of migration people reached (raw)"
 msgstr "número de personas alcanzadas - migración (datos sin procesar)"
 
-#: api/models.py:1276
+#: models.py:1363
 msgid "number of migration people targeted (raw)"
 msgstr "número de personas a alcanzar - migración (datos sin procesar)"
 
-#: api/models.py:1277
+#: models.py:1364
 msgid "number of migration requirements (raw)"
 msgstr "numero de requisitos - migración (datos sin procesar)"
 
-#: api/models.py:1279
+#: models.py:1366
 msgid "number of protection gender and inclusion female (raw)"
 msgstr ""
-"número de mujeres - protección género e inclusión social (datos sin "
-"procesar)"
+"número de mujeres - protección género e inclusión social (datos sin procesar)"
 
-#: api/models.py:1281
+#: models.py:1368
 msgid "number of protection gender and inclusion male (raw)"
 msgstr ""
-"número de hombres - protección género e inclusión social (datos sin "
-"procesar)"
+"número de hombres - protección género e inclusión social (datos sin procesar)"
 
-#: api/models.py:1283
+#: models.py:1370
 msgid "number of protection gender and inclusion people reached (raw)"
 msgstr ""
 "número de personas alcanzadas - protección género e inclusión social (datos "
 "sin procesar)"
 
-#: api/models.py:1285
+#: models.py:1372
 msgid "number of protection gender and inclusion people targeted (raw)"
 msgstr ""
 "número de personas a alcanzar - protección género e inclusión social (datos "
 "sin procesar)"
 
-#: api/models.py:1287
+#: models.py:1374
 msgid "number of protection gender and inclusion requirements (raw)"
 msgstr ""
 "requisitos de requisitos - protección género e inclusión social (datos sin "
 "procesar)"
 
-#: api/models.py:1288
+#: models.py:1375
 msgid "number of shelter female (raw)"
 msgstr "número de mujeres - alojamiento (datos sin procesar)"
 
-#: api/models.py:1289
+#: models.py:1376
 msgid "number of shelter male (raw)"
 msgstr "número de hombres - alojamiento (datos sin procesar)"
 
-#: api/models.py:1290
+#: models.py:1377
 msgid "number of shelter people reached (raw)"
 msgstr "número de personas alcanzadas - alojamiento (datos sin procesar)"
 
-#: api/models.py:1292
+#: models.py:1379
 msgid "number of shelter people targeted (raw)"
 msgstr "número de personas a alcanzar - alojamiento (datos sin procesar)"
 
-#: api/models.py:1293
+#: models.py:1380
 msgid "number of shelter requirements (raw)"
 msgstr "numero de requisitos - alojamiento (datos sin procesar)"
 
-#: api/models.py:1295
+#: models.py:1382
 msgid "number of water sanitation and hygiene female (raw)"
 msgstr "número de mujeres - agua saneamiento e higiene (datos sin procesar)"
 
-#: api/models.py:1297
+#: models.py:1384
 msgid "number of water sanitation and hygiene male (raw)"
 msgstr "número de hombres - agua saneamiento e higiene (datos sin procesar)"
 
-#: api/models.py:1299
+#: models.py:1386
 msgid "number of water sanitation and hygiene people reached (raw)"
 msgstr ""
 "número de personas alcanzadas - agua saneamiento e higiene (datos sin "
 "procesar)"
 
-#: api/models.py:1301
+#: models.py:1388
 msgid "number of water sanitation and hygiene people targeted (raw)"
 msgstr ""
 "número de personas a alcanzar - agua saneamiento e higiene (datos sin "
 "procesar)"
 
-#: api/models.py:1303
+#: models.py:1390
 msgid "number of water sanitation and hygiene requirements (raw)"
-msgstr ""
-"número de requisitos - agua saneamiento e higiene (datos sin procesar)"
+msgstr "número de requisitos - agua saneamiento e higiene (datos sin procesar)"
 
-#: api/models.py:1307
+#: models.py:1394
 msgid "appeal number"
 msgstr "número de llamamiento"
 
-#: api/models.py:1308
+#: models.py:1395
 msgid "date of issue"
 msgstr "fecha de emisión "
 
-#: api/models.py:1309
+#: models.py:1396
 msgid "glide number"
 msgstr "número glide"
 
-#: api/models.py:1310
+#: models.py:1397
 msgid "number of people affected"
 msgstr "número de personas afectadas "
 
-#: api/models.py:1311
+#: models.py:1398
 msgid "number of people to be assisted"
 msgstr "número de personas a asistir"
 
-#: api/models.py:1312 api/models.py:1513
+#: models.py:1399 models.py:1600
 msgid "operation start date"
 msgstr "fecha de inicio de la operación"
 
-#: api/models.py:1314
+#: models.py:1401
 msgid "DREF allocated"
 msgstr "DREF asignado"
 
-#: api/models.py:1316
+#: models.py:1403
 msgid "number of disaster risk reduction female"
 msgstr "número de mujeres - reducción de riesgo a desastres"
 
-#: api/models.py:1318
+#: models.py:1405
 msgid "number of disaster risk reduction male"
 msgstr "número de hombres - reducción de riesgo a desastres"
 
-#: api/models.py:1320
+#: models.py:1407
 msgid "number of disaster risk reduction people reached"
 msgstr "número de personas alcanzadas - reducción de riesgo a desastres"
 
-#: api/models.py:1322
+#: models.py:1409
 msgid "number of disaster risk reduction people targeted"
 msgstr "número de personas a alcanzar - reducción de riesgo a desastres"
 
-#: api/models.py:1324
+#: models.py:1411
 msgid "number of disaster risk reduction people requirements"
 msgstr "número de requisitos - reducción de riesgo a desastres"
 
-#: api/models.py:1325
+#: models.py:1412
 msgid "number of health female"
 msgstr "mujeres - salud"
 
-#: api/models.py:1326
+#: models.py:1413
 msgid "number of health male"
 msgstr "hombres - salud (datos sin procesar)"
 
-#: api/models.py:1327
+#: models.py:1414
 msgid "number of health people reached"
 msgstr "personas alcanzadas - salud"
 
-#: api/models.py:1328
+#: models.py:1415
 msgid "number of health people targeted"
 msgstr "personas a alcanzar - salud"
 
-#: api/models.py:1329
+#: models.py:1416
 msgid "number of health requirements"
 msgstr "requisitos - salud"
 
-#: api/models.py:1331
+#: models.py:1418
 msgid "number of livelihhods and basic needs female"
 msgstr "número de mujeres - medios de vida y necesidades básicas"
 
-#: api/models.py:1333
+#: models.py:1420
 msgid "number of livelihhods and basic needs male"
 msgstr "número de hombres - medios de vida y necesidades básicas"
 
-#: api/models.py:1335
+#: models.py:1422
 msgid "number of livelihhods and basic people reached"
 msgstr "número de personas alcanzadas - medios de vida y necesidades básicas"
 
-#: api/models.py:1337
+#: models.py:1424
 msgid "number of livelihhods and basic people targeted"
 msgstr "número de personas a alcanzar - medios de vida y necesidades básicas"
 
-#: api/models.py:1339
+#: models.py:1426
 msgid "number of livelihhods and basic needs requirements"
 msgstr "número de requisitos - medios de vida y necesidades básicas"
 
-#: api/models.py:1340
+#: models.py:1427
 msgid "number of migration female"
 msgstr "número de mujeres - migración"
 
-#: api/models.py:1341
+#: models.py:1428
 msgid "number of migration male"
 msgstr "número de hombres - migración"
 
-#: api/models.py:1342
+#: models.py:1429
 msgid "number of migration people reached"
 msgstr "número de personas alcanzadas - migración"
 
-#: api/models.py:1343
+#: models.py:1430
 msgid "number of migration people targeted"
 msgstr "número de personas a alcanzar - migración"
 
-#: api/models.py:1344
+#: models.py:1431
 msgid "number of migration requirements"
 msgstr "numero de requisitos - migración"
 
-#: api/models.py:1346
+#: models.py:1433
 msgid "number of protection gender and inclusion female"
 msgstr "número de mujeres - protección género e inclusión social"
 
-#: api/models.py:1348
+#: models.py:1435
 msgid "number of protection gender and inclusion male"
 msgstr "número de hombres - protección género e inclusión social"
 
-#: api/models.py:1350
+#: models.py:1437
 msgid "number of protection gender and inclusion people reached"
 msgstr "número de personas alcanzadas - protección género e inclusión social"
 
-#: api/models.py:1352
+#: models.py:1439
 msgid "number of protection gender and inclusion people targeted"
 msgstr "número de personas a alcanzar - protección género e inclusión social"
 
-#: api/models.py:1354
+#: models.py:1441
 msgid "number of protection gender and inclusion requirements"
 msgstr "requisitos de requisitos - protección género e inclusión social"
 
-#: api/models.py:1355
+#: models.py:1442
 msgid "number of shelter female"
 msgstr "número de mujeres - alojamiento"
 
-#: api/models.py:1356
+#: models.py:1443
 msgid "number of shelter male"
 msgstr "número de hombres - alojamiento"
 
-#: api/models.py:1357
+#: models.py:1444
 msgid "number of shelter people reached"
 msgstr "número de personas alcanzadas - alojamiento"
 
-#: api/models.py:1358
+#: models.py:1445
 msgid "number of shelter people targeted"
 msgstr "número de personas a alcanzar - alojamiento"
 
-#: api/models.py:1359
+#: models.py:1446
 msgid "number of shelter people requirements"
 msgstr "numero de requisitos - alojamiento"
 
-#: api/models.py:1361
+#: models.py:1448
 msgid "water sanitation and hygiene female"
 msgstr "número de mujeres - agua saneamiento e higiene"
 
-#: api/models.py:1363
+#: models.py:1450
 msgid "water sanitation and hygiene male"
 msgstr "número de hombres - agua saneamiento e higiene"
 
-#: api/models.py:1365
+#: models.py:1452
 msgid "water sanitation and hygiene people reached"
 msgstr "número de personas alcanzadas - agua saneamiento e higiene"
 
-#: api/models.py:1367
+#: models.py:1454
 msgid "water sanitation and hygiene people targeted"
 msgstr "número de personas a alcanzar - agua saneamiento e higiene"
 
-#: api/models.py:1369
+#: models.py:1456
 msgid "water sanitation and hygiene requirements"
 msgstr "número de requisitos - agua saneamiento e higiene"
 
-#: api/models.py:1377 api/models.py:1463
+#: models.py:1464 models.py:1550
 msgid "appeal launch date (raw)"
 msgstr "fecha del lanzamiento del llamamiento (datos sin procesar)"
 
-#: api/models.py:1378
+#: models.py:1465
 msgid "category allocated (raw)"
 msgstr "categoría asignada (datos sin procesar)"
 
-#: api/models.py:1379
+#: models.py:1466
 msgid "expected end date (raw)"
 msgstr "fecha de finalización esperada (datos sin procesar)"
 
-#: api/models.py:1380
+#: models.py:1467
 msgid "expected time frame (raw)"
 msgstr "duración esperada (datos sin procesar)"
 
-#: api/models.py:1382
+#: models.py:1469
 msgid "number of eduction female (raw)"
 msgstr "número de mujeres - educación (datos sin procesar)"
 
-#: api/models.py:1383
+#: models.py:1470
 msgid "number of eduction male (raw)"
 msgstr "número de hombres - educación (datos sin procesar)"
 
-#: api/models.py:1385
+#: models.py:1472
 msgid "number of eduction people reached (raw)"
 msgstr "número de personas alcanzadas - educación (datos sin procesar)"
 
-#: api/models.py:1387
+#: models.py:1474
 msgid "number of eduction people targeted (raw)"
 msgstr "número de personas a alcanzar - educación (datos sin procesar)"
 
-#: api/models.py:1388
+#: models.py:1475
 msgid "number of eduction requirements (raw)"
 msgstr "número de requisitos - educación (datos sin procesar)"
 
-#: api/models.py:1394 api/models.py:1473
+#: models.py:1481 models.py:1560
 msgid "appeal launch date"
 msgstr "fecha del lanzamiento del llamamiento "
 
-#: api/models.py:1395
+#: models.py:1482
 msgid "category allocated"
 msgstr "categoría asignada"
 
-#: api/models.py:1396
+#: models.py:1483
 msgid "expected end date"
 msgstr "fecha de finalización esperada"
 
-#: api/models.py:1397
+#: models.py:1484
 msgid "expected time frame"
 msgstr "duración esperada"
 
-#: api/models.py:1399
+#: models.py:1486
 msgid "number of eduction female"
 msgstr "número de mujeres - educación"
 
-#: api/models.py:1400
+#: models.py:1487
 msgid "number of eduction male"
 msgstr "número de hombres - educación"
 
-#: api/models.py:1401
+#: models.py:1488
 msgid "number of eduction people reached"
 msgstr "número de personas alcanzadas - educación"
 
-#: api/models.py:1402
+#: models.py:1489
 msgid "number of eduction people targeted"
 msgstr "número de personas a alcanzar - educación"
 
-#: api/models.py:1403
+#: models.py:1490
 msgid "number of eduction requirements"
 msgstr "número de requisitos - educación"
 
-#: api/models.py:1409
+#: models.py:1496
 msgid "emergency operations dataset"
 msgstr "conjunto de datos de operación de emergencia"
 
-#: api/models.py:1410
+#: models.py:1497
 msgid "emergency operations datasets"
 msgstr "conjuntos de datos de operaciones de emergencia"
 
-#: api/models.py:1418
+#: models.py:1505
 msgid "EPOA update number (raw)"
 msgstr "número de PDAE actualizado (datos sin procesar)"
 
-#: api/models.py:1419
+#: models.py:1506
 msgid "operation timeframe (raw)"
 msgstr "duración de la operación (datos sin procesar)"
 
-#: api/models.py:1421
+#: models.py:1508
 msgid "time frame covered by update (raw)"
 msgstr "duración cubierta por la actualización (datos sin procesar)"
 
-#: api/models.py:1436
+#: models.py:1523
 msgid "EPOA update number"
 msgstr "número de PDAE actualizado "
 
-#: api/models.py:1437
+#: models.py:1524
 msgid "operation timeframe"
 msgstr "duración de la operación"
 
-#: api/models.py:1439
+#: models.py:1526
 msgid "time frame covered by update"
 msgstr "duración cubierta por la actualización"
 
-#: api/models.py:1454 api/models.py:1455
+#: models.py:1541 models.py:1542
 msgid "emergency operations people reached"
 msgstr "personas alcanzadas - operaciones de emergencia"
 
-#: api/models.py:1462
+#: models.py:1549
 msgid "appeal ends (raw)"
 msgstr "fin del llamamiento (datos sin procesar)"
 
-#: api/models.py:1464
+#: models.py:1551
 msgid "current operation budget (raw)"
 msgstr "presupuesto actual de la operación (datos sin procesar)"
 
-#: api/models.py:1472
+#: models.py:1559
 msgid "appeal ends"
 msgstr "fin del llamamiento"
 
-#: api/models.py:1474
+#: models.py:1561
 msgid "current operation budget"
 msgstr "presupuesto actual  de la operación"
 
-#: api/models.py:1482
+#: models.py:1569
 msgid "emergency operations emergency appeal"
 msgstr "llamamiento de emergencia de operaciones de emergencia"
 
-#: api/models.py:1483
+#: models.py:1570
 msgid "emergency operations emergency appeals"
 msgstr "llamamientos de emergencia de operaciones de emergencia"
 
-#: api/models.py:1490
+#: models.py:1577
 msgid "date of disaster (raw)"
 msgstr "fecha del desastre (datos sin procesar)"
 
-#: api/models.py:1492
+#: models.py:1579
 msgid "number of other partner involved (raw)"
 msgstr "número de otras partes implicadas (datos sin procesar)"
 
-#: api/models.py:1494
+#: models.py:1581
 msgid "number of NS partner involved (raw)"
 msgstr "número de otras SN implicadas (datos sin procesar)"
 
-#: api/models.py:1495
+#: models.py:1582
 msgid "operation end date (raw)"
 msgstr "fecha de finalización (datos sin procesar)"
 
-#: api/models.py:1496
+#: models.py:1583
 msgid "overall operation budget (raw)"
 msgstr "resumen de la operación actual (datos sin procesar)"
 
-#: api/models.py:1509
+#: models.py:1596
 msgid "date of disaster"
 msgstr "fecha del desastre"
 
-#: api/models.py:1510
+#: models.py:1597
 msgid "number of other partner involved"
 msgstr "número de otras partes implicadas "
 
-#: api/models.py:1511
+#: models.py:1598
 msgid "number of NS partner involved"
 msgstr "número de SN participantes"
 
-#: api/models.py:1512
+#: models.py:1599
 msgid "operation end date"
 msgstr "fecha final de la operación"
 
-#: api/models.py:1514
+#: models.py:1601
 msgid "overall operation budget"
 msgstr "resumen del presupuesto de la operación "
 
-#: api/models.py:1527
+#: models.py:1614
 msgid "emergency operations final report"
 msgstr "informe final de la operación de emergencia"
 
-#: api/models.py:1528
+#: models.py:1615
 msgid "emergency operations final reports"
 msgstr "informes finales de la operación de emergencia"
 
-#: api/models.py:1541
+#: models.py:1628
 msgid "Never run"
 msgstr "No ejecutar nunca"
 
-#: api/models.py:1542
+#: models.py:1629
 msgid "Successfull"
 msgstr "Satisfactorio"
 
-#: api/models.py:1543
+#: models.py:1630
 msgid "Warned"
 msgstr "Alertar"
 
-#: api/models.py:1544
+#: models.py:1631
 msgid "Erroneous"
 msgstr "Erroneo"
 
-#: api/models.py:1552
+#: models.py:1639
 msgid "message"
 msgstr "mensaje"
 
-#: api/models.py:1553
+#: models.py:1640
 msgid "number of results"
 msgstr "número de resultados"
 
-#: api/models.py:1554
+#: models.py:1641
 msgid "storing days"
 msgstr "días almacenados"
 
-#: api/models.py:1556
+#: models.py:1643
 msgid "backend side"
 msgstr "backend side"
 
-#: api/models.py:1560
+#: models.py:1647
 msgid "cronjob log record"
 msgstr "registro del trabajo cronológico"
 
-#: api/models.py:1561
+#: models.py:1648
 msgid "cronjob log records"
 msgstr "registro del trabajo cronológico"
 
-#: api/models.py:1623 api/models.py:1641
+#: models.py:1710 models.py:1728
 msgid "username"
 msgstr "nombre de usuario"
 
-#: api/models.py:1628
+#: models.py:1715
 msgid "auth log"
 msgstr "registro aut."
 
-#: api/models.py:1629
+#: models.py:1716
 msgid "auth logs"
 msgstr "registros aut."
 
-#: api/models.py:1642
+#: models.py:1729
 msgid "object id"
 msgstr "id del objeto"
 
-#: api/models.py:1643
+#: models.py:1730
 msgid "object name"
 msgstr "nombre del objeto"
 
-#: api/models.py:1644
+#: models.py:1731
 msgid "object type"
 msgstr "tipo de objeto"
 
-#: api/models.py:1647
+#: models.py:1734
 msgid "changed from"
 msgstr "cambiado desde"
 
-#: api/models.py:1651
+#: models.py:1738
 msgid "changed to"
 msgstr "cambiado a"
 
-#: api/models.py:1655
+#: models.py:1742
 msgid "reversion difference log"
 msgstr "registro de diferencia de reversión"
 
-#: api/models.py:1656
+#: models.py:1743
 msgid "reversion difference logs"
 msgstr "registros de diferencia de reversión"
 
-#: api/templates/admin/base.html:62
+#: templates/admin/base.html:74
 msgid "Welcome,"
 msgstr "Le damos la bienvenida,"
 
-#: api/templates/admin/base.html:67
+#: templates/admin/base.html:79
 msgid "View site"
 msgstr "Ver sitio web"
 
-#: api/templates/admin/base.html:72
+#: templates/admin/base.html:84
 msgid "Documentation"
 msgstr "Documentación"
 
-#: api/templates/admin/base.html:76
+#: templates/admin/base.html:88
 msgid "Change password"
 msgstr "Cambiar contraseña"
 
-#: api/templates/admin/base.html:78
+#: templates/admin/base.html:90
 msgid "Log out"
 msgstr "Cerrar sesión"
 
-#: api/templates/admin/base.html:88 api/templates/admin/import_form.html:13
+#: templates/admin/base.html:100 templates/admin/import_form.html:13
 msgid "Home"
 msgstr "Página de inicio"
 
-#: api/templates/admin/base_site.html:5
+#: templates/admin/base_site.html:5
 msgid "Django site admin"
 msgstr "Administración del sitio Django"
 
-#: api/templates/admin/edit_inline/tabular.html:21
+#: templates/admin/edit_inline/tabular.html:21
 msgid "Delete?"
 msgstr "¿Eliminar?"
 
-#: api/templates/admin/edit_inline/tabular.html:35
+#: templates/admin/edit_inline/tabular.html:35
 msgid "Change"
 msgstr "Cambiar"
 
-#: api/templates/admin/edit_inline/tabular.html:37
+#: templates/admin/edit_inline/tabular.html:37
 msgid "View on site"
 msgstr "Ver en el sitio web"
 
-#: api/templates/admin/submit_line.html:5
+#: templates/admin/submit_line.html:5
 msgid "Save"
 msgstr "Guardar"
 
-#: api/templates/admin/submit_line.html:9
+#: templates/admin/submit_line.html:9
 msgid "Delete the whole"
 msgstr "Eliminar todo"
 
-#: api/templates/admin/submit_line.html:12
+#: templates/admin/submit_line.html:12
 msgid "Save as new"
 msgstr "Guardar como nuevo"
 
-#: api/templates/admin/submit_line.html:13
+#: templates/admin/submit_line.html:13
 msgid "Save and add another"
 msgstr "Guardar y añadir otro"
 
-#: api/templates/admin/submit_line.html:14
+#: templates/admin/submit_line.html:14
 msgid "Save and continue editing"
 msgstr "Guardar y seguir editando"
 
-#: api/templates/admin/submit_line.html:14
+#: templates/admin/submit_line.html:14
 msgid "Save and view"
 msgstr "Guardar y ver"
 
-#: api/templates/admin/submit_line.html:15
+#: templates/admin/submit_line.html:15
 msgid "Close"
 msgstr "Cerrar"
 
-#: api/utils.py:38
+#: utils.py:38
 msgid "slug should not start with a number"
 msgstr "la indicación no debe comenzar con un número"
+
+#~ msgid "number of cases (MOH)"
+#~ msgstr "número de casos (Ministerio de Salud)"
+
+#~ msgid "number of suspected cases (MOH)"
+#~ msgstr "número de casos sospechosos (Ministerio de Salud)"
+
+#~ msgid "number of probabale cases (MOH)"
+#~ msgstr "número de casos probables (Ministerio de Salud)"
+
+#~ msgid "number of confirmed cases (MOH)"
+#~ msgstr "número de casos confirmados (Ministerio de Salud)"
+
+#~ msgid "number of dead (MOH)"
+#~ msgstr "número de muertos (Ministerio de Salud)"
+
+#~ msgid "number of cases (WHO)"
+#~ msgstr "número de casos (OMS)"
+
+#~ msgid "number of suspected cases (WHO)"
+#~ msgstr "número de casos sospechosos (OMS)"
+
+#~ msgid "number of probable cases (WHO)"
+#~ msgstr "número de casos probables (OMS)"
+
+#~ msgid "number of confirmed cases (WHO)"
+#~ msgstr "número de casos confirmados (OMS)"
+
+#~ msgid "number of number of dead (WHO)"
+#~ msgstr "número de muertos (OMS)"
+
+#~ msgid "number of cases (other)"
+#~ msgstr "número de casos (otro)"
+
+#~ msgid "number of suspected cases (other)"
+#~ msgstr "número de casos sospechosos (otro)"
+
+#~ msgid "number of probable cases (other)"
+#~ msgstr "número de posibles probables (otro)"
+
+#~ msgid "number of confirmed cases (other)"
+#~ msgstr "número de casos confirmados (otro)"
+
+#~ msgid "number of cases"
+#~ msgstr "número de casos "
+
+#~ msgid "number of suspected cases"
+#~ msgstr "número de presuntos casos "
+
+#~ msgid "number of probable cases"
+#~ msgstr "número de casos sospechosos"
+
+#~ msgid "number of confirmed cases"
+#~ msgstr "número de casos confirmados "
+
+#~ msgid "field report contact"
+#~ msgstr "contact de informe de campo"

--- a/api/locale/fr/LC_MESSAGES/django.po
+++ b/api/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-24 07:55+0000\n"
+"POT-Creation-Date: 2020-11-30 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,2061 +18,2195 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: api/admin.py:51
+#: admin.py:32 models.py:1306
+msgid "user profile"
+msgstr "profil d’utilisateur"
+
+#: admin.py:67
 msgid "related emergency"
 msgstr "urgence liée"
 
-#: api/admin.py:56
+#: admin.py:72
 msgid "Exists"
 msgstr "Existe"
 
-#: api/admin.py:57
+#: admin.py:73
 msgid "Needs confirmation"
 msgstr "À confirmer"
 
-#: api/admin.py:58
+#: admin.py:74
 msgid "None"
 msgstr "Aucun"
 
-#: api/admin.py:71
+#: admin.py:87
 msgid "membership"
 msgstr "adhésion"
 
-#: api/admin.py:83 api/models.py:670
+#: admin.py:99 models.py:779
 msgid "appeal type"
 msgstr "type d'appel"
 
-#: api/admin.py:95
+#: admin.py:111
 msgid "featured"
 msgstr "inclus"
 
-#: api/admin.py:100
+#: admin.py:116
 msgid "Featured"
 msgstr "Inclus"
 
-#: api/admin.py:101
+#: admin.py:117
 msgid "Not Featured"
 msgstr "Non inclus"
 
-#: api/admin.py:112 api/models.py:233 api/models.py:532 api/models.py:1175
+#: admin.py:128 models.py:285 models.py:641 models.py:1261
 msgid "source"
 msgstr "source"
 
-#: api/admin.py:117
+#: admin.py:133
 msgid "Manual input"
 msgstr "Saisie manuelle"
 
-#: api/admin.py:118
+#: admin.py:134
 msgid "GDACs scraper"
 msgstr "Outil d’extraction de données GDAC"
 
-#: api/admin.py:119
+#: admin.py:135
 msgid "WHO scraper"
 msgstr "Outil d’extraction de données OMS"
 
-#: api/admin.py:120
+#: admin.py:136
 msgid "Field report ingest"
 msgstr "Contribution rapport de terrain "
 
-#: api/admin.py:121
+#: admin.py:137
 msgid "Field report admin"
 msgstr "Rapport de terrain admin"
 
-#: api/admin.py:122
+#: admin.py:138
 msgid "Appeals admin"
 msgstr "Appel admin"
 
-#: api/admin.py:123
+#: admin.py:139
 msgid "Unknown automated"
 msgstr "Inconnu automatisé"
 
-#: api/apps.py:6
+#: apps.py:6
 msgid "api"
 msgstr "api"
 
-#: api/forms.py:8 api/models.py:1114
+#: forms.py:8 models.py:1200
 msgid "organizations"
 msgstr "organisations"
 
-#: api/forms.py:9 api/models.py:1118
+#: forms.py:9 models.py:1204
 msgid "field report types"
 msgstr "types de rapports de terrain"
 
-#: api/models.py:38 api/models.py:67 api/models.py:125 api/models.py:178
-#: api/models.py:350 api/models.py:392 api/models.py:420 api/models.py:514
-#: api/models.py:585 api/models.py:668 api/models.py:773 api/models.py:1053
-#: api/models.py:1111 api/models.py:1156 api/models.py:1549
+#: models.py:39 models.py:68 models.py:136 models.py:225 models.py:459
+#: models.py:501 models.py:623 models.py:694 models.py:777 models.py:882
+#: models.py:1139 models.py:1197 models.py:1242 models.py:1636
 msgid "name"
 msgstr "nom"
 
-#: api/models.py:39 api/models.py:414 api/models.py:835 api/models.py:1141
+#: models.py:40 models.py:523 models.py:944 models.py:1227
 msgid "summary"
 msgstr "résumé"
 
-#: api/models.py:43 api/models.py:403 api/models.py:669 api/models.py:837
+#: models.py:44 models.py:512 models.py:778 models.py:946
 msgid "disaster type"
 msgstr "Type de catastrophe"
 
-#: api/models.py:44
+#: models.py:45
 msgid "disaster types"
 msgstr "Types de catastrophes"
 
-#: api/models.py:58
+#: models.py:59
 msgid "Africa"
 msgstr "Afrique"
 
-#: api/models.py:59
+#: models.py:60
 msgid "Americas"
 msgstr "Amériques"
 
-#: api/models.py:60
+#: models.py:61
 msgid "Asia Pacific"
 msgstr "Asie-Pacifique"
 
-#: api/models.py:61
+#: models.py:62
 msgid "Europe"
 msgstr "Europe"
 
-#: api/models.py:62
+#: models.py:63
 msgid "Middle East & North Africa"
 msgstr "Moyen-Orient et Afrique du Nord"
 
-#: api/models.py:85 api/models.py:132 api/models.py:246 api/models.py:288
-#: api/models.py:333 api/models.py:363 api/models.py:692
+#: models.py:70
+#, fuzzy
+#| msgid "number of highest risk"
+msgid "name of the region"
+msgstr "nombre de risques les plus élevés"
+
+#: models.py:95 models.py:144 models.py:298 models.py:340 models.py:358
+#: models.py:374 models.py:390 models.py:441 models.py:472 models.py:801
 msgid "region"
 msgstr "région"
 
-#: api/models.py:86 api/models.py:406 api/models.py:843
+#: models.py:96 models.py:515 models.py:952
 msgid "regions"
 msgstr "régions"
 
-#: api/models.py:110
+#: models.py:120
 msgid "Country"
 msgstr "Pays"
 
-#: api/models.py:111
+#: models.py:121
 msgid "Cluster"
 msgstr "Cluster"
 
-#: api/models.py:112
+#: models.py:122
 msgid "Region"
 msgstr "Région"
 
-#: api/models.py:113
+#: models.py:123
 msgid "Country Office"
 msgstr "Bureau national"
 
-#: api/models.py:114
+#: models.py:124
 msgid "Representative Office"
 msgstr "Bureau de représentation"
 
-#: api/models.py:126 api/models.py:349 api/models.py:513 api/models.py:565
-#: api/models.py:593 api/models.py:1052 api/models.py:1168
+#: models.py:137 models.py:458 models.py:622 models.py:674 models.py:702
+#: models.py:1138 models.py:1254
 msgid "type"
 msgstr "type"
 
-#: api/models.py:126
+#: models.py:137
 msgid "Type of entity"
 msgstr "Type d'entité"
 
-#: api/models.py:127
+#: models.py:138
 msgid "ISO"
 msgstr "ISO"
 
-#: api/models.py:128
+#: models.py:139
 msgid "ISO3"
 msgstr "ISO3"
 
-#: api/models.py:129
+#: models.py:140
+msgid "FDRS"
+msgstr ""
+
+#: models.py:141
 msgid "society name"
 msgstr "nom de la société"
 
-#: api/models.py:130
+#: models.py:142
 msgid "URL - Society"
 msgstr "URL - Société"
 
-#: api/models.py:131
+#: models.py:143
 msgid "URL - IFRC"
 msgstr "URL - FICR"
 
-#: api/models.py:133
+#: models.py:145
 msgid "overview"
 msgstr "aperçu"
 
-#: api/models.py:134
+#: models.py:146
 msgid "key priorities"
 msgstr "priorités clés"
 
-#: api/models.py:135
+#: models.py:147
 msgid "inform score"
 msgstr "renseigner le résultat :"
 
-#: api/models.py:137
+#: models.py:149
 msgid "logo"
 msgstr "logo"
 
-#: api/models.py:143 api/models.py:189
+#: models.py:156
+#, fuzzy
+#| msgid "Is it an enclave away from parent country?"
+msgid "Is this an independent country?"
+msgstr "est-ce une enclave éloignée du pays d'origine ?"
+
+#: models.py:159
+msgid "Is this an active, valid country?"
+msgstr ""
+
+#: models.py:164 models.py:241
 msgid "WB population"
 msgstr "Population BM"
 
-#: api/models.py:143 api/models.py:189
+#: models.py:164 models.py:241
 msgid "population data from WB API"
 msgstr "données de population de l'API de la BM"
 
-#: api/models.py:146
+#: models.py:167
 msgid "WB Year"
 msgstr "Année de la BM"
 
-#: api/models.py:146 api/models.py:192
+#: models.py:167 models.py:244
 msgid "population data year from WB API"
 msgstr "année de données démographiques de l'API de la BM"
 
-#: api/models.py:168 api/models.py:180 api/models.py:254 api/models.py:306
-#: api/models.py:341 api/models.py:371 api/models.py:691 api/models.py:1207
+#: models.py:169
+msgid "Label for Additional Tab"
+msgstr ""
+
+#: models.py:172
+msgid "Income (CHF)"
+msgstr ""
+
+#: models.py:173
+msgid "Expenditures (CHF)"
+msgstr ""
+
+#: models.py:174
+msgid "Branches"
+msgstr ""
+
+#: models.py:175
+msgid "Staff"
+msgstr ""
+
+#: models.py:176
+#, fuzzy
+#| msgid "number of volunteers"
+msgid "Volunteers"
+msgstr "nombre de bénévoles"
+
+#: models.py:177
+msgid "Youth - 6-19 Yrs"
+msgstr ""
+
+#: models.py:178
+msgid "Trained in First Aid"
+msgstr ""
+
+#: models.py:179
+msgid "Gov Financial Support"
+msgstr ""
+
+#: models.py:180
+msgid ">50% Domestically Generated Income"
+msgstr ""
+
+#: models.py:181
+msgid "Annual Reporting to FDRS"
+msgstr ""
+
+#: models.py:182
+msgid "Your Policy / Programme Implementation"
+msgstr ""
+
+#: models.py:183
+msgid "Risk Management Framework"
+msgstr ""
+
+#: models.py:184
+msgid "Complying with CMC Dashboard"
+msgstr ""
+
+#: models.py:187
+msgid "Total WASH Staff"
+msgstr ""
+
+#: models.py:188
+msgid "WASH Kit2"
+msgstr ""
+
+#: models.py:189
+msgid "WASH Kit5"
+msgstr ""
+
+#: models.py:190
+msgid "WASH Kit10"
+msgstr ""
+
+#: models.py:191
+msgid "WASH Staff at HQ"
+msgstr ""
+
+#: models.py:192
+msgid "WASH Staff at Branch"
+msgstr ""
+
+#: models.py:193
+msgid "NDRT Trained"
+msgstr ""
+
+#: models.py:194
+msgid "RDRT Trained"
+msgstr ""
+
+#: models.py:215 models.py:227 models.py:306 models.py:414 models.py:450
+#: models.py:480 models.py:800 models.py:1293
 msgid "country"
 msgstr "pays"
 
-#: api/models.py:169 api/models.py:405 api/models.py:627 api/models.py:842
+#: models.py:216 models.py:514 models.py:736 models.py:951
 msgid "countries"
 msgstr "pays"
 
-#: api/models.py:179 api/models.py:673
+#: models.py:226 models.py:782
 msgid "code"
 msgstr "Code"
 
-#: api/models.py:181
-msgid "country ISO3"
+#: models.py:228
+#, fuzzy
+#| msgid "country ISO3"
+msgid "country ISO2"
 msgstr "pays ISO3"
 
-#: api/models.py:182
+#: models.py:229
 msgid "country name"
 msgstr "Nom du pays"
 
-#: api/models.py:184
+#: models.py:231
 msgid "is enclave?"
 msgstr "est une enclave ?"
 
-#: api/models.py:184
+#: models.py:231
 msgid "Is it an enclave away from parent country?"
 msgstr "est-ce une enclave éloignée du pays d'origine ?"
 
-#: api/models.py:192
+#: models.py:237
+msgid "Is this an active, valid district?"
+msgstr ""
+
+#: models.py:244
 msgid "WB year"
 msgstr "Année de la BM"
 
-#: api/models.py:197
+#: models.py:249
 msgid "district"
 msgstr "district"
 
-#: api/models.py:198 api/models.py:404 api/models.py:841
+#: models.py:250 models.py:513 models.py:950
 msgid "districts"
 msgstr "districts"
 
-#: api/models.py:210 api/models.py:222
+#: models.py:262 models.py:274
 msgid "Membership"
 msgstr "Adhésion"
 
-#: api/models.py:211 api/models.py:223
+#: models.py:263 models.py:275
 msgid "IFRC Only"
 msgstr "FICR uniquement"
 
-#: api/models.py:212 api/models.py:224
+#: models.py:264 models.py:276
 msgid "Public"
 msgstr "Public"
 
-#: api/models.py:231
+#: models.py:283
 msgid "figure"
 msgstr "Chiffre"
 
-#: api/models.py:232 api/models.py:531
+#: models.py:284 models.py:640
 msgid "deck"
 msgstr "Plateforme"
 
-#: api/models.py:234 api/models.py:293 api/models.py:311 api/models.py:550
-#: api/models.py:595 api/models.py:934
+#: models.py:286 models.py:345 models.py:419 models.py:659 models.py:704
+#: models.py:1020
 msgid "visibility"
 msgstr "visibilité"
 
-#: api/models.py:238
+#: models.py:290
 msgid "admin key figure"
 msgstr "chiffre clé admin"
 
-#: api/models.py:239
+#: models.py:291
 msgid "admin key figures"
 msgstr "chiffres clés admin"
 
-#: api/models.py:249
+#: models.py:301
 msgid "region key figure"
 msgstr "chiffre clé région"
 
-#: api/models.py:250
+#: models.py:302
 msgid "region key figures"
 msgstr "chiffres clés région"
 
-#: api/models.py:257
+#: models.py:309
 msgid "country key figure"
 msgstr "chiffre clé pays"
 
-#: api/models.py:258
+#: models.py:310
 msgid "country key figures"
 msgstr "chiffres clés pays"
 
-#: api/models.py:269
+#: models.py:321
 msgid "Top"
 msgstr "Haut"
 
-#: api/models.py:270
+#: models.py:322
 msgid "High"
 msgstr "Élevé"
 
-#: api/models.py:271
+#: models.py:323
 msgid "Middle"
 msgstr "Milieu"
 
-#: api/models.py:272
+#: models.py:324
 msgid "Low"
 msgstr "Faible"
 
-#: api/models.py:273
+#: models.py:325
 msgid "Bottom"
 msgstr "Bas"
 
-#: api/models.py:282
+#: models.py:334
 msgid "Tab 1"
 msgstr "Onglet 1"
 
-#: api/models.py:283
+#: models.py:335
 msgid "Tab 2"
 msgstr "Onglet 2"
 
-#: api/models.py:284
+#: models.py:336
 msgid "Tab 3"
 msgstr "Onglet 3"
 
-#: api/models.py:289 api/models.py:307 api/models.py:545 api/models.py:556
+#: models.py:341 models.py:360 models.py:376 models.py:392 models.py:415
+#: models.py:654 models.py:665
 msgid "snippet"
 msgstr "extrait"
 
-#: api/models.py:291 api/models.py:309 api/models.py:547 api/models.py:612
+#: models.py:343 models.py:417 models.py:656 models.py:721
 msgid "image"
 msgstr "image"
 
-#: api/models.py:294 api/models.py:312 api/models.py:551 api/models.py:1215
+#: models.py:346 models.py:362 models.py:378 models.py:394 models.py:420
+#: models.py:660 models.py:1301
 msgid "position"
 msgstr "Lieu"
 
-#: api/models.py:298
+#: models.py:350
 msgid "region snippet"
 msgstr "extrait de région"
 
-#: api/models.py:299
+#: models.py:351
 msgid "region snippets"
 msgstr "extraits de région"
 
-#: api/models.py:316
+#: models.py:366
+#, fuzzy
+#| msgid "region snippet"
+msgid "region emergencies snippet"
+msgstr "extrait de région"
+
+#: models.py:367
+#, fuzzy
+#| msgid "region snippets"
+msgid "region emergencies snippets"
+msgstr "extraits de région"
+
+#: models.py:382
+#, fuzzy
+#| msgid "region snippet"
+msgid "region preparedness snippet"
+msgstr "extrait de région"
+
+#: models.py:383
+#, fuzzy
+#| msgid "region snippets"
+msgid "region preparedness snippets"
+msgstr "extraits de région"
+
+#: models.py:398
+#, fuzzy
+#| msgid "region snippet"
+msgid "region profile snippet"
+msgstr "extrait de région"
+
+#: models.py:399
+#, fuzzy
+#| msgid "region snippets"
+msgid "region profile snippets"
+msgstr "extraits de région"
+
+#: models.py:424
 msgid "country snippet"
 msgstr "extrait de pays"
 
-#: api/models.py:317
+#: models.py:425
 msgid "country snippets"
 msgstr "extraits de pays"
 
-#: api/models.py:324 api/models.py:351 api/models.py:515 api/models.py:610
-#: api/models.py:1054
+#: models.py:432 models.py:460 models.py:624 models.py:719 models.py:1140
 msgid "title"
 msgstr "Intitulé"
 
-#: api/models.py:325
+#: models.py:433
 msgid "url"
 msgstr "url"
 
-#: api/models.py:328
+#: models.py:436
 msgid "admin link"
 msgstr "lien admin"
 
-#: api/models.py:329
+#: models.py:437
 msgid "admin links"
 msgstr "liens admin"
 
-#: api/models.py:336
+#: models.py:445
 msgid "region link"
 msgstr "lien région"
 
-#: api/models.py:337
+#: models.py:446
 msgid "region links"
 msgstr "liens région"
 
-#: api/models.py:344
+#: models.py:453
 msgid "country link"
 msgstr "lien pays"
 
-#: api/models.py:345
+#: models.py:454
 msgid "country links"
 msgstr "liens pays"
 
-#: api/models.py:352 api/models.py:516 api/models.py:1055
+#: models.py:461 models.py:625 models.py:1141
 msgid "email"
 msgstr "courriel"
 
-#: api/models.py:355
+#: models.py:464
 msgid "admin contact"
 msgstr "contact admin"
 
-#: api/models.py:356
+#: models.py:465
 msgid "admin contacts"
 msgstr "contacts admin"
 
-#: api/models.py:366
+#: models.py:475
 msgid "region contact"
 msgstr "contact région"
 
-#: api/models.py:367
+#: models.py:476
 msgid "region contacts"
 msgstr "contacts région"
 
-#: api/models.py:374
+#: models.py:483
 msgid "country contact"
 msgstr "contact pays"
 
-#: api/models.py:375
+#: models.py:484
 msgid "country contacts"
 msgstr "contacts pays"
 
-#: api/models.py:384
+#: models.py:493
 msgid "Green"
 msgstr "Vert"
 
-#: api/models.py:385
+#: models.py:494
 msgid "Orange"
 msgstr "Orange"
 
-#: api/models.py:386
+#: models.py:495
 msgid "Red"
 msgstr "Rouge"
 
-#: api/models.py:395
+#: models.py:504
 msgid "slug"
 msgstr "slug"
 
-#: api/models.py:398
+#: models.py:507
 msgid ""
-"Optional string for a clean URL. For example, "
-"go.ifrc.org/emergencies/hurricane-katrina-2019. The string cannot start with"
-" a number and is forced to be lowercase. Recommend using hyphens over "
-"underscores. Special characters like # is not allowed."
+"Optional string for a clean URL. For example, go.ifrc.org/emergencies/"
+"hurricane-katrina-2019. The string cannot start with a number and is forced "
+"to be lowercase. Recommend using hyphens over underscores. Special "
+"characters like # is not allowed."
 msgstr ""
-"Chaîne optionnelle pour une bonne URL.  Par exemple, "
-"go.ifrc.org/emergencies/hurricane-katrina-2019. La chaîne ne peut pas "
-"commencer par un chiffre et doit être en minuscules. Il est recommandé "
-"d'utiliser des traits d'union au lieu du tiret du bas. Les caractères "
-"spéciaux comme # ne sont pas autorisés."
+"Chaîne optionnelle pour une bonne URL.  Par exemple, go.ifrc.org/emergencies/"
+"hurricane-katrina-2019. La chaîne ne peut pas commencer par un chiffre et "
+"doit être en minuscules. Il est recommandé d'utiliser des traits d'union au "
+"lieu du tiret du bas. Les caractères spéciaux comme # ne sont pas autorisés."
 
-#: api/models.py:408
+#: models.py:517
 msgid "Parent Emergency"
 msgstr "Urgence parentale"
 
-#: api/models.py:410
+#: models.py:519
 msgid ""
-"If needed, you have to change the connected Appeals', Field Reports', etc to"
-" point to the parent Emergency manually."
+"If needed, you have to change the connected Appeals', Field Reports', etc to "
+"point to the parent Emergency manually."
 msgstr ""
 "Si nécessaire, vous devez modifier manuellement les appels connectés, les "
 "rapports de terrain, etc. pour réorienter vers l'urgence parentale."
 
-#: api/models.py:416 api/models.py:848
+#: models.py:525 models.py:957
 msgid "number of injured"
 msgstr "nombre de blessés"
 
-#: api/models.py:417 api/models.py:849
+#: models.py:526 models.py:958
 msgid "number of dead"
 msgstr "nombre de décédés"
 
-#: api/models.py:418 api/models.py:850
+#: models.py:527 models.py:959
 msgid "number of missing"
 msgstr "nombre de disparus"
 
-#: api/models.py:419 api/models.py:851
+#: models.py:528 models.py:960
 msgid "number of affected"
 msgstr "nombre de touchés"
 
-#: api/models.py:422
+#: models.py:529 models.py:961
+msgid "number of displaced"
+msgstr "nombre de déplacés"
+
+#: models.py:531
 msgid "IFRC Severity level"
 msgstr "Niveau de gravité FICR"
 
-#: api/models.py:423
+#: models.py:532
 msgid "glide"
 msgstr "Glide"
 
-#: api/models.py:425
+#: models.py:534
 msgid "disaster start date"
 msgstr "date de commencement de la catastrophe"
 
-#: api/models.py:426 api/models.py:584 api/models.py:682 api/models.py:772
-#: api/models.py:994 api/models.py:1551 api/models.py:1624 api/models.py:1639
+#: models.py:535 models.py:693 models.py:791 models.py:881 models.py:1080
+#: models.py:1638 models.py:1711 models.py:1726
 msgid "created at"
 msgstr "Créée à"
 
-#: api/models.py:427 api/models.py:995
+#: models.py:536 models.py:1081
 msgid "updated at"
 msgstr "mise à jour à"
 
-#: api/models.py:428 api/models.py:684
+#: models.py:537 models.py:793
 msgid "previous update"
 msgstr "mise à jour précédente"
 
-#: api/models.py:430
+#: models.py:539
 msgid "auto generated"
 msgstr "générée automatiquement"
 
-#: api/models.py:432
+#: models.py:541
 msgid "auto generated source"
 msgstr "source générée automatiquement"
 
-#: api/models.py:436
+#: models.py:545
 msgid "is featured on home page"
 msgstr "est inclus sur la page d'accueil"
 
-#: api/models.py:439
+#: models.py:548
 msgid "is featured on region page"
 msgstr "est inclus sur la page de la région"
 
-#: api/models.py:441
+#: models.py:550
 msgid "hide attached field reports?"
 msgstr "cacher les rapports de terrain joints ?"
 
-#: api/models.py:445
+#: models.py:554
 msgid "tab one title"
 msgstr "Intitulé onglet 1"
 
-#: api/models.py:447
+#: models.py:556
 msgid "tab two title"
 msgstr "Intitulé onglet 2"
 
-#: api/models.py:448
+#: models.py:557
 msgid "tab three title"
 msgstr "Intitulé Onglet 3"
 
-#: api/models.py:452
+#: models.py:561
 msgid "emergency"
 msgstr "urgence"
 
-#: api/models.py:453
+#: models.py:562
 msgid "emergencies"
 msgstr "urgences"
 
-#: api/models.py:517 api/models.py:1056
+#: models.py:626 models.py:1142
 msgid "phone"
 msgstr "téléphone"
 
-#: api/models.py:518 api/models.py:529 api/models.py:549 api/models.py:591
-#: api/models.py:688 api/models.py:839
+#: models.py:627 models.py:638 models.py:658 models.py:700 models.py:797
+#: models.py:948
 msgid "event"
 msgstr "évènement"
 
-#: api/models.py:521
+#: models.py:630
 msgid "event contact"
 msgstr "contact de l'événement"
 
-#: api/models.py:522
+#: models.py:631
 msgid "event contacts"
 msgstr "contacts de l'événement"
 
-#: api/models.py:530
+#: models.py:639
 msgid "number"
 msgstr "Numéro"
 
-#: api/models.py:530
+#: models.py:639
 msgid "key figure metric"
 msgstr "chiffre clé métrique"
 
-#: api/models.py:531
+#: models.py:640
 msgid "key figure units"
 msgstr "unités chiffre clé"
 
-#: api/models.py:532
+#: models.py:641
 msgid "key figure website link, publication"
 msgstr "lien vers le site du chiffre clé, publication"
 
-#: api/models.py:535
+#: models.py:644
 msgid "key figure"
 msgstr "chiffre clé"
 
-#: api/models.py:536
+#: models.py:645
 msgid "key figures"
 msgstr "chiffres clés"
 
-#: api/models.py:552
+#: models.py:661
 msgid "tab"
 msgstr "onglet"
 
-#: api/models.py:557
+#: models.py:666
 msgid "snippets"
 msgstr "extraits"
 
-#: api/models.py:567
+#: models.py:676
 msgid "is primary?"
 msgstr "est essentiel ?"
 
-#: api/models.py:568
+#: models.py:677
 msgid "Ensure this type gets precedence over others that are empty"
 msgstr ""
 "Veillez à ce que ce type soit prioritaire par rapport à d'autres qui sont "
 "vides"
 
-#: api/models.py:572
+#: models.py:681
 msgid "situation report type"
 msgstr "types de rapports sur la situation"
 
-#: api/models.py:573
+#: models.py:682
 msgid "situation report types"
 msgstr "types de rapports sur la situation"
 
-#: api/models.py:587 api/models.py:775
+#: models.py:696 models.py:884
 msgid "document"
 msgstr "document"
 
-#: api/models.py:589 api/models.py:777
+#: models.py:698 models.py:886
 msgid "document url"
 msgstr "url du document"
 
-#: api/models.py:596
+#: models.py:705
 msgid "is pinned?"
 msgstr "est épinglé ?"
 
-#: api/models.py:596
+#: models.py:705
 msgid "pin this report at the top"
 msgstr "épingler ce rapport en haut"
 
-#: api/models.py:599
+#: models.py:708
 msgid "situation report"
 msgstr "rapport sur la situation"
 
-#: api/models.py:600
+#: models.py:709
 msgid "situation reports"
 msgstr "rapports sur la situation"
 
-#: api/models.py:609
+#: models.py:718
 msgid "event id"
 msgstr "identifiant de l'événement"
 
-#: api/models.py:611 api/models.py:836
+#: models.py:720 models.py:945
 msgid "description"
 msgstr "description"
 
-#: api/models.py:613
+#: models.py:722
 msgid "report"
 msgstr "rapport"
 
-#: api/models.py:614
+#: models.py:723
 msgid "publication date"
 msgstr "date de publication"
 
-#: api/models.py:615
+#: models.py:724
 msgid "year"
 msgstr "année"
 
-#: api/models.py:616
+#: models.py:725
 msgid "latitude"
 msgstr "latitude"
 
-#: api/models.py:617
+#: models.py:726
 msgid "longitude"
 msgstr "longitude"
 
-#: api/models.py:618
+#: models.py:727
 msgid "event type"
 msgstr "type d'événement"
 
-#: api/models.py:619
+#: models.py:728
 msgid "alert level"
 msgstr "niveau d'alerte"
 
-#: api/models.py:620
+#: models.py:729
 msgid "alert score"
 msgstr "Résultat de l’alerte"
 
-#: api/models.py:621
+#: models.py:730
 msgid "severity"
 msgstr "gravité"
 
-#: api/models.py:622
+#: models.py:731
 msgid "severity unit"
 msgstr "unité de gravité"
 
-#: api/models.py:623
+#: models.py:732
 msgid "severity value"
 msgstr "valeur de gravité"
 
-#: api/models.py:624
+#: models.py:733
 msgid "population unit"
 msgstr "unité de population"
 
-#: api/models.py:625
+#: models.py:734
 msgid "population value"
 msgstr "valeur de la population"
 
-#: api/models.py:626
+#: models.py:735
 msgid "vulnerability"
 msgstr "vulnérabilité"
 
-#: api/models.py:628
+#: models.py:737
 msgid "country text"
 msgstr "texte du pays"
 
-#: api/models.py:631
+#: models.py:740
 msgid "gdacs event"
 msgstr "événement gdacs"
 
-#: api/models.py:632
+#: models.py:741
 msgid "gdacs events"
 msgstr "événements gdacs"
 
-#: api/models.py:645 api/models.py:938
+#: models.py:754 models.py:1024
 msgid "DREF"
 msgstr "DREF"
 
-#: api/models.py:646
+#: models.py:755
 msgid "Emergency Appeal"
 msgstr "Appel d'urgence"
 
-#: api/models.py:647
+#: models.py:756
 msgid "International Appeal"
 msgstr "Appel international"
 
-#: api/models.py:657
+#: models.py:766
 msgid "Active"
 msgstr "Actif"
 
-#: api/models.py:658
+#: models.py:767
 msgid "Closed"
 msgstr "Fermé"
 
-#: api/models.py:659
+#: models.py:768
 msgid "Frozen"
 msgstr "Bloqué"
 
-#: api/models.py:660
+#: models.py:769
 msgid "Archived"
 msgstr "Archivé"
 
-#: api/models.py:667
+#: models.py:776
 msgid "appeal ID"
 msgstr "Identifiant de l’appel"
 
-#: api/models.py:672 api/models.py:844 api/models.py:1550
+#: models.py:781 models.py:953 models.py:1637
 msgid "status"
 msgstr "statut"
 
-#: api/models.py:674
+#: models.py:783
 msgid "sector"
 msgstr "secteur"
 
-#: api/models.py:676
+#: models.py:785
 msgid "number of beneficiaries"
 msgstr "nombre de bénéficiaires"
 
-#: api/models.py:677
+#: models.py:786
 msgid "amount requested"
 msgstr "montant demandé"
 
-#: api/models.py:678
+#: models.py:787
 msgid "amount funded"
 msgstr "montant financé"
 
-#: api/models.py:680 api/models.py:988
+#: models.py:789 models.py:1074
 msgid "start date"
 msgstr "date de démarrage"
 
-#: api/models.py:681
+#: models.py:790
 msgid "end date"
 msgstr "date de fin"
 
-#: api/models.py:683
+#: models.py:792
 msgid "modified at"
 msgstr "modifiée à"
 
-#: api/models.py:685
+#: models.py:794
 msgid "real data update"
 msgstr "mise à jour des données réelles"
 
-#: api/models.py:690
+#: models.py:799
 msgid "needs confirmation?"
 msgstr "à confirmer ?"
 
-#: api/models.py:733 api/models.py:779 api/models.py:940
+#: models.py:842 models.py:888 models.py:1026
 msgid "appeal"
 msgstr "appel"
 
-#: api/models.py:734
+#: models.py:843
 msgid "appeals"
 msgstr "appels"
 
-#: api/models.py:782
+#: models.py:891
 msgid "appeal document"
 msgstr "document d'appel"
 
-#: api/models.py:783
+#: models.py:892
 msgid "appeal documents"
 msgstr "documents d'appel"
 
-#: api/models.py:802
+#: models.py:911
 msgid "No"
 msgstr "Non"
 
-#: api/models.py:803
+#: models.py:912
 msgid "Requested"
 msgstr "Demandé"
 
-#: api/models.py:804
+#: models.py:913
 msgid "Planned"
 msgstr "Prévu"
 
-#: api/models.py:805
+#: models.py:914
 msgid "Complete"
 msgstr "Terminé"
 
-#: api/models.py:814
+#: models.py:923
 msgid "Ministry of health"
 msgstr "Ministère de la santé"
 
-#: api/models.py:815
+#: models.py:924
 msgid "WHO"
 msgstr "OMS"
 
-#: api/models.py:816
+#: models.py:925
 msgid "OTHER"
 msgstr "AUTRE"
 
-#: api/models.py:823 api/models.py:1200
+#: models.py:932 models.py:1286
 msgid "user"
 msgstr "utilisateur"
 
-#: api/models.py:828
+#: models.py:937
 msgid "is covid report?"
 msgstr "est un rapport sur le covid ?"
 
-#: api/models.py:830
+#: models.py:939
 msgid "Is this a Field Report specific to the COVID-19 emergency?"
 msgstr "Est-ce un rapport de terrain spécifique à l'urgence COVID-19 ?"
 
-#: api/models.py:834
+#: models.py:943
 msgid "r id"
 msgstr "Identifiant r"
 
-#: api/models.py:845
+#: models.py:954
 msgid "request assistance"
 msgstr "Besoin d’aide"
 
-#: api/models.py:846
+#: models.py:955
 msgid "NS request assistance"
 msgstr "NS a besoin d’une aide"
 
-#: api/models.py:852
-msgid "number of displaced"
-msgstr "nombre de déplacés"
-
-#: api/models.py:853
+#: models.py:962
 msgid "number of assisted"
 msgstr "nombre d’aidés"
 
-#: api/models.py:854
+#: models.py:963
 msgid "number of localstaff"
 msgstr "nombre d'employés locaux"
 
-#: api/models.py:855
+#: models.py:964
 msgid "number of volunteers"
 msgstr "nombre de bénévoles"
 
-#: api/models.py:856
+#: models.py:965
 msgid "number of expatriate delegates"
 msgstr "nombre de délégués expatriés"
 
-#: api/models.py:859
+#: models.py:968
 msgid "number of potentially affected"
 msgstr "nombre d’individus potentiellement touchés"
 
-#: api/models.py:860
+#: models.py:969
 msgid "number of highest risk"
 msgstr "nombre de risques les plus élevés"
 
-#: api/models.py:861
+#: models.py:970
 msgid "affected population centres"
 msgstr "centres de population touchés"
 
-#: api/models.py:863
+#: models.py:972
 msgid "number of injured (goverment)"
 msgstr "nombre de blessés (gouvernement)"
 
-#: api/models.py:864
+#: models.py:973
 msgid "number of dead (goverment)"
 msgstr "nombre de décédés (gouvernement)"
 
-#: api/models.py:865
+#: models.py:974
 msgid "number of missing (goverment)"
 msgstr "nombre de disparus (gouvernement)"
 
-#: api/models.py:866
+#: models.py:975
 msgid "number of affected (goverment)"
 msgstr "nombre de touchés (gouvernement)"
 
-#: api/models.py:867
+#: models.py:976
 msgid "number of displaced (goverment)"
 msgstr "nombre de déplacés (gouvernement)"
 
-#: api/models.py:868
+#: models.py:977
 msgid "number of assisted (goverment)"
 msgstr "nombre d’aidés (gouvernement)"
 
-#: api/models.py:871
+#: models.py:980
 msgid "number of cases (epidemic)"
 msgstr "nombre de cas (épidémie)"
 
-#: api/models.py:872
+#: models.py:981
 msgid "number of suspected cases (epidemic)"
 msgstr "nombre de cas suspects (épidémie)"
 
-#: api/models.py:873
+#: models.py:982
 msgid "number of probable cases (epidemic)"
 msgstr "nombre de cas probables (épidémie)"
 
-#: api/models.py:874
+#: models.py:983
 msgid "number of confirmed cases (epidemic)"
 msgstr "nombre de cas confirmés (épidémie)"
 
-#: api/models.py:875
+#: models.py:984
 msgid "number of dead (epidemic)"
 msgstr "nombre de décédés (épidémie)"
 
-#: api/models.py:876
+#: models.py:985
 msgid "figures source (epidemic)"
 msgstr "source des chiffres (épidémie)"
 
-#: api/models.py:878
-msgid "number of cases (MOH)"
-msgstr "nombre de cas (Ministère de la Santé)"
-
-#: api/models.py:879
-msgid "number of suspected cases (MOH)"
-msgstr "nombre de cas suspects (Ministère de la Santé)"
-
-#: api/models.py:880
-msgid "number of probabale cases (MOH)"
-msgstr "nombre de cas probables (Ministère de la Santé)"
-
-#: api/models.py:881
-msgid "number of confirmed cases (MOH)"
-msgstr "nombre de cas confirmés (Ministère de la Santé)"
-
-#: api/models.py:882
-msgid "number of dead (MOH)"
-msgstr "nombre de décédés (Ministère de la Santé)"
-
-#: api/models.py:884
-msgid "number of cases (WHO)"
-msgstr "nombre de cas (OMS)"
-
-#: api/models.py:885
-msgid "number of suspected cases (WHO)"
-msgstr "nombre de cas suspects (OMS)"
-
-#: api/models.py:886
-msgid "number of probable cases (WHO)"
-msgstr "nombre de cas probables (OMS)"
-
-#: api/models.py:887
-msgid "number of confirmed cases (WHO)"
-msgstr "nombre de cas confirmés (OMS) "
-
-#: api/models.py:888
-msgid "number of number of dead (WHO)"
-msgstr "nombre de décédés (OMS)"
-
-#: api/models.py:890
-msgid "number of cases (other)"
-msgstr "nombre de cas (autre)"
-
-#: api/models.py:891
-msgid "number of suspected cases (other)"
-msgstr "nombre de cas suspects (autre)"
-
-#: api/models.py:892
-msgid "number of probable cases (other)"
-msgstr "nombre de cas probables (autre)"
-
-#: api/models.py:893
-msgid "number of confirmed cases (other)"
-msgstr "nombre de cas confirmés (autre)"
-
-#: api/models.py:895 api/models.py:896
+#: models.py:987 models.py:988
 msgid "number of assisted (who)"
 msgstr "nombre d’aidés (OMS)"
 
-#: api/models.py:899
+#: models.py:991
 msgid "potentially affected (goverment)"
 msgstr "Potentiellement touchés (Gouvernement)"
 
-#: api/models.py:900
+#: models.py:992
 msgid "people at highest risk (goverment)"
 msgstr "personnes à haut risque (gouvernement)"
 
-#: api/models.py:902
+#: models.py:994
 msgid "affected population centres (goverment)"
 msgstr "centres de population touchés (gouvernement)"
 
-#: api/models.py:904
+#: models.py:996
 msgid "number of injured (other)"
 msgstr "nombre de blessés (autre)"
 
-#: api/models.py:905
+#: models.py:997
 msgid "number of dead (other)"
 msgstr "nombre de décédés (autre)"
 
-#: api/models.py:906
+#: models.py:998
 msgid "number of missing (other)"
 msgstr "nombre de disparus (autre)"
 
-#: api/models.py:907
+#: models.py:999
 msgid "number of affected (other)"
 msgstr "nombre de touchés (autre)"
 
-#: api/models.py:908
+#: models.py:1000
 msgid "number of displace (other)"
 msgstr "nombre de déplacés (autre)"
 
-#: api/models.py:909
+#: models.py:1001
 msgid "number of assisted (other)"
 msgstr "nombre d’aidés (autre)"
 
-#: api/models.py:913
+#: models.py:1005
 msgid "number of potentially affected (other)"
 msgstr "nombre d’individus potentiellement touchés (autre)"
 
-#: api/models.py:914
+#: models.py:1006
 msgid "number of highest risk (other)"
 msgstr "nombre de risques les plus élevés (autre)"
 
-#: api/models.py:916
+#: models.py:1008
 msgid "number of affected population centres (other)"
 msgstr "centres de population touchés (autre)"
 
-#: api/models.py:919
-msgid "number of cases"
-msgstr "nombre de cas"
-
-#: api/models.py:920
-msgid "number of suspected cases"
-msgstr "nombre de cas suspects"
-
-#: api/models.py:921
-msgid "number of probable cases"
-msgstr "nombre de cas probables"
-
-#: api/models.py:922
-msgid "number of confirmed cases"
-msgstr "nombre de cas confirmés"
-
-#: api/models.py:925
+#: models.py:1011
 msgid "situation fields date"
 msgstr "Situation sur le terrain (date)"
 
-#: api/models.py:928
+#: models.py:1014
 msgid "sources (other)"
 msgstr "sources (autres)"
 
-#: api/models.py:931
+#: models.py:1017
 msgid "actions taken (others)"
 msgstr "Actions initiées (autre)"
 
-#: api/models.py:937
+#: models.py:1023
 msgid "bullentin"
 msgstr "Bulletin"
 
-#: api/models.py:939
+#: models.py:1025
 msgid "DREF amount"
 msgstr "Montant DREF"
 
-#: api/models.py:941
+#: models.py:1027
 msgid "appeal amount"
 msgstr "montant de l'appel"
 
-#: api/models.py:942
+#: models.py:1028
 msgid "imminent dref"
 msgstr "DREF imminent"
 
-#: api/models.py:943
+#: models.py:1029
 msgid "imminent dref amount"
 msgstr "Montant DREF imminent"
 
-#: api/models.py:944
+#: models.py:1030
 msgid "forecast based action"
 msgstr "action basée sur les prévisions"
 
-#: api/models.py:946
+#: models.py:1032
 msgid "forecast based action amount"
 msgstr "montant de l'action basé sur les prévisions"
 
-#: api/models.py:949
+#: models.py:1035
 msgid "RDRT"
 msgstr "RDRT"
 
-#: api/models.py:950
+#: models.py:1036
 msgid "number of RDRT"
 msgstr "nombre de RDRT"
 
-#: api/models.py:951
+#: models.py:1037
 msgid "fact"
 msgstr "fait"
 
-#: api/models.py:952
+#: models.py:1038
 msgid "number of fact"
 msgstr "nombre de faits"
 
-#: api/models.py:953
+#: models.py:1039
 msgid "IFRC staff"
 msgstr "Personnel de la FICR"
 
-#: api/models.py:954
+#: models.py:1040
 msgid "number of IFRC staff"
 msgstr "nombre d'employés de la FICR"
 
-#: api/models.py:957
+#: models.py:1043
 msgid "ERU base camp"
 msgstr "Camp de base UIU"
 
-#: api/models.py:958
+#: models.py:1044
 msgid "ERU base camp units"
 msgstr "Unités camp de base UIU"
 
-#: api/models.py:960
+#: models.py:1046
 msgid "ERU basic health care"
 msgstr "Soins de première nécessité UIU"
 
-#: api/models.py:961
+#: models.py:1047
 msgid "ERU basic health units"
 msgstr "Unités de soins de première nécessité IUI"
 
-#: api/models.py:963
+#: models.py:1049
 msgid "ERU IT telecom"
 msgstr "Télécommunications Informatique UIU"
 
-#: api/models.py:964
+#: models.py:1050
 msgid "ERU IT telecom units"
 msgstr "Unités de télécommunications UIU"
 
-#: api/models.py:966
+#: models.py:1052
 msgid "ERU logistics"
 msgstr "Logistique UIU"
 
-#: api/models.py:967
+#: models.py:1053
 msgid "ERU logistics units"
 msgstr "Unités de logistique UIU"
 
-#: api/models.py:969
+#: models.py:1055
 msgid "ERU deployment hospital"
 msgstr "Déploiement hôpital UIU"
 
-#: api/models.py:970
+#: models.py:1056
 msgid "ERU deployment hospital units"
 msgstr "Unités de déploiement d’hôpitaux UIU"
 
-#: api/models.py:972
+#: models.py:1058
 msgid "ERU referral hospital"
 msgstr "Hôpital de référence UIU"
 
-#: api/models.py:973
+#: models.py:1059
 msgid "ERU referral hospital units"
 msgstr "Hôpitaux de référence UIU"
 
-#: api/models.py:975
+#: models.py:1061
 msgid "ERU relief"
 msgstr "Secours UIU"
 
-#: api/models.py:976
+#: models.py:1062
 msgid "ERU relief units"
 msgstr "Unités de secours UIU"
 
-#: api/models.py:978
+#: models.py:1064
 msgid "ERU water sanitaion M15"
 msgstr "assainissement de l'eau M15 UIU"
 
-#: api/models.py:979
+#: models.py:1065
 msgid "ERU water sanitaion M15 units"
 msgstr "Unités d’assainissement de l'eau M15 UIU"
 
-#: api/models.py:981
+#: models.py:1067
 msgid "ERU water sanitaion M40"
 msgstr "assainissement de l'eau M40 UIU"
 
-#: api/models.py:982
+#: models.py:1068
 msgid "ERU water sanitaion M40 units"
 msgstr "Unités d’assainissement de l'eau M40 UIU"
 
-#: api/models.py:984
+#: models.py:1070
 msgid "ERU water sanitaion MSM20"
 msgstr "assainissement de l'eau MSM20 UIU"
 
-#: api/models.py:985
+#: models.py:1071
 msgid "ERU water sanitaion MSM20 units"
 msgstr "Unités d’assainissement de l'eau MSM20 UIU"
 
-#: api/models.py:993
+#: models.py:1079
 msgid "report date"
 msgstr "date du rapport"
 
-#: api/models.py:996
+#: models.py:1082
 msgid "previous updated at"
 msgstr "mise à jour précédente"
 
-#: api/models.py:1000 api/models.py:1058 api/models.py:1143 api/models.py:1171
+#: models.py:1086 models.py:1144 models.py:1229 models.py:1257
 msgid "field report"
 msgstr "rapport de terrain"
 
-#: api/models.py:1001
+#: models.py:1087
 msgid "field reports"
 msgstr "rapports de terrain"
 
-#: api/models.py:1062
-msgid "field report contact"
-msgstr "champ rapport contact"
-
-#: api/models.py:1063
+#: models.py:1148 models.py:1149
 msgid "field report contacts"
 msgstr "contacts de rapport de champ"
 
-#: api/models.py:1075 api/models.py:1191
+#: models.py:1161 models.py:1277
 msgid "National Society"
 msgstr "Société nationale "
 
-#: api/models.py:1076
+#: models.py:1162
 msgid "Foreign Society"
 msgstr "Société étrangère"
 
-#: api/models.py:1077
+#: models.py:1163
 msgid "Federation"
 msgstr "Fédération"
 
-#: api/models.py:1088
+#: models.py:1174
 msgid "Event"
 msgstr "Événement"
 
-#: api/models.py:1089
+#: models.py:1175
 msgid "Early Warning"
 msgstr "Alerte précoce"
 
-#: api/models.py:1090
+#: models.py:1176
 msgid "Epidemic"
 msgstr "Épidémie"
 
-#: api/models.py:1091
+#: models.py:1177
 msgid "COVID-19"
 msgstr "COVID-19"
 
-#: api/models.py:1102
+#: models.py:1188
 msgid "General"
 msgstr "Informations générales"
 
-#: api/models.py:1103
+#: models.py:1189
 msgid "Health"
 msgstr "Santé"
 
-#: api/models.py:1104
+#: models.py:1190
 msgid "NS Institutional Strengthening"
 msgstr "Renforcement institutionnel NS"
 
-#: api/models.py:1105
+#: models.py:1191
 msgid "Socioeconomic Interventions"
 msgstr "Interventions socio-économiques"
 
-#: api/models.py:1121
+#: models.py:1207
 msgid "category"
 msgstr "catégorie"
 
-#: api/models.py:1123
+#: models.py:1209
 msgid "is disabled?"
 msgstr "est désactivée ?"
 
-#: api/models.py:1123
+#: models.py:1209
 msgid "Disable in form"
 msgstr "Désactiver"
 
-#: api/models.py:1126 api/models.py:1622 api/models.py:1640
+#: models.py:1212 models.py:1709 models.py:1727
 msgid "action"
 msgstr "action"
 
-#: api/models.py:1127 api/models.py:1140
+#: models.py:1213 models.py:1226
 msgid "actions"
 msgstr "actions"
 
-#: api/models.py:1138 api/models.py:1211
+#: models.py:1224 models.py:1297
 msgid "organization"
 msgstr "organisation"
 
-#: api/models.py:1147
+#: models.py:1233
 msgid "actions taken"
 msgstr "actions entreprises"
 
-#: api/models.py:1148
+#: models.py:1234
 msgid "all actions taken"
 msgstr "toutes les actions entreprises"
 
-#: api/models.py:1159
+#: models.py:1245
 msgid "source type"
 msgstr "type de source"
 
-#: api/models.py:1160
+#: models.py:1246
 msgid "source types"
 msgstr "types de source"
 
-#: api/models.py:1169
+#: models.py:1255
 msgid "spec"
 msgstr "spécifications"
 
-#: api/models.py:1176
+#: models.py:1262
 msgid "sources"
 msgstr "sources"
 
-#: api/models.py:1192
+#: models.py:1278
 msgid "Delegation"
 msgstr "Délégation"
 
-#: api/models.py:1193
+#: models.py:1279
 msgid "Secretariat"
 msgstr "Secrétariat"
 
-#: api/models.py:1194
+#: models.py:1280
 msgid "ICRC"
 msgstr "CICR"
 
-#: api/models.py:1195
+#: models.py:1281
 msgid "Other"
 msgstr "Autre"
 
-#: api/models.py:1212
+#: models.py:1298
 msgid "organization type"
 msgstr "type d'organisation"
 
-#: api/models.py:1213
+#: models.py:1299
 msgid "city"
 msgstr "ville"
 
-#: api/models.py:1214
+#: models.py:1300
 msgid "department"
 msgstr "département"
 
-#: api/models.py:1216
+#: models.py:1302
 msgid "phone number"
 msgstr "numéro de téléphone"
 
-#: api/models.py:1219
-msgid "user profile"
-msgstr "profil d’utilisateur"
+#: models.py:1303
+msgid "last frontend login"
+msgstr ""
 
-#: api/models.py:1220
+#: models.py:1307
 msgid "user profiles"
 msgstr "profils d’utilisateurs"
 
-#: api/models.py:1229
+#: models.py:1316
 msgid "is validated?"
 msgstr "est validé ?"
 
-#: api/models.py:1229
+#: models.py:1316
 msgid "Did anyone check the editable data?"
 msgstr "Quelqu'un a-t-il vérifié les données modifiables ?"
 
-#: api/models.py:1231
+#: models.py:1318
 msgid "created_at"
 msgstr "créé_à"
 
-#: api/models.py:1232
+#: models.py:1319
 msgid "modified_at"
 msgstr "modified_à"
 
-#: api/models.py:1237
+#: models.py:1324
 msgid "appeal number (raw)"
 msgstr "numéro d'appel (brut)"
 
-#: api/models.py:1238
+#: models.py:1325
 msgid "date of issue (raw)"
 msgstr "date d'émission (brut)"
 
-#: api/models.py:1239
+#: models.py:1326
 msgid "glide number (raw)"
 msgstr "numéro Glide (brut)"
 
-#: api/models.py:1241
+#: models.py:1328
 msgid "number of people to be assisted (raw)"
 msgstr "nombre de personnes à aider (brut)"
 
-#: api/models.py:1242
+#: models.py:1329
 msgid "number of people affected (raw)"
 msgstr "nombre de personnes touchées (brut)"
 
-#: api/models.py:1247
+#: models.py:1334
 msgid "number of disaster risk reduction female (raw)"
 msgstr "Réduction des risques de catastrophe, nombre de femmes (brut)"
 
-#: api/models.py:1249
+#: models.py:1336
 msgid "number of disaster risk reduction male (raw)"
 msgstr "Réduction des risques de catastrophe, nombre d’hommes (brut)"
 
-#: api/models.py:1251
+#: models.py:1338
 msgid "number of disaster risk reduction people reached (raw)"
 msgstr ""
 "nombre de personnes couvertes par la réduction des risques de catastrophe "
 "(brut)"
 
-#: api/models.py:1253
+#: models.py:1340
 msgid "number of disaster risk reduction people targeted (raw)"
 msgstr ""
 "nombre de personnes ciblées par la réduction des risques de catastrophe "
 "(brut)"
 
-#: api/models.py:1255
+#: models.py:1342
 msgid "number of disaster risk reduction requirements (raw)"
 msgstr ""
 "nombre d'exigences en matière de réduction des risques de catastrophe (brut)"
 
-#: api/models.py:1256
+#: models.py:1343
 msgid "health female (raw)"
 msgstr "santé féminine (brut)"
 
-#: api/models.py:1257
+#: models.py:1344
 msgid "health male (raw)"
 msgstr "santé masculine (brut)"
 
-#: api/models.py:1258
+#: models.py:1345
 msgid "health people reached (raw)"
 msgstr "Santé : personnes couvertes (brut)"
 
-#: api/models.py:1259
+#: models.py:1346
 msgid "health people targeted (raw)"
 msgstr "Santé : personnes ciblées (brut)"
 
-#: api/models.py:1260
+#: models.py:1347
 msgid "health requirements (raw)"
 msgstr "exigences en matière de santé (brut)"
 
-#: api/models.py:1262
+#: models.py:1349
 msgid "number of livelihhods and basic needs female (raw)"
 msgstr ""
 "Moyens d'existence et de besoins de première nécessité, chiffre concernant "
 "les femmes (brut)"
 
-#: api/models.py:1264
+#: models.py:1351
 msgid "number of livelihhods and basic needs male (raw)"
 msgstr ""
 "Moyens d'existence et de besoins de première nécessité, chiffre concernant "
 "les hommes (brut)"
 
-#: api/models.py:1266
+#: models.py:1353
 msgid "number of livelihhods and basic needs people reached (raw)"
 msgstr ""
 "Moyens de subsistance et de besoins de première nécessité : personnes "
 "touchées (brut)"
 
-#: api/models.py:1268
+#: models.py:1355
 msgid "number of livelihhods and basic needs people targeted (raw)"
 msgstr ""
 "Moyens de subsistance et de besoins de première nécessité : personnes "
 "ciblées (brut)"
 
-#: api/models.py:1270
+#: models.py:1357
 msgid "number of livelihhods and basic needs requirements (raw)"
 msgstr ""
 "nombre de moyens de subsistance et de besoins de première nécessité (brut)"
 
-#: api/models.py:1271
+#: models.py:1358
 msgid "number of migration female (raw)"
 msgstr "nombre de femmes migrantes (brut)"
 
-#: api/models.py:1272
+#: models.py:1359
 msgid "number of migration male (raw)"
 msgstr "nombre d’hommes migrants (brut)"
 
-#: api/models.py:1274
+#: models.py:1361
 msgid "number of migration people reached (raw)"
 msgstr "nombre de personnes migrantes couvertes (brut)"
 
-#: api/models.py:1276
+#: models.py:1363
 msgid "number of migration people targeted (raw)"
 msgstr "nombre de personnes migrantes ciblées (brut)"
 
-#: api/models.py:1277
+#: models.py:1364
 msgid "number of migration requirements (raw)"
 msgstr "Chiffre des besoins en matière de migration (brut)"
 
-#: api/models.py:1279
+#: models.py:1366
 msgid "number of protection gender and inclusion female (raw)"
 msgstr "Chiffre PGI femmes (brut)"
 
-#: api/models.py:1281
+#: models.py:1368
 msgid "number of protection gender and inclusion male (raw)"
 msgstr "Chiffre PGI hommes (brut)"
 
-#: api/models.py:1283
+#: models.py:1370
 msgid "number of protection gender and inclusion people reached (raw)"
 msgstr "Chiffre PGI personnes couvertes (brut)"
 
-#: api/models.py:1285
+#: models.py:1372
 msgid "number of protection gender and inclusion people targeted (raw)"
 msgstr "Chiffre PGI personnes ciblées (brut)"
 
-#: api/models.py:1287
+#: models.py:1374
 msgid "number of protection gender and inclusion requirements (raw)"
 msgstr "Chiffre des besoins en matière de PGI (brut)"
 
-#: api/models.py:1288
+#: models.py:1375
 msgid "number of shelter female (raw)"
 msgstr "nombre de femmes en refuge (brut)"
 
-#: api/models.py:1289
+#: models.py:1376
 msgid "number of shelter male (raw)"
 msgstr "nombre d'hommes en refuge (brut)"
 
-#: api/models.py:1290
+#: models.py:1377
 msgid "number of shelter people reached (raw)"
 msgstr "nombre de personnes couvertes en refuge (brut)"
 
-#: api/models.py:1292
+#: models.py:1379
 msgid "number of shelter people targeted (raw)"
 msgstr "nombre de personnes ciblées en refuge (brut)"
 
-#: api/models.py:1293
+#: models.py:1380
 msgid "number of shelter requirements (raw)"
 msgstr "Chiffre des besoins en matière de refuge (brut)"
 
-#: api/models.py:1295
+#: models.py:1382
 msgid "number of water sanitation and hygiene female (raw)"
 msgstr "Eau salubre et hygiène, nombre de femmes (brut)"
 
-#: api/models.py:1297
+#: models.py:1384
 msgid "number of water sanitation and hygiene male (raw)"
 msgstr "Eau salubre et hygiène, nombre d’hommes (brut)"
 
-#: api/models.py:1299
+#: models.py:1386
 msgid "number of water sanitation and hygiene people reached (raw)"
 msgstr "Eau salubre et hygiène, nombre de personnes couvertes (brut)"
 
-#: api/models.py:1301
+#: models.py:1388
 msgid "number of water sanitation and hygiene people targeted (raw)"
 msgstr "Eau salubre et hygiène, nombre de personnes ciblées (brut)"
 
-#: api/models.py:1303
+#: models.py:1390
 msgid "number of water sanitation and hygiene requirements (raw)"
 msgstr "Chiffre des besoins en matière d’eau salubre et d’hygiène (brut)"
 
-#: api/models.py:1307
+#: models.py:1394
 msgid "appeal number"
 msgstr "numéro d'appel"
 
-#: api/models.py:1308
+#: models.py:1395
 msgid "date of issue"
 msgstr "date d'émission"
 
-#: api/models.py:1309
+#: models.py:1396
 msgid "glide number"
 msgstr "Chiffre Glide"
 
-#: api/models.py:1310
+#: models.py:1397
 msgid "number of people affected"
 msgstr "nombre de personnes touchées"
 
-#: api/models.py:1311
+#: models.py:1398
 msgid "number of people to be assisted"
 msgstr "nombre de personnes à aider"
 
-#: api/models.py:1312 api/models.py:1513
+#: models.py:1399 models.py:1600
 msgid "operation start date"
 msgstr "date de commencement de l’opération"
 
-#: api/models.py:1314
+#: models.py:1401
 msgid "DREF allocated"
 msgstr "DREF alloué"
 
-#: api/models.py:1316
+#: models.py:1403
 msgid "number of disaster risk reduction female"
 msgstr ""
-"nombre d'exigences en matière de réduction des risques de catastrophe, "
-"Femmes"
+"nombre d'exigences en matière de réduction des risques de catastrophe, Femmes"
 
-#: api/models.py:1318
+#: models.py:1405
 msgid "number of disaster risk reduction male"
 msgstr ""
-"nombre d'exigences en matière de réduction des risques de catastrophe, "
-"Hommes"
+"nombre d'exigences en matière de réduction des risques de catastrophe, Hommes"
 
-#: api/models.py:1320
+#: models.py:1407
 msgid "number of disaster risk reduction people reached"
 msgstr ""
 "nombre de personnes couvertes par la réduction des risques de catastrophe"
 
-#: api/models.py:1322
+#: models.py:1409
 msgid "number of disaster risk reduction people targeted"
 msgstr ""
 "nombre de personnes ciblées par la réduction des risques de catastrophe"
 
-#: api/models.py:1324
+#: models.py:1411
 msgid "number of disaster risk reduction people requirements"
 msgstr ""
 "nombre d’exigences pour les personnes ciblées par la réduction des risques "
 "de catastrophe (brut)"
 
-#: api/models.py:1325
+#: models.py:1412
 msgid "number of health female"
 msgstr "nombre de femmes en bonne santé"
 
-#: api/models.py:1326
+#: models.py:1413
 msgid "number of health male"
 msgstr "nombre d'hommes en bonne santé"
 
-#: api/models.py:1327
+#: models.py:1414
 msgid "number of health people reached"
 msgstr "nombre de personnes en bonne santé couvertes"
 
-#: api/models.py:1328
+#: models.py:1415
 msgid "number of health people targeted"
 msgstr "nombre de personnes en bonne santé ciblées"
 
-#: api/models.py:1329
+#: models.py:1416
 msgid "number of health requirements"
 msgstr "nombre d'exigences en matière de santé"
 
-#: api/models.py:1331
+#: models.py:1418
 msgid "number of livelihhods and basic needs female"
 msgstr ""
 "nombre de moyens d'existence et de besoins de première nécessité pour les "
 "femmes"
 
-#: api/models.py:1333
+#: models.py:1420
 msgid "number of livelihhods and basic needs male"
 msgstr ""
 "nombre de moyens d'existence et de besoins de première nécessité pour les "
 "hommes"
 
-#: api/models.py:1335
+#: models.py:1422
 msgid "number of livelihhods and basic people reached"
 msgstr ""
 "nombre de moyens d'existence et de besoins de première nécessité couverts"
 
-#: api/models.py:1337
+#: models.py:1424
 msgid "number of livelihhods and basic people targeted"
 msgstr ""
 "nombre de moyens d'existence et de besoins de première nécessité ciblés"
 
-#: api/models.py:1339
+#: models.py:1426
 msgid "number of livelihhods and basic needs requirements"
 msgstr ""
-"nombre de moyens d'existence et exigences concernant les besoins de première"
-" nécessité "
+"nombre de moyens d'existence et exigences concernant les besoins de première "
+"nécessité "
 
-#: api/models.py:1340
+#: models.py:1427
 msgid "number of migration female"
 msgstr "nombre de femmes migrantes"
 
-#: api/models.py:1341
+#: models.py:1428
 msgid "number of migration male"
 msgstr "nombre d’hommes migrants"
 
-#: api/models.py:1342
+#: models.py:1429
 msgid "number of migration people reached"
 msgstr "nombre de personnes migrantes touchées couvertes"
 
-#: api/models.py:1343
+#: models.py:1430
 msgid "number of migration people targeted"
 msgstr "nombre de personnes migrantes ciblées"
 
-#: api/models.py:1344
+#: models.py:1431
 msgid "number of migration requirements"
 msgstr "nombre d'exigences en matière de migration"
 
-#: api/models.py:1346
+#: models.py:1433
 msgid "number of protection gender and inclusion female"
 msgstr "Chiffre PGI femmes"
 
-#: api/models.py:1348
+#: models.py:1435
 msgid "number of protection gender and inclusion male"
 msgstr "Chiffre PGI hommes"
 
-#: api/models.py:1350
+#: models.py:1437
 msgid "number of protection gender and inclusion people reached"
 msgstr "Chiffre PGI personnes couvertes"
 
-#: api/models.py:1352
+#: models.py:1439
 msgid "number of protection gender and inclusion people targeted"
 msgstr "Chiffre PGI personnes ciblées"
 
-#: api/models.py:1354
+#: models.py:1441
 msgid "number of protection gender and inclusion requirements"
 msgstr "Chiffre PGI, besoins pour les hommes"
 
-#: api/models.py:1355
+#: models.py:1442
 msgid "number of shelter female"
 msgstr "nombre de femmes en refuge"
 
-#: api/models.py:1356
+#: models.py:1443
 msgid "number of shelter male"
 msgstr "nombre d'hommes en refuge"
 
-#: api/models.py:1357
+#: models.py:1444
 msgid "number of shelter people reached"
 msgstr "nombre de personnes en refuge couvertes"
 
-#: api/models.py:1358
+#: models.py:1445
 msgid "number of shelter people targeted"
 msgstr "nombre de personnes en refuge ciblées"
 
-#: api/models.py:1359
+#: models.py:1446
 msgid "number of shelter people requirements"
 msgstr "Nombre des besoins des personnes en refuge"
 
-#: api/models.py:1361
+#: models.py:1448
 msgid "water sanitation and hygiene female"
 msgstr "Eau salubre et hygiène, femmes"
 
-#: api/models.py:1363
+#: models.py:1450
 msgid "water sanitation and hygiene male"
 msgstr "Eau salubre et hygiène, hommes"
 
-#: api/models.py:1365
+#: models.py:1452
 msgid "water sanitation and hygiene people reached"
 msgstr "Eau salubre et hygiène, nombre de personnes couvertes"
 
-#: api/models.py:1367
+#: models.py:1454
 msgid "water sanitation and hygiene people targeted"
 msgstr "Eau salubre et hygiène, nombre de personnes ciblées"
 
-#: api/models.py:1369
+#: models.py:1456
 msgid "water sanitation and hygiene requirements"
 msgstr "Besoins en eau salubre et hygiène"
 
-#: api/models.py:1377 api/models.py:1463
+#: models.py:1464 models.py:1550
 msgid "appeal launch date (raw)"
 msgstr "date de lancement de l'appel (brut)"
 
-#: api/models.py:1378
+#: models.py:1465
 msgid "category allocated (raw)"
 msgstr "catégorie attribuée (brut)"
 
-#: api/models.py:1379
+#: models.py:1466
 msgid "expected end date (raw)"
 msgstr "date de fin prévue (brut)"
 
-#: api/models.py:1380
+#: models.py:1467
 msgid "expected time frame (raw)"
 msgstr "délai prévu (brut)"
 
-#: api/models.py:1382
+#: models.py:1469
 msgid "number of eduction female (raw)"
 msgstr "nombre d'éducatrices (brut)"
 
-#: api/models.py:1383
+#: models.py:1470
 msgid "number of eduction male (raw)"
 msgstr "nombre d’éducateurs (brut)"
 
-#: api/models.py:1385
+#: models.py:1472
 msgid "number of eduction people reached (raw)"
 msgstr "nombre de personnes couvertes en matière d’éducation (brut)"
 
-#: api/models.py:1387
+#: models.py:1474
 msgid "number of eduction people targeted (raw)"
 msgstr "nombre de personnes ciblées en matière d’éducation (brut)"
 
-#: api/models.py:1388
+#: models.py:1475
 msgid "number of eduction requirements (raw)"
 msgstr "Besoins en matière d’éducation (brut)"
 
-#: api/models.py:1394 api/models.py:1473
+#: models.py:1481 models.py:1560
 msgid "appeal launch date"
 msgstr "date de lancement de l'appel"
 
-#: api/models.py:1395
+#: models.py:1482
 msgid "category allocated"
 msgstr "catégorie attribuée"
 
-#: api/models.py:1396
+#: models.py:1483
 msgid "expected end date"
 msgstr "date de fin prévue"
 
-#: api/models.py:1397
+#: models.py:1484
 msgid "expected time frame"
 msgstr "délai prévu"
 
-#: api/models.py:1399
+#: models.py:1486
 msgid "number of eduction female"
 msgstr "nombre d'éducatrices"
 
-#: api/models.py:1400
+#: models.py:1487
 msgid "number of eduction male"
 msgstr "nombre d’éducateurs"
 
-#: api/models.py:1401
+#: models.py:1488
 msgid "number of eduction people reached"
 msgstr "nombre de personnes couvertes en matière d’éducation"
 
-#: api/models.py:1402
+#: models.py:1489
 msgid "number of eduction people targeted"
 msgstr "nombre de personnes ciblées en matière d’éducation"
 
-#: api/models.py:1403
+#: models.py:1490
 msgid "number of eduction requirements"
 msgstr "Chiffre des besoins en matière d’éducation"
 
-#: api/models.py:1409
+#: models.py:1496
 msgid "emergency operations dataset"
 msgstr "ensemble de données sur les opérations d'urgence"
 
-#: api/models.py:1410
+#: models.py:1497
 msgid "emergency operations datasets"
 msgstr "ensembles de données sur les opérations d'urgence"
 
-#: api/models.py:1418
+#: models.py:1505
 msgid "EPOA update number (raw)"
 msgstr "Numéro de mise à jour du PEA (brut)"
 
-#: api/models.py:1419
+#: models.py:1506
 msgid "operation timeframe (raw)"
 msgstr "calendrier de l’opération (brut)"
 
-#: api/models.py:1421
+#: models.py:1508
 msgid "time frame covered by update (raw)"
 msgstr "période couverte par la mise à jour (brut)"
 
-#: api/models.py:1436
+#: models.py:1523
 msgid "EPOA update number"
 msgstr "Numéro de mise à jour du PEA"
 
-#: api/models.py:1437
+#: models.py:1524
 msgid "operation timeframe"
 msgstr "calendrier de de l’opération"
 
-#: api/models.py:1439
+#: models.py:1526
 msgid "time frame covered by update"
 msgstr "période couverte par la mise à jour"
 
-#: api/models.py:1454 api/models.py:1455
+#: models.py:1541 models.py:1542
 msgid "emergency operations people reached"
 msgstr "Personnes couvertes par les opérations d’urgence"
 
-#: api/models.py:1462
+#: models.py:1549
 msgid "appeal ends (raw)"
 msgstr "fin de l'appel (brut)"
 
-#: api/models.py:1464
+#: models.py:1551
 msgid "current operation budget (raw)"
 msgstr "budget de fonctionnement courant (brut)"
 
-#: api/models.py:1472
+#: models.py:1559
 msgid "appeal ends"
 msgstr "fin de l'appel"
 
-#: api/models.py:1474
+#: models.py:1561
 msgid "current operation budget"
 msgstr "budget de fonctionnement courant"
 
-#: api/models.py:1482
+#: models.py:1569
 msgid "emergency operations emergency appeal"
 msgstr "opération d'urgence appel d'urgence"
 
-#: api/models.py:1483
+#: models.py:1570
 msgid "emergency operations emergency appeals"
 msgstr "opérations d'urgence appels d'urgence"
 
-#: api/models.py:1490
+#: models.py:1577
 msgid "date of disaster (raw)"
 msgstr "date de la catastrophe (brut)"
 
-#: api/models.py:1492
+#: models.py:1579
 msgid "number of other partner involved (raw)"
 msgstr "nombre d'autres partenaires impliqués (brut)"
 
-#: api/models.py:1494
+#: models.py:1581
 msgid "number of NS partner involved (raw)"
 msgstr "nombre de partenaires NS impliqués (brut)"
 
-#: api/models.py:1495
+#: models.py:1582
 msgid "operation end date (raw)"
 msgstr "date de fin de l’opération (brut)"
 
-#: api/models.py:1496
+#: models.py:1583
 msgid "overall operation budget (raw)"
 msgstr "budget de fonctionnement courant (brut)"
 
-#: api/models.py:1509
+#: models.py:1596
 msgid "date of disaster"
 msgstr "date de la catastrophe"
 
-#: api/models.py:1510
+#: models.py:1597
 msgid "number of other partner involved"
 msgstr "nombre d'autres partenaires impliqués"
 
-#: api/models.py:1511
+#: models.py:1598
 msgid "number of NS partner involved"
 msgstr "nombre de partenaires NS impliqués"
 
-#: api/models.py:1512
+#: models.py:1599
 msgid "operation end date"
 msgstr "date de fin de l’opération"
 
-#: api/models.py:1514
+#: models.py:1601
 msgid "overall operation budget"
 msgstr "budget global de fonctionnement"
 
-#: api/models.py:1527
+#: models.py:1614
 msgid "emergency operations final report"
 msgstr "rapport final des opérations d'urgence"
 
-#: api/models.py:1528
+#: models.py:1615
 msgid "emergency operations final reports"
 msgstr "rapports finaux des opérations d'urgence"
 
-#: api/models.py:1541
+#: models.py:1628
 msgid "Never run"
 msgstr "Ne fonctionne jamais"
 
-#: api/models.py:1542
+#: models.py:1629
 msgid "Successfull"
 msgstr "Réussi"
 
-#: api/models.py:1543
+#: models.py:1630
 msgid "Warned"
 msgstr "Averti"
 
-#: api/models.py:1544
+#: models.py:1631
 msgid "Erroneous"
 msgstr "Erroné"
 
-#: api/models.py:1552
+#: models.py:1639
 msgid "message"
 msgstr "message"
 
-#: api/models.py:1553
+#: models.py:1640
 msgid "number of results"
 msgstr "nombre de résultats"
 
-#: api/models.py:1554
+#: models.py:1641
 msgid "storing days"
 msgstr "Jours de stockage"
 
-#: api/models.py:1556
+#: models.py:1643
 msgid "backend side"
 msgstr "Côté backend"
 
-#: api/models.py:1560
+#: models.py:1647
 msgid "cronjob log record"
 msgstr "Enregistrement journal cronjob"
 
-#: api/models.py:1561
+#: models.py:1648
 msgid "cronjob log records"
 msgstr "Enregistrements journal cronjob"
 
-#: api/models.py:1623 api/models.py:1641
+#: models.py:1710 models.py:1728
 msgid "username"
 msgstr "nom d'utilisateur"
 
-#: api/models.py:1628
+#: models.py:1715
 msgid "auth log"
 msgstr "Authentification de connexion"
 
-#: api/models.py:1629
+#: models.py:1716
 msgid "auth logs"
 msgstr "Authentifications de connexion"
 
-#: api/models.py:1642
+#: models.py:1729
 msgid "object id"
 msgstr "identifiant de l’objet"
 
-#: api/models.py:1643
+#: models.py:1730
 msgid "object name"
 msgstr "nom de l'objet"
 
-#: api/models.py:1644
+#: models.py:1731
 msgid "object type"
 msgstr "type d'objet"
 
-#: api/models.py:1647
+#: models.py:1734
 msgid "changed from"
 msgstr "a changé de"
 
-#: api/models.py:1651
+#: models.py:1738
 msgid "changed to"
 msgstr "changé en"
 
-#: api/models.py:1655
+#: models.py:1742
 msgid "reversion difference log"
 msgstr "Journal de « reversion difference »"
 
-#: api/models.py:1656
+#: models.py:1743
 msgid "reversion difference logs"
 msgstr "Journaux de « reversion difference »"
 
-#: api/templates/admin/base.html:62
+#: templates/admin/base.html:74
 msgid "Welcome,"
 msgstr "Bienvenue,"
 
-#: api/templates/admin/base.html:67
+#: templates/admin/base.html:79
 msgid "View site"
 msgstr "Voir le site"
 
-#: api/templates/admin/base.html:72
+#: templates/admin/base.html:84
 msgid "Documentation"
 msgstr "Documentation"
 
-#: api/templates/admin/base.html:76
+#: templates/admin/base.html:88
 msgid "Change password"
 msgstr "Changer de mot de passe"
 
-#: api/templates/admin/base.html:78
+#: templates/admin/base.html:90
 msgid "Log out"
 msgstr "Déconnexion"
 
-#: api/templates/admin/base.html:88 api/templates/admin/import_form.html:13
+#: templates/admin/base.html:100 templates/admin/import_form.html:13
 msgid "Home"
 msgstr "Accueil"
 
-#: api/templates/admin/base_site.html:5
+#: templates/admin/base_site.html:5
 msgid "Django site admin"
 msgstr "Administrateur du site Django"
 
-#: api/templates/admin/edit_inline/tabular.html:21
+#: templates/admin/edit_inline/tabular.html:21
 msgid "Delete?"
 msgstr "Supprimer ?"
 
-#: api/templates/admin/edit_inline/tabular.html:35
+#: templates/admin/edit_inline/tabular.html:35
 msgid "Change"
 msgstr "Changer"
 
-#: api/templates/admin/edit_inline/tabular.html:37
+#: templates/admin/edit_inline/tabular.html:37
 msgid "View on site"
 msgstr "Voir sur le site"
 
-#: api/templates/admin/submit_line.html:5
+#: templates/admin/submit_line.html:5
 msgid "Save"
 msgstr "Enregistrer"
 
-#: api/templates/admin/submit_line.html:9
+#: templates/admin/submit_line.html:9
 msgid "Delete the whole"
 msgstr "Supprimer l'ensemble"
 
-#: api/templates/admin/submit_line.html:12
+#: templates/admin/submit_line.html:12
 msgid "Save as new"
 msgstr "Enregistrer comme nouveau"
 
-#: api/templates/admin/submit_line.html:13
+#: templates/admin/submit_line.html:13
 msgid "Save and add another"
 msgstr "Enregistrer et ajouter un autre"
 
-#: api/templates/admin/submit_line.html:14
+#: templates/admin/submit_line.html:14
 msgid "Save and continue editing"
 msgstr "Enregistrer et continuer les modifications"
 
-#: api/templates/admin/submit_line.html:14
+#: templates/admin/submit_line.html:14
 msgid "Save and view"
 msgstr "Enregistrer et voir"
 
-#: api/templates/admin/submit_line.html:15
+#: templates/admin/submit_line.html:15
 msgid "Close"
 msgstr "Fermer"
 
-#: api/utils.py:38
+#: utils.py:38
 msgid "slug should not start with a number"
 msgstr "slug ne doit pas commencer par un chiffre"
+
+#~ msgid "number of cases (MOH)"
+#~ msgstr "nombre de cas (Ministère de la Santé)"
+
+#~ msgid "number of suspected cases (MOH)"
+#~ msgstr "nombre de cas suspects (Ministère de la Santé)"
+
+#~ msgid "number of probabale cases (MOH)"
+#~ msgstr "nombre de cas probables (Ministère de la Santé)"
+
+#~ msgid "number of confirmed cases (MOH)"
+#~ msgstr "nombre de cas confirmés (Ministère de la Santé)"
+
+#~ msgid "number of dead (MOH)"
+#~ msgstr "nombre de décédés (Ministère de la Santé)"
+
+#~ msgid "number of cases (WHO)"
+#~ msgstr "nombre de cas (OMS)"
+
+#~ msgid "number of suspected cases (WHO)"
+#~ msgstr "nombre de cas suspects (OMS)"
+
+#~ msgid "number of probable cases (WHO)"
+#~ msgstr "nombre de cas probables (OMS)"
+
+#~ msgid "number of confirmed cases (WHO)"
+#~ msgstr "nombre de cas confirmés (OMS) "
+
+#~ msgid "number of number of dead (WHO)"
+#~ msgstr "nombre de décédés (OMS)"
+
+#~ msgid "number of cases (other)"
+#~ msgstr "nombre de cas (autre)"
+
+#~ msgid "number of suspected cases (other)"
+#~ msgstr "nombre de cas suspects (autre)"
+
+#~ msgid "number of probable cases (other)"
+#~ msgstr "nombre de cas probables (autre)"
+
+#~ msgid "number of confirmed cases (other)"
+#~ msgstr "nombre de cas confirmés (autre)"
+
+#~ msgid "number of cases"
+#~ msgstr "nombre de cas"
+
+#~ msgid "number of suspected cases"
+#~ msgstr "nombre de cas suspects"
+
+#~ msgid "number of probable cases"
+#~ msgstr "nombre de cas probables"
+
+#~ msgid "number of confirmed cases"
+#~ msgstr "nombre de cas confirmés"
+
+#~ msgid "field report contact"
+#~ msgstr "champ rapport contact"

--- a/deployments/locale/ar/LC_MESSAGES/django.po
+++ b/deployments/locale/ar/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-24 07:55+0000\n"
+"POT-Creation-Date: 2020-11-30 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,563 +16,563 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
-#: deployments/admin.py:74
+#: admin.py:91
 msgid "National Society"
 msgstr "الجمعية الوطنية"
 
-#: deployments/admin.py:79
+#: admin.py:96
 msgid "Country"
 msgstr "البلد"
 
-#: deployments/admin.py:106
+#: admin.py:126
 msgid "New Import"
 msgstr "طلب إستيراد جديد"
 
-#: deployments/admin.py:109
+#: admin.py:129
 msgid "Recent Imports"
 msgstr "الواردات الحديثة"
 
-#: deployments/admin.py:112
+#: admin.py:132
 msgid "Import Template"
 msgstr "استيراد قالب"
 
-#: deployments/admin.py:162 deployments/models.py:365
+#: admin.py:182 models.py:386
 msgid "Projects"
 msgstr "المشاريع"
 
-#: deployments/apps.py:7
+#: apps.py:7
 msgid "Deployments & 3W's (Who, What, Where)"
 msgstr "عمليات النشر و 3 W (من وماذا وأين)"
 
-#: deployments/forms.py:52 deployments/models.py:411
+#: forms.py:52 models.py:432
 msgid "file"
 msgstr "الملف"
 
-#: deployments/forms.py:53
+#: forms.py:53
 msgid "file delimiter"
 msgstr "محدد الملف"
 
-#: deployments/forms.py:54
+#: forms.py:54
 msgid "string delimiter"
 msgstr "محدد السلسلة"
 
-#: deployments/models.py:29
+#: models.py:29
 msgid "Basecamp"
 msgstr "معسكر القاعدة"
 
-#: deployments/models.py:30
+#: models.py:30
 msgid "IT & Telecom"
 msgstr "تكنولوجيا المعلومات والاتصالات"
 
-#: deployments/models.py:31
+#: models.py:31
 msgid "Logistics"
 msgstr "الامدادات"
 
-#: deployments/models.py:32
+#: models.py:32
 msgid "RCRC Emergency Hospital"
 msgstr "مستشفى الطوارئ RCRC"
 
-#: deployments/models.py:33
+#: models.py:33
 msgid "RCRC Emergency Clinic"
 msgstr "عيادة الطوارئ RCRC"
 
-#: deployments/models.py:34
+#: models.py:34
 msgid "Relief"
 msgstr "الإغاثة"
 
-#: deployments/models.py:35
+#: models.py:35
 msgid "Wash M15"
 msgstr "اغسل M15"
 
-#: deployments/models.py:36
+#: models.py:36
 msgid "Wash MSM20"
 msgstr "اغسل MSM20"
 
-#: deployments/models.py:37
+#: models.py:37
 msgid "Wash M40"
 msgstr "اغسل M40"
 
-#: deployments/models.py:44
+#: models.py:44
 msgid "national society country"
 msgstr "بلد الجمعية الوطنية"
 
-#: deployments/models.py:47 deployments/models.py:114
-#: deployments/models.py:299 deployments/models.py:407
+#: models.py:47 models.py:114 models.py:319 models.py:428
 msgid "created at"
 msgstr "أنشئت في"
 
-#: deployments/models.py:48 deployments/models.py:115
-#: deployments/models.py:429
+#: models.py:48 models.py:115 models.py:450
 msgid "updated at"
 msgstr "تم التحديث في"
 
-#: deployments/models.py:51
+#: models.py:51
 msgid "ERUs from a National Society"
 msgstr "ERUs من جمعية وطنية"
 
-#: deployments/models.py:52
+#: models.py:52
 msgid "ERUs"
 msgstr "ERUs"
 
-#: deployments/models.py:62 deployments/models.py:158
+#: models.py:62 models.py:174
 msgid "type"
 msgstr "النوع"
 
-#: deployments/models.py:63
+#: models.py:63
 msgid "units"
 msgstr "وحدات"
 
-#: deployments/models.py:64
+#: models.py:64
 msgid "equipment units"
 msgstr "وحدات المعدات"
 
-#: deployments/models.py:66
+#: models.py:66
 msgid "number of people deployed"
 msgstr "عدد الأفراد المنتشرين"
 
-#: deployments/models.py:66 deployments/models.py:75 deployments/models.py:80
-#: deployments/models.py:82 deployments/models.py:83 deployments/models.py:85
-#: deployments/models.py:103 deployments/models.py:105
-#: deployments/models.py:107 deployments/models.py:110
-#: deployments/models.py:112 deployments/models.py:113
+#: models.py:66 models.py:75 models.py:80 models.py:82 models.py:83
+#: models.py:85 models.py:103 models.py:105 models.py:107 models.py:110
+#: models.py:112 models.py:113
 msgid "still not used in frontend"
 msgstr "لا يزال غير مستخدم في الواجهة الأمامية"
 
-#: deployments/models.py:70 deployments/models.py:96 deployments/models.py:193
+#: models.py:70 models.py:96 models.py:213
 msgid "country deployed to"
 msgstr "نشر بلد إلى"
 
-#: deployments/models.py:72 deployments/models.py:328
+#: models.py:72 models.py:348
 msgid "event"
 msgstr "فعالية"
 
-#: deployments/models.py:74
+#: models.py:74
 msgid "appeal"
 msgstr "استئناف"
 
-#: deployments/models.py:78
+#: models.py:78
 msgid "owner"
 msgstr "المالك"
 
-#: deployments/models.py:80
+#: models.py:80
 msgid "supporting societies"
 msgstr "دعم المجتمعات"
 
-#: deployments/models.py:82 deployments/models.py:112
-#: deployments/models.py:128 deployments/models.py:338
+#: models.py:82 models.py:112 models.py:144 models.py:358
 msgid "start date"
 msgstr "تاريخ البدء"
 
-#: deployments/models.py:83 deployments/models.py:113
-#: deployments/models.py:129 deployments/models.py:339
+#: models.py:83 models.py:113 models.py:145 models.py:359
 msgid "end date"
 msgstr "تاريخ النهاية"
 
-#: deployments/models.py:84
+#: models.py:84
 msgid "available"
 msgstr "متوفر"
 
-#: deployments/models.py:85 deployments/models.py:105
+#: models.py:85 models.py:105
 msgid "alert date"
 msgstr "تاريخ التنبيه"
 
-#: deployments/models.py:88
+#: models.py:88
 msgid "Emergency Response Unit"
 msgstr "وحدة التصدي للطوارئ"
 
-#: deployments/models.py:89
+#: models.py:89
 msgid "Emergency Response Units"
 msgstr "وحدات الاستجابة للطوارئ"
 
-#: deployments/models.py:97
+#: models.py:97
 msgid "region deployed to"
 msgstr "المنطقة المنتشرة في"
 
-#: deployments/models.py:99
+#: models.py:99
 msgid "event deployed to"
 msgstr "تم نشر الحدث ل"
 
-#: deployments/models.py:102
+#: models.py:102
 msgid "appeal deployed to"
 msgstr "نشر النداء ل"
 
-#: deployments/models.py:107
+#: models.py:107
 msgid "expire start date"
 msgstr "تاريخ بدء انتهاء الصلاحية"
 
-#: deployments/models.py:110
+#: models.py:110
 msgid "end duration"
 msgstr "مدة النهاية"
 
-#: deployments/models.py:116
+#: models.py:116
 msgid "previous update"
 msgstr "التحديث السابق"
 
-#: deployments/models.py:117
+#: models.py:117
 msgid "comments"
 msgstr "تعليقات"
 
-#: deployments/models.py:120
+#: models.py:121
 msgid "Personnel Deployment"
 msgstr "توزيع الموظفين"
 
-#: deployments/models.py:121
+#: models.py:122
 msgid "Personnel Deployments"
 msgstr "حسنا. أفراد الإنتشار."
 
-#: deployments/models.py:130 deployments/models.py:298
-#: deployments/models.py:331
+#: models.py:146 models.py:318 models.py:351
 msgid "name"
 msgstr "الأب"
 
-#: deployments/models.py:131
+#: models.py:147
 msgid "role"
 msgstr "إشْتِراك ; إصْبَع ; دَور ; ضِلْع ; يَد"
 
-#: deployments/models.py:134
+#: models.py:150
 msgid "Deployed Person"
 msgstr "فرد منتشر"
 
-#: deployments/models.py:135
+#: models.py:151
 msgid "Deployed Persons"
 msgstr "الأشخاص المنتشرون"
 
-#: deployments/models.py:150
-msgid "Fact"
-msgstr "واقعة- حقيقية"
+#: models.py:166
+msgid "FACT"
+msgstr ""
 
-#: deployments/models.py:151
+#: models.py:167
 msgid "HEOP"
 msgstr "HEOP"
 
-#: deployments/models.py:152
+#: models.py:168
 msgid "RDRT"
 msgstr "RDRT"
 
-#: deployments/models.py:153
+#: models.py:169
 msgid "IFRC"
 msgstr "‫الاتحاد الدولي لجمعيات الصليب الأحمر والهلال الأحمر‬"
 
-#: deployments/models.py:154
+#: models.py:170
 msgid "ERU HR"
 msgstr "ERU HR"
 
-#: deployments/models.py:155
+#: models.py:171
 msgid "Rapid Response"
 msgstr "الاستجابة السريعة"
 
-#: deployments/models.py:160
+#: models.py:176
 msgid "country from"
 msgstr "بلد من"
 
-#: deployments/models.py:162
+#: models.py:178
 msgid "deployment"
 msgstr "توزيع"
 
-#: deployments/models.py:168
+#: models.py:188
 msgid "Personnel"
 msgstr "الموظفين"
 
-#: deployments/models.py:169
+#: models.py:189
 msgid "Personnels"
 msgstr "الأفراد"
 
-#: deployments/models.py:173 deployments/models.py:185
+#: models.py:193 models.py:205
 msgid "activity"
 msgstr "الأنشطة"
 
-#: deployments/models.py:179
+#: models.py:199
 msgid "Partner society activity"
 msgstr "نشاط المجتمع الشريك"
 
-#: deployments/models.py:180
+#: models.py:200
 msgid "Partner society activities"
 msgstr "أنشطة المجتمع الشريك"
 
-#: deployments/models.py:189
+#: models.py:209
 msgid "parent society"
 msgstr "مجتمع الوالدين"
 
-#: deployments/models.py:196
+#: models.py:216
 msgid "district deployed to"
 msgstr "نشر منطقة ل"
 
-#: deployments/models.py:199
+#: models.py:219
 msgid "Partner Society Deployment"
 msgstr "انتشار المجتمع الشريك"
 
-#: deployments/models.py:200
+#: models.py:220
 msgid "Partner Society Deployments"
 msgstr "عمليات نشر المجتمع الشريك"
 
-#: deployments/models.py:212
+#: models.py:232
 msgid "Bilateral"
 msgstr "ذو جانبين، في الجانبين، على الجانبين"
 
-#: deployments/models.py:213
+#: models.py:233
 msgid "Multilateral"
 msgstr "متعددة الأطراف"
 
-#: deployments/models.py:214
+#: models.py:234
 msgid "Domestic"
 msgstr "بيتي، بلدي"
 
-#: deployments/models.py:230 deployments/models.py:260
+#: models.py:250 models.py:280
 msgid "WASH"
 msgstr "المياه وخدمات الصرف الصحي والنظافة الصحية WASH"
 
-#: deployments/models.py:231 deployments/models.py:261
+#: models.py:251 models.py:281
 msgid "PGI"
 msgstr "PGI"
 
-#: deployments/models.py:232 deployments/models.py:262
+#: models.py:252 models.py:282
 msgid "CEA"
 msgstr "CEA"
 
-#: deployments/models.py:233 deployments/models.py:263
+#: models.py:253 models.py:283
 msgid "Migration"
 msgstr "الهجرة"
 
-#: deployments/models.py:234
+#: models.py:254
 msgid "Health"
 msgstr "الصحة"
 
-#: deployments/models.py:235 deployments/models.py:264
+#: models.py:255 models.py:284
 msgid "DRR"
 msgstr "الحد من مخاطر الكوارث"
 
-#: deployments/models.py:236 deployments/models.py:265
+#: models.py:256 models.py:285
 msgid "Shelter"
 msgstr "مأوى"
 
-#: deployments/models.py:237 deployments/models.py:266
+#: models.py:257 models.py:286
 msgid "NS Strengthening"
 msgstr "تعزيز NS"
 
-#: deployments/models.py:238 deployments/models.py:267
+#: models.py:258 models.py:287
 msgid "Education"
 msgstr "التعليم"
 
-#: deployments/models.py:239 deployments/models.py:268
+#: models.py:259 models.py:288
 msgid "Livelihoods and basic needs"
 msgstr "سبل العيش والاحتياجات الأساسية"
 
-#: deployments/models.py:269
+#: models.py:289
 msgid "Recovery"
 msgstr "استرداد"
 
-#: deployments/models.py:270
+#: models.py:290
 msgid "Internal displacement"
 msgstr "خامسا - التشريد الداخلي"
 
-#: deployments/models.py:271
+#: models.py:291
 msgid "Health (public)"
 msgstr "الصحة (عامة)"
 
-#: deployments/models.py:272
+#: models.py:292
 msgid "Health (clinical)"
 msgstr "الصحة (السريرية)"
 
-#: deployments/models.py:273
+#: models.py:293
 msgid "COVID-19"
 msgstr "كوفويد-19"
 
-#: deployments/models.py:274
+#: models.py:294
 msgid "RCCE"
 msgstr "RCCE"
 
-#: deployments/models.py:283
+#: models.py:303
 msgid "Planned"
 msgstr "مخطط"
 
-#: deployments/models.py:284
+#: models.py:304
 msgid "Ongoing"
 msgstr "مستمرة"
 
-#: deployments/models.py:285
+#: models.py:305
 msgid "Completed"
 msgstr "اكتمل"
 
-#: deployments/models.py:293
+#: models.py:313
 msgid "Programme"
 msgstr "رصد"
 
-#: deployments/models.py:294
+#: models.py:314
 msgid "Emergency Operation"
 msgstr "تشغيل الطوارئ"
 
-#: deployments/models.py:300 deployments/models.py:311
+#: models.py:320 models.py:331
 msgid "modified at"
 msgstr "تعديل في"
 
-#: deployments/models.py:303
+#: models.py:323
 msgid "Regional Project"
 msgstr "مشروع إقليمي"
 
-#: deployments/models.py:304
+#: models.py:324
 msgid "Regional Projects"
 msgstr "المشاريع الإقليمية"
 
-#: deployments/models.py:313
+#: models.py:333
 msgid "user"
 msgstr "المستعمل"
 
-#: deployments/models.py:316
+#: models.py:336
 msgid "reporting national society"
 msgstr "الإبلاغ عن المجتمع الوطني"
 
-#: deployments/models.py:320
+#: models.py:340
 msgid "country"
 msgstr "البلد"
 
-#: deployments/models.py:325
+#: models.py:345
 msgid "districts"
 msgstr "المناطق"
 
-#: deployments/models.py:330
+#: models.py:350
 msgid "disaster type"
 msgstr "نوع الكارثة"
 
-#: deployments/models.py:332
+#: models.py:352
 msgid "programme type"
 msgstr "نوع البرنامج"
 
-#: deployments/models.py:333
+#: models.py:353
 msgid "sector"
 msgstr "حَقْل ; قِسْم ; قِطَاع ; قاطِع ; مَجَال"
 
-#: deployments/models.py:335
+#: models.py:355
 msgid "tags"
 msgstr "الكلمات الدلالية"
 
-#: deployments/models.py:337
+#: models.py:357
 msgid "operation type"
 msgstr "نوع العملية"
 
-#: deployments/models.py:340
+#: models.py:360
 msgid "budget amount"
 msgstr "مبلغ الميزانية"
 
-#: deployments/models.py:341 deployments/models.py:410
+#: models.py:361
+msgid "actual expenditure"
+msgstr ""
+
+#: models.py:362 models.py:431
 msgid "status"
 msgstr ""
-"بال ; حال ; حالَة ; دَرَجَة ; رُتْبَة ; سُدّة ; طَوْر ; مَرْكَز ; مَقَام ; "
-"مَكَانَة ; مَنْزِلَة ; مَنْصِب ; مَوْقِف ; وَضْع"
+"بال ; حال ; حالَة ; دَرَجَة ; رُتْبَة ; سُدّة ; طَوْر ; مَرْكَز ; مَقَام ; مَكَانَة ; مَنْزِلَة ; "
+"مَنْصِب ; مَوْقِف ; وَضْع"
 
-#: deployments/models.py:344
+#: models.py:365
 msgid "target male"
 msgstr "الهدف من الذكور"
 
-#: deployments/models.py:345
+#: models.py:366
 msgid "target female"
 msgstr "تستهدف الإناث"
 
-#: deployments/models.py:346
+#: models.py:367
 msgid "target other"
 msgstr "الهدف الآخر"
 
-#: deployments/models.py:347
+#: models.py:368
 msgid "target total"
 msgstr "الهدف الإجمالي"
 
-#: deployments/models.py:350
+#: models.py:371
 msgid "reached male"
 msgstr "وصل ذكر"
 
-#: deployments/models.py:351
+#: models.py:372
 msgid "reached female"
 msgstr "وصلت أنثى"
 
-#: deployments/models.py:352
+#: models.py:373
 msgid "reached other"
 msgstr "وصلت أخرى"
 
-#: deployments/models.py:353
+#: models.py:374
 msgid "reached total"
 msgstr "بلغ المجموع"
 
-#: deployments/models.py:356
+#: models.py:377
 msgid "regional project"
 msgstr "مشروع إقليمي"
 
-#: deployments/models.py:359
+#: models.py:380
 msgid "visibility"
 msgstr "وُضُوح"
 
-#: deployments/models.py:364
+#: models.py:385
 msgid "Project"
 msgstr "المشروع"
 
-#: deployments/models.py:399
+#: models.py:420
 msgid "Pending"
 msgstr "قيد الانتظار"
 
-#: deployments/models.py:400
+#: models.py:421
 msgid "Success"
 msgstr "عادي"
 
-#: deployments/models.py:401
+#: models.py:422
 msgid "Failure"
 msgstr "فشل"
 
-#: deployments/models.py:405
+#: models.py:426
 msgid "created by"
 msgstr "مُسَبّب عن"
 
-#: deployments/models.py:408
+#: models.py:429
 msgid "projects created"
 msgstr "إنشاء المشاريع"
 
-#: deployments/models.py:409
+#: models.py:430
 msgid "message"
 msgstr "رسالة"
 
-#: deployments/models.py:414
+#: models.py:435
 msgid "Project Import"
 msgstr "استيراد المشروع"
 
-#: deployments/models.py:415
+#: models.py:436
 msgid "Projects Import"
 msgstr "استيراد المشاريع"
 
-#: deployments/models.py:424
+#: models.py:445
 msgid "national society"
 msgstr "الجمعية الوطنية"
 
-#: deployments/models.py:426
+#: models.py:447
 msgid "ERU type"
 msgstr "نوع ERU"
 
-#: deployments/models.py:427
+#: models.py:448
 msgid "is personnel?"
 msgstr "هو الأفراد؟"
 
-#: deployments/models.py:428
+#: models.py:449
 msgid "is equipment?"
 msgstr "هي المعدات؟"
 
-#: deployments/models.py:433
+#: models.py:454
 msgid "ERU Readiness"
 msgstr "استعداد ERU"
 
-#: deployments/models.py:434
+#: models.py:455
 msgid "NS-es ERU Readiness"
 msgstr "جاهزية NS-es ERU"
 
-#: deployments/serializers.py:134
+#: serializers.py:166
 msgid "Different country found for given districts"
 msgstr "تم العثور على دولة مختلفة لمناطق معينة"
 
-#: deployments/serializers.py:136
-msgid "Reached total should be provided if status is completed"
-msgstr "يجب تقديم المجموع الذي تم الوصول إليه في حالة اكتمال الحالة"
-
-#: deployments/serializers.py:143
+#: serializers.py:173
 msgid ""
 "Event should be provided if operation type is Emergency Operation and "
 "programme type is Multilateral"
 msgstr ""
-"يجب توفير الحدث إذا كان نوع العملية عبارة عن عملية طارئة ونوع البرنامج متعدد"
-" الأطراف"
+"يجب توفير الحدث إذا كان نوع العملية عبارة عن عملية طارئة ونوع البرنامج متعدد "
+"الأطراف"
+
+#~ msgid "Fact"
+#~ msgstr "واقعة- حقيقية"
+
+#~ msgid "Reached total should be provided if status is completed"
+#~ msgstr "يجب تقديم المجموع الذي تم الوصول إليه في حالة اكتمال الحالة"

--- a/deployments/locale/en/LC_MESSAGES/django.po
+++ b/deployments/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-24 07:55+0000\n"
+"POT-Creation-Date: 2020-11-30 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,559 +18,558 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: deployments/admin.py:74
+#: admin.py:91
 msgid "National Society"
 msgstr "National Society"
 
-#: deployments/admin.py:79
+#: admin.py:96
 msgid "Country"
 msgstr "Country"
 
-#: deployments/admin.py:106
+#: admin.py:126
 msgid "New Import"
 msgstr "New Import"
 
-#: deployments/admin.py:109
+#: admin.py:129
 msgid "Recent Imports"
 msgstr "Recent Imports"
 
-#: deployments/admin.py:112
+#: admin.py:132
 msgid "Import Template"
 msgstr "Import Template"
 
-#: deployments/admin.py:162 deployments/models.py:365
+#: admin.py:182 models.py:386
 msgid "Projects"
 msgstr "Projects"
 
-#: deployments/apps.py:7
+#: apps.py:7
 msgid "Deployments & 3W's (Who, What, Where)"
 msgstr "Deployments & 3W's (Who, What, Where)"
 
-#: deployments/forms.py:52 deployments/models.py:411
+#: forms.py:52 models.py:432
 msgid "file"
 msgstr "file"
 
-#: deployments/forms.py:53
+#: forms.py:53
 msgid "file delimiter"
 msgstr "file delimiter"
 
-#: deployments/forms.py:54
+#: forms.py:54
 msgid "string delimiter"
 msgstr "string delimiter"
 
-#: deployments/models.py:29
+#: models.py:29
 msgid "Basecamp"
 msgstr "Basecamp"
 
-#: deployments/models.py:30
+#: models.py:30
 msgid "IT & Telecom"
 msgstr "IT & Telecom"
 
-#: deployments/models.py:31
+#: models.py:31
 msgid "Logistics"
 msgstr "Logistics"
 
-#: deployments/models.py:32
+#: models.py:32
 msgid "RCRC Emergency Hospital"
 msgstr "RCRC Emergency Hospital"
 
-#: deployments/models.py:33
+#: models.py:33
 msgid "RCRC Emergency Clinic"
 msgstr "RCRC Emergency Clinic"
 
-#: deployments/models.py:34
+#: models.py:34
 msgid "Relief"
 msgstr "Relief"
 
-#: deployments/models.py:35
+#: models.py:35
 msgid "Wash M15"
 msgstr "Wash M15"
 
-#: deployments/models.py:36
+#: models.py:36
 msgid "Wash MSM20"
 msgstr "Wash MSM20"
 
-#: deployments/models.py:37
+#: models.py:37
 msgid "Wash M40"
 msgstr "Wash M40"
 
-#: deployments/models.py:44
+#: models.py:44
 msgid "national society country"
 msgstr "national society country"
 
-#: deployments/models.py:47 deployments/models.py:114
-#: deployments/models.py:299 deployments/models.py:407
+#: models.py:47 models.py:114 models.py:319 models.py:428
 msgid "created at"
 msgstr "created at"
 
-#: deployments/models.py:48 deployments/models.py:115
-#: deployments/models.py:429
+#: models.py:48 models.py:115 models.py:450
 msgid "updated at"
 msgstr "updated at"
 
-#: deployments/models.py:51
+#: models.py:51
 msgid "ERUs from a National Society"
 msgstr "ERUs from a National Society"
 
-#: deployments/models.py:52
+#: models.py:52
 msgid "ERUs"
 msgstr "ERUs"
 
-#: deployments/models.py:62 deployments/models.py:158
+#: models.py:62 models.py:174
 msgid "type"
 msgstr "type"
 
-#: deployments/models.py:63
+#: models.py:63
 msgid "units"
 msgstr "units"
 
-#: deployments/models.py:64
+#: models.py:64
 msgid "equipment units"
 msgstr "equipment units"
 
-#: deployments/models.py:66
+#: models.py:66
 msgid "number of people deployed"
 msgstr "number of people deployed"
 
-#: deployments/models.py:66 deployments/models.py:75 deployments/models.py:80
-#: deployments/models.py:82 deployments/models.py:83 deployments/models.py:85
-#: deployments/models.py:103 deployments/models.py:105
-#: deployments/models.py:107 deployments/models.py:110
-#: deployments/models.py:112 deployments/models.py:113
+#: models.py:66 models.py:75 models.py:80 models.py:82 models.py:83
+#: models.py:85 models.py:103 models.py:105 models.py:107 models.py:110
+#: models.py:112 models.py:113
 msgid "still not used in frontend"
 msgstr "still not used in frontend"
 
-#: deployments/models.py:70 deployments/models.py:96 deployments/models.py:193
+#: models.py:70 models.py:96 models.py:213
 msgid "country deployed to"
 msgstr "country deployed to"
 
-#: deployments/models.py:72 deployments/models.py:328
+#: models.py:72 models.py:348
 msgid "event"
 msgstr "event"
 
-#: deployments/models.py:74
+#: models.py:74
 msgid "appeal"
 msgstr "appeal"
 
-#: deployments/models.py:78
+#: models.py:78
 msgid "owner"
 msgstr "owner"
 
-#: deployments/models.py:80
+#: models.py:80
 msgid "supporting societies"
 msgstr "supporting societies"
 
-#: deployments/models.py:82 deployments/models.py:112
-#: deployments/models.py:128 deployments/models.py:338
+#: models.py:82 models.py:112 models.py:144 models.py:358
 msgid "start date"
 msgstr "start date"
 
-#: deployments/models.py:83 deployments/models.py:113
-#: deployments/models.py:129 deployments/models.py:339
+#: models.py:83 models.py:113 models.py:145 models.py:359
 msgid "end date"
 msgstr "end date"
 
-#: deployments/models.py:84
+#: models.py:84
 msgid "available"
 msgstr "available"
 
-#: deployments/models.py:85 deployments/models.py:105
+#: models.py:85 models.py:105
 msgid "alert date"
 msgstr "alert date"
 
-#: deployments/models.py:88
+#: models.py:88
 msgid "Emergency Response Unit"
 msgstr "Emergency Response Unit"
 
-#: deployments/models.py:89
+#: models.py:89
 msgid "Emergency Response Units"
 msgstr "Emergency Response Units"
 
-#: deployments/models.py:97
+#: models.py:97
 msgid "region deployed to"
 msgstr "region deployed to"
 
-#: deployments/models.py:99
+#: models.py:99
 msgid "event deployed to"
 msgstr "event deployed to"
 
-#: deployments/models.py:102
+#: models.py:102
 msgid "appeal deployed to"
 msgstr "appeal deployed to"
 
-#: deployments/models.py:107
+#: models.py:107
 msgid "expire start date"
 msgstr "expire start date"
 
-#: deployments/models.py:110
+#: models.py:110
 msgid "end duration"
 msgstr "end duration"
 
-#: deployments/models.py:116
+#: models.py:116
 msgid "previous update"
 msgstr "previous update"
 
-#: deployments/models.py:117
+#: models.py:117
 msgid "comments"
 msgstr "comments"
 
-#: deployments/models.py:120
+#: models.py:121
 msgid "Personnel Deployment"
 msgstr "Personnel Deployment"
 
-#: deployments/models.py:121
+#: models.py:122
 msgid "Personnel Deployments"
 msgstr "Personnel Deployments"
 
-#: deployments/models.py:130 deployments/models.py:298
-#: deployments/models.py:331
+#: models.py:146 models.py:318 models.py:351
 msgid "name"
 msgstr "name"
 
-#: deployments/models.py:131
+#: models.py:147
 msgid "role"
 msgstr "role"
 
-#: deployments/models.py:134
+#: models.py:150
 msgid "Deployed Person"
 msgstr "Deployed Person"
 
-#: deployments/models.py:135
+#: models.py:151
 msgid "Deployed Persons"
 msgstr "Deployed Persons"
 
-#: deployments/models.py:150
-msgid "Fact"
-msgstr "Fact"
+#: models.py:166
+msgid "FACT"
+msgstr ""
 
-#: deployments/models.py:151
+#: models.py:167
 msgid "HEOP"
 msgstr "HEOP"
 
-#: deployments/models.py:152
+#: models.py:168
 msgid "RDRT"
 msgstr "RDRT"
 
-#: deployments/models.py:153
+#: models.py:169
 msgid "IFRC"
 msgstr "IFRC"
 
-#: deployments/models.py:154
+#: models.py:170
 msgid "ERU HR"
 msgstr "ERU HR"
 
-#: deployments/models.py:155
+#: models.py:171
 msgid "Rapid Response"
 msgstr "Rapid Response"
 
-#: deployments/models.py:160
+#: models.py:176
 msgid "country from"
 msgstr "country from"
 
-#: deployments/models.py:162
+#: models.py:178
 msgid "deployment"
 msgstr "deployment"
 
-#: deployments/models.py:168
+#: models.py:188
 msgid "Personnel"
 msgstr "Personnel"
 
-#: deployments/models.py:169
+#: models.py:189
 msgid "Personnels"
 msgstr "Personnels"
 
-#: deployments/models.py:173 deployments/models.py:185
+#: models.py:193 models.py:205
 msgid "activity"
 msgstr "activity"
 
-#: deployments/models.py:179
+#: models.py:199
 msgid "Partner society activity"
 msgstr "Partner society activity"
 
-#: deployments/models.py:180
+#: models.py:200
 msgid "Partner society activities"
 msgstr "Partner society activities"
 
-#: deployments/models.py:189
+#: models.py:209
 msgid "parent society"
 msgstr "parent society"
 
-#: deployments/models.py:196
+#: models.py:216
 msgid "district deployed to"
 msgstr "district deployed to"
 
-#: deployments/models.py:199
+#: models.py:219
 msgid "Partner Society Deployment"
 msgstr "Partner Society Deployment"
 
-#: deployments/models.py:200
+#: models.py:220
 msgid "Partner Society Deployments"
 msgstr "Partner Society Deployments"
 
-#: deployments/models.py:212
+#: models.py:232
 msgid "Bilateral"
 msgstr "Bilateral"
 
-#: deployments/models.py:213
+#: models.py:233
 msgid "Multilateral"
 msgstr "Multilateral"
 
-#: deployments/models.py:214
+#: models.py:234
 msgid "Domestic"
 msgstr "Domestic"
 
-#: deployments/models.py:230 deployments/models.py:260
+#: models.py:250 models.py:280
 msgid "WASH"
 msgstr "WASH"
 
-#: deployments/models.py:231 deployments/models.py:261
+#: models.py:251 models.py:281
 msgid "PGI"
 msgstr "PGI"
 
-#: deployments/models.py:232 deployments/models.py:262
+#: models.py:252 models.py:282
 msgid "CEA"
 msgstr "CEA"
 
-#: deployments/models.py:233 deployments/models.py:263
+#: models.py:253 models.py:283
 msgid "Migration"
 msgstr "Migration"
 
-#: deployments/models.py:234
+#: models.py:254
 msgid "Health"
 msgstr "Health"
 
-#: deployments/models.py:235 deployments/models.py:264
+#: models.py:255 models.py:284
 msgid "DRR"
 msgstr "DRR"
 
-#: deployments/models.py:236 deployments/models.py:265
+#: models.py:256 models.py:285
 msgid "Shelter"
 msgstr "Shelter"
 
-#: deployments/models.py:237 deployments/models.py:266
+#: models.py:257 models.py:286
 msgid "NS Strengthening"
 msgstr "NS Strengthening"
 
-#: deployments/models.py:238 deployments/models.py:267
+#: models.py:258 models.py:287
 msgid "Education"
 msgstr "Education"
 
-#: deployments/models.py:239 deployments/models.py:268
+#: models.py:259 models.py:288
 msgid "Livelihoods and basic needs"
 msgstr "Livelihoods and basic needs"
 
-#: deployments/models.py:269
+#: models.py:289
 msgid "Recovery"
 msgstr "Recovery"
 
-#: deployments/models.py:270
+#: models.py:290
 msgid "Internal displacement"
 msgstr "Internal displacement"
 
-#: deployments/models.py:271
+#: models.py:291
 msgid "Health (public)"
 msgstr "Health (public)"
 
-#: deployments/models.py:272
+#: models.py:292
 msgid "Health (clinical)"
 msgstr "Health (clinical)"
 
-#: deployments/models.py:273
+#: models.py:293
 msgid "COVID-19"
 msgstr "COVID-19"
 
-#: deployments/models.py:274
+#: models.py:294
 msgid "RCCE"
 msgstr "RCCE"
 
-#: deployments/models.py:283
+#: models.py:303
 msgid "Planned"
 msgstr "Planned"
 
-#: deployments/models.py:284
+#: models.py:304
 msgid "Ongoing"
 msgstr "Ongoing"
 
-#: deployments/models.py:285
+#: models.py:305
 msgid "Completed"
 msgstr "Completed"
 
-#: deployments/models.py:293
+#: models.py:313
 msgid "Programme"
 msgstr "Programme"
 
-#: deployments/models.py:294
+#: models.py:314
 msgid "Emergency Operation"
 msgstr "Emergency Operation"
 
-#: deployments/models.py:300 deployments/models.py:311
+#: models.py:320 models.py:331
 msgid "modified at"
 msgstr "modified at"
 
-#: deployments/models.py:303
+#: models.py:323
 msgid "Regional Project"
 msgstr "Regional Project"
 
-#: deployments/models.py:304
+#: models.py:324
 msgid "Regional Projects"
 msgstr "Regional Projects"
 
-#: deployments/models.py:313
+#: models.py:333
 msgid "user"
 msgstr "user"
 
-#: deployments/models.py:316
+#: models.py:336
 msgid "reporting national society"
 msgstr "reporting national society"
 
-#: deployments/models.py:320
+#: models.py:340
 msgid "country"
 msgstr "country"
 
-#: deployments/models.py:325
+#: models.py:345
 msgid "districts"
 msgstr "districts"
 
-#: deployments/models.py:330
+#: models.py:350
 msgid "disaster type"
 msgstr "disaster type"
 
-#: deployments/models.py:332
+#: models.py:352
 msgid "programme type"
 msgstr "programme type"
 
-#: deployments/models.py:333
+#: models.py:353
 msgid "sector"
 msgstr "sector"
 
-#: deployments/models.py:335
+#: models.py:355
 msgid "tags"
 msgstr "tags"
 
-#: deployments/models.py:337
+#: models.py:357
 msgid "operation type"
 msgstr "operation type"
 
-#: deployments/models.py:340
+#: models.py:360
 msgid "budget amount"
 msgstr "budget amount"
 
-#: deployments/models.py:341 deployments/models.py:410
+#: models.py:361
+msgid "actual expenditure"
+msgstr ""
+
+#: models.py:362 models.py:431
 msgid "status"
 msgstr "status"
 
-#: deployments/models.py:344
+#: models.py:365
 msgid "target male"
 msgstr "target male"
 
-#: deployments/models.py:345
+#: models.py:366
 msgid "target female"
 msgstr "target female"
 
-#: deployments/models.py:346
+#: models.py:367
 msgid "target other"
 msgstr "target other"
 
-#: deployments/models.py:347
+#: models.py:368
 msgid "target total"
 msgstr "target total"
 
-#: deployments/models.py:350
+#: models.py:371
 msgid "reached male"
 msgstr "reached male"
 
-#: deployments/models.py:351
+#: models.py:372
 msgid "reached female"
 msgstr "reached female"
 
-#: deployments/models.py:352
+#: models.py:373
 msgid "reached other"
 msgstr "reached other"
 
-#: deployments/models.py:353
+#: models.py:374
 msgid "reached total"
 msgstr "reached total"
 
-#: deployments/models.py:356
+#: models.py:377
 msgid "regional project"
 msgstr "regional project"
 
-#: deployments/models.py:359
+#: models.py:380
 msgid "visibility"
 msgstr "visibility"
 
-#: deployments/models.py:364
+#: models.py:385
 msgid "Project"
 msgstr "Project"
 
-#: deployments/models.py:399
+#: models.py:420
 msgid "Pending"
 msgstr "Pending"
 
-#: deployments/models.py:400
+#: models.py:421
 msgid "Success"
 msgstr "Success"
 
-#: deployments/models.py:401
+#: models.py:422
 msgid "Failure"
 msgstr "Failure"
 
-#: deployments/models.py:405
+#: models.py:426
 msgid "created by"
 msgstr "created by"
 
-#: deployments/models.py:408
+#: models.py:429
 msgid "projects created"
 msgstr "projects created"
 
-#: deployments/models.py:409
+#: models.py:430
 msgid "message"
 msgstr "message"
 
-#: deployments/models.py:414
+#: models.py:435
 msgid "Project Import"
 msgstr "Project Import"
 
-#: deployments/models.py:415
+#: models.py:436
 msgid "Projects Import"
 msgstr "Projects Import"
 
-#: deployments/models.py:424
+#: models.py:445
 msgid "national society"
 msgstr "national society"
 
-#: deployments/models.py:426
+#: models.py:447
 msgid "ERU type"
 msgstr "ERU type"
 
-#: deployments/models.py:427
+#: models.py:448
 msgid "is personnel?"
 msgstr "is personnel?"
 
-#: deployments/models.py:428
+#: models.py:449
 msgid "is equipment?"
 msgstr "is equipment?"
 
-#: deployments/models.py:433
+#: models.py:454
 msgid "ERU Readiness"
 msgstr "ERU Readiness"
 
-#: deployments/models.py:434
+#: models.py:455
 msgid "NS-es ERU Readiness"
 msgstr "NS-es ERU Readiness"
 
-#: deployments/serializers.py:134
+#: serializers.py:166
 msgid "Different country found for given districts"
 msgstr "Different country found for given districts"
 
-#: deployments/serializers.py:136
-msgid "Reached total should be provided if status is completed"
-msgstr "Reached total should be provided if status is completed"
-
-#: deployments/serializers.py:143
+#: serializers.py:173
 msgid ""
 "Event should be provided if operation type is Emergency Operation and "
 "programme type is Multilateral"
 msgstr ""
 "Event should be provided if operation type is Emergency Operation and "
 "programme type is Multilateral"
+
+#~ msgid "Fact"
+#~ msgstr "Fact"
+
+#~ msgid "Reached total should be provided if status is completed"
+#~ msgstr "Reached total should be provided if status is completed"

--- a/deployments/locale/es/LC_MESSAGES/django.po
+++ b/deployments/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-24 07:55+0000\n"
+"POT-Creation-Date: 2020-11-30 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,561 +18,560 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: deployments/admin.py:74
+#: admin.py:91
 msgid "National Society"
 msgstr "Sociedad nacional"
 
-#: deployments/admin.py:79
+#: admin.py:96
 msgid "Country"
 msgstr "País"
 
-#: deployments/admin.py:106
+#: admin.py:126
 msgid "New Import"
 msgstr "Importar nuevo"
 
-#: deployments/admin.py:109
+#: admin.py:129
 msgid "Recent Imports"
 msgstr "Importados recientemente"
 
-#: deployments/admin.py:112
+#: admin.py:132
 msgid "Import Template"
 msgstr "Importar plantilla"
 
-#: deployments/admin.py:162 deployments/models.py:365
+#: admin.py:182 models.py:386
 msgid "Projects"
 msgstr "Proyectos"
 
-#: deployments/apps.py:7
+#: apps.py:7
 msgid "Deployments & 3W's (Who, What, Where)"
 msgstr "Despliegues y 3W (Quién, Qué y Dónde)"
 
-#: deployments/forms.py:52 deployments/models.py:411
+#: forms.py:52 models.py:432
 msgid "file"
 msgstr "archivo"
 
-#: deployments/forms.py:53
+#: forms.py:53
 msgid "file delimiter"
 msgstr "delimitador de archivo"
 
-#: deployments/forms.py:54
+#: forms.py:54
 msgid "string delimiter"
 msgstr "delimitador de cadena"
 
-#: deployments/models.py:29
+#: models.py:29
 msgid "Basecamp"
 msgstr "Campamento base"
 
-#: deployments/models.py:30
+#: models.py:30
 msgid "IT & Telecom"
 msgstr "TI y Telecomunicaciones"
 
-#: deployments/models.py:31
+#: models.py:31
 msgid "Logistics"
 msgstr "Logística"
 
-#: deployments/models.py:32
+#: models.py:32
 msgid "RCRC Emergency Hospital"
 msgstr "Hospital de emergencia de RCRC"
 
-#: deployments/models.py:33
+#: models.py:33
 msgid "RCRC Emergency Clinic"
 msgstr "Clínica de emergencia de RCRC"
 
-#: deployments/models.py:34
+#: models.py:34
 msgid "Relief"
 msgstr "Socorro"
 
-#: deployments/models.py:35
+#: models.py:35
 msgid "Wash M15"
 msgstr "Wash M15"
 
-#: deployments/models.py:36
+#: models.py:36
 msgid "Wash MSM20"
 msgstr "Wash MSM20"
 
-#: deployments/models.py:37
+#: models.py:37
 msgid "Wash M40"
 msgstr "Wash M40"
 
-#: deployments/models.py:44
+#: models.py:44
 msgid "national society country"
 msgstr "país de la sociedad nacional"
 
-#: deployments/models.py:47 deployments/models.py:114
-#: deployments/models.py:299 deployments/models.py:407
+#: models.py:47 models.py:114 models.py:319 models.py:428
 msgid "created at"
 msgstr "creado el"
 
-#: deployments/models.py:48 deployments/models.py:115
-#: deployments/models.py:429
+#: models.py:48 models.py:115 models.py:450
 msgid "updated at"
 msgstr "actualizado el"
 
-#: deployments/models.py:51
+#: models.py:51
 msgid "ERUs from a National Society"
 msgstr "ERU de una sociedad nacional"
 
-#: deployments/models.py:52
+#: models.py:52
 msgid "ERUs"
 msgstr "ERU"
 
-#: deployments/models.py:62 deployments/models.py:158
+#: models.py:62 models.py:174
 msgid "type"
 msgstr "tipo"
 
-#: deployments/models.py:63
+#: models.py:63
 msgid "units"
 msgstr "unidades"
 
-#: deployments/models.py:64
+#: models.py:64
 msgid "equipment units"
 msgstr "unidades de equipamiento"
 
-#: deployments/models.py:66
+#: models.py:66
 msgid "number of people deployed"
 msgstr "número de personas desplegadas"
 
-#: deployments/models.py:66 deployments/models.py:75 deployments/models.py:80
-#: deployments/models.py:82 deployments/models.py:83 deployments/models.py:85
-#: deployments/models.py:103 deployments/models.py:105
-#: deployments/models.py:107 deployments/models.py:110
-#: deployments/models.py:112 deployments/models.py:113
+#: models.py:66 models.py:75 models.py:80 models.py:82 models.py:83
+#: models.py:85 models.py:103 models.py:105 models.py:107 models.py:110
+#: models.py:112 models.py:113
 msgid "still not used in frontend"
 msgstr "todavía no se usa en el frontend"
 
-#: deployments/models.py:70 deployments/models.py:96 deployments/models.py:193
+#: models.py:70 models.py:96 models.py:213
 msgid "country deployed to"
 msgstr "país desplegado en"
 
-#: deployments/models.py:72 deployments/models.py:328
+#: models.py:72 models.py:348
 msgid "event"
 msgstr "evento"
 
-#: deployments/models.py:74
+#: models.py:74
 msgid "appeal"
 msgstr "llamamiento"
 
-#: deployments/models.py:78
+#: models.py:78
 msgid "owner"
 msgstr "propietario"
 
-#: deployments/models.py:80
+#: models.py:80
 msgid "supporting societies"
 msgstr "sociedades de apoyo"
 
-#: deployments/models.py:82 deployments/models.py:112
-#: deployments/models.py:128 deployments/models.py:338
+#: models.py:82 models.py:112 models.py:144 models.py:358
 msgid "start date"
 msgstr "fecha de inicio"
 
-#: deployments/models.py:83 deployments/models.py:113
-#: deployments/models.py:129 deployments/models.py:339
+#: models.py:83 models.py:113 models.py:145 models.py:359
 msgid "end date"
 msgstr "fecha de finalización"
 
-#: deployments/models.py:84
+#: models.py:84
 msgid "available"
 msgstr "disponible"
 
-#: deployments/models.py:85 deployments/models.py:105
+#: models.py:85 models.py:105
 msgid "alert date"
 msgstr "fecha de alerta"
 
-#: deployments/models.py:88
+#: models.py:88
 msgid "Emergency Response Unit"
 msgstr "Unidad de respuestas de emergencia"
 
-#: deployments/models.py:89
+#: models.py:89
 msgid "Emergency Response Units"
 msgstr "Unidades de respuestas de emergencia"
 
-#: deployments/models.py:97
+#: models.py:97
 msgid "region deployed to"
 msgstr "región desplegada en"
 
-#: deployments/models.py:99
+#: models.py:99
 msgid "event deployed to"
 msgstr "evento desplegado en"
 
-#: deployments/models.py:102
+#: models.py:102
 msgid "appeal deployed to"
 msgstr "llamamiento desplegado en "
 
-#: deployments/models.py:107
+#: models.py:107
 msgid "expire start date"
 msgstr "fecha de inicio expirada"
 
-#: deployments/models.py:110
+#: models.py:110
 msgid "end duration"
 msgstr "duración final"
 
-#: deployments/models.py:116
+#: models.py:116
 msgid "previous update"
 msgstr "actualización anterior"
 
-#: deployments/models.py:117
+#: models.py:117
 msgid "comments"
 msgstr "comentarios"
 
-#: deployments/models.py:120
+#: models.py:121
 msgid "Personnel Deployment"
 msgstr "Despliegue de personal"
 
-#: deployments/models.py:121
+#: models.py:122
 msgid "Personnel Deployments"
 msgstr "Despliegues de personal"
 
-#: deployments/models.py:130 deployments/models.py:298
-#: deployments/models.py:331
+#: models.py:146 models.py:318 models.py:351
 msgid "name"
 msgstr "nombre"
 
-#: deployments/models.py:131
+#: models.py:147
 msgid "role"
 msgstr "función"
 
-#: deployments/models.py:134
+#: models.py:150
 msgid "Deployed Person"
 msgstr "Persona desplegada"
 
-#: deployments/models.py:135
+#: models.py:151
 msgid "Deployed Persons"
 msgstr "Personas desplegadas"
 
-#: deployments/models.py:150
-msgid "Fact"
-msgstr "Fact"
+#: models.py:166
+msgid "FACT"
+msgstr ""
 
-#: deployments/models.py:151
+#: models.py:167
 msgid "HEOP"
 msgstr "HEOP"
 
-#: deployments/models.py:152
+#: models.py:168
 msgid "RDRT"
 msgstr "RIT"
 
-#: deployments/models.py:153
+#: models.py:169
 msgid "IFRC"
 msgstr "IFRC"
 
-#: deployments/models.py:154
+#: models.py:170
 msgid "ERU HR"
 msgstr "RR. HH. ERU"
 
-#: deployments/models.py:155
+#: models.py:171
 msgid "Rapid Response"
 msgstr "Respuesta rápida"
 
-#: deployments/models.py:160
+#: models.py:176
 msgid "country from"
 msgstr "país desde"
 
-#: deployments/models.py:162
+#: models.py:178
 msgid "deployment"
 msgstr "despliegue"
 
-#: deployments/models.py:168
+#: models.py:188
 msgid "Personnel"
 msgstr "Personal"
 
-#: deployments/models.py:169
+#: models.py:189
 msgid "Personnels"
 msgstr "Personal"
 
-#: deployments/models.py:173 deployments/models.py:185
+#: models.py:193 models.py:205
 msgid "activity"
 msgstr "actividad"
 
-#: deployments/models.py:179
+#: models.py:199
 msgid "Partner society activity"
 msgstr "actividad de la sociedad asociada"
 
-#: deployments/models.py:180
+#: models.py:200
 msgid "Partner society activities"
 msgstr "actividades de la sociedad asociada"
 
-#: deployments/models.py:189
+#: models.py:209
 msgid "parent society"
 msgstr "sociedad matriz"
 
-#: deployments/models.py:196
+#: models.py:216
 msgid "district deployed to"
 msgstr "distrito desplegado a"
 
-#: deployments/models.py:199
+#: models.py:219
 msgid "Partner Society Deployment"
 msgstr "Despliegue de la sociedad asociada"
 
-#: deployments/models.py:200
+#: models.py:220
 msgid "Partner Society Deployments"
 msgstr "Despliegues de la sociedad asociada"
 
-#: deployments/models.py:212
+#: models.py:232
 msgid "Bilateral"
 msgstr "Bilateral"
 
-#: deployments/models.py:213
+#: models.py:233
 msgid "Multilateral"
 msgstr "Multilateral"
 
-#: deployments/models.py:214
+#: models.py:234
 msgid "Domestic"
 msgstr "Doméstico"
 
-#: deployments/models.py:230 deployments/models.py:260
+#: models.py:250 models.py:280
 msgid "WASH"
 msgstr "WASH"
 
-#: deployments/models.py:231 deployments/models.py:261
+#: models.py:251 models.py:281
 msgid "PGI"
 msgstr "PGI"
 
-#: deployments/models.py:232 deployments/models.py:262
+#: models.py:252 models.py:282
 msgid "CEA"
 msgstr "CEA"
 
-#: deployments/models.py:233 deployments/models.py:263
+#: models.py:253 models.py:283
 msgid "Migration"
 msgstr "Migración"
 
-#: deployments/models.py:234
+#: models.py:254
 msgid "Health"
 msgstr "Salud"
 
-#: deployments/models.py:235 deployments/models.py:264
+#: models.py:255 models.py:284
 msgid "DRR"
 msgstr "DRR"
 
-#: deployments/models.py:236 deployments/models.py:265
+#: models.py:256 models.py:285
 msgid "Shelter"
 msgstr "Refugio"
 
-#: deployments/models.py:237 deployments/models.py:266
+#: models.py:257 models.py:286
 msgid "NS Strengthening"
 msgstr "Refuerzo de SN"
 
-#: deployments/models.py:238 deployments/models.py:267
+#: models.py:258 models.py:287
 msgid "Education"
 msgstr "Educación"
 
-#: deployments/models.py:239 deployments/models.py:268
+#: models.py:259 models.py:288
 msgid "Livelihoods and basic needs"
 msgstr "Medios de vida y necesidades básicas"
 
-#: deployments/models.py:269
+#: models.py:289
 msgid "Recovery"
 msgstr "Recuperación"
 
-#: deployments/models.py:270
+#: models.py:290
 msgid "Internal displacement"
 msgstr "Desplazamiento interno"
 
-#: deployments/models.py:271
+#: models.py:291
 msgid "Health (public)"
 msgstr "Salud (pública)"
 
-#: deployments/models.py:272
+#: models.py:292
 msgid "Health (clinical)"
 msgstr "Salud (clínica)"
 
-#: deployments/models.py:273
+#: models.py:293
 msgid "COVID-19"
 msgstr "COVID-19"
 
-#: deployments/models.py:274
+#: models.py:294
 msgid "RCCE"
 msgstr "RCCE"
 
-#: deployments/models.py:283
+#: models.py:303
 msgid "Planned"
 msgstr "Planificado"
 
-#: deployments/models.py:284
+#: models.py:304
 msgid "Ongoing"
 msgstr "En marcha"
 
-#: deployments/models.py:285
+#: models.py:305
 msgid "Completed"
 msgstr "Completado"
 
-#: deployments/models.py:293
+#: models.py:313
 msgid "Programme"
 msgstr "Programa"
 
-#: deployments/models.py:294
+#: models.py:314
 msgid "Emergency Operation"
 msgstr "Operación de emergencia"
 
-#: deployments/models.py:300 deployments/models.py:311
+#: models.py:320 models.py:331
 msgid "modified at"
 msgstr "modificado el"
 
-#: deployments/models.py:303
+#: models.py:323
 msgid "Regional Project"
 msgstr "Proyecto regional"
 
-#: deployments/models.py:304
+#: models.py:324
 msgid "Regional Projects"
 msgstr "Proyectos regionales"
 
-#: deployments/models.py:313
+#: models.py:333
 msgid "user"
 msgstr "usuario"
 
-#: deployments/models.py:316
+#: models.py:336
 msgid "reporting national society"
 msgstr "sociedad nacional que reporta"
 
-#: deployments/models.py:320
+#: models.py:340
 msgid "country"
 msgstr "país"
 
-#: deployments/models.py:325
+#: models.py:345
 msgid "districts"
 msgstr "distritos"
 
-#: deployments/models.py:330
+#: models.py:350
 msgid "disaster type"
 msgstr "tipo de desastre"
 
-#: deployments/models.py:332
+#: models.py:352
 msgid "programme type"
 msgstr "tipo de programa"
 
-#: deployments/models.py:333
+#: models.py:353
 msgid "sector"
 msgstr "sector"
 
-#: deployments/models.py:335
+#: models.py:355
 msgid "tags"
 msgstr "etiquetas"
 
-#: deployments/models.py:337
+#: models.py:357
 msgid "operation type"
 msgstr "tipo de operación"
 
-#: deployments/models.py:340
+#: models.py:360
 msgid "budget amount"
 msgstr "cantidad de presupuesto"
 
-#: deployments/models.py:341 deployments/models.py:410
+#: models.py:361
+msgid "actual expenditure"
+msgstr ""
+
+#: models.py:362 models.py:431
 msgid "status"
 msgstr "estado"
 
-#: deployments/models.py:344
+#: models.py:365
 msgid "target male"
 msgstr "objetivo hombres"
 
-#: deployments/models.py:345
+#: models.py:366
 msgid "target female"
 msgstr "objetivo mujeres"
 
-#: deployments/models.py:346
+#: models.py:367
 msgid "target other"
 msgstr "objetivo otro"
 
-#: deployments/models.py:347
+#: models.py:368
 msgid "target total"
 msgstr "objetivo total"
 
-#: deployments/models.py:350
+#: models.py:371
 msgid "reached male"
 msgstr "hombres alcanzados"
 
-#: deployments/models.py:351
+#: models.py:372
 msgid "reached female"
 msgstr "mujeres alcanzadas"
 
-#: deployments/models.py:352
+#: models.py:373
 msgid "reached other"
 msgstr "otros a los que ha alcanzado"
 
-#: deployments/models.py:353
+#: models.py:374
 msgid "reached total"
 msgstr "total a los que se ha alcanzado"
 
-#: deployments/models.py:356
+#: models.py:377
 msgid "regional project"
 msgstr "proyectos regionales"
 
-#: deployments/models.py:359
+#: models.py:380
 msgid "visibility"
 msgstr "visibilidad"
 
-#: deployments/models.py:364
+#: models.py:385
 msgid "Project"
 msgstr "Proyecto"
 
-#: deployments/models.py:399
+#: models.py:420
 msgid "Pending"
 msgstr "Pendiente"
 
-#: deployments/models.py:400
+#: models.py:421
 msgid "Success"
 msgstr "Éxito"
 
-#: deployments/models.py:401
+#: models.py:422
 msgid "Failure"
 msgstr "Fracaso"
 
-#: deployments/models.py:405
+#: models.py:426
 msgid "created by"
 msgstr "creado por"
 
-#: deployments/models.py:408
+#: models.py:429
 msgid "projects created"
 msgstr "proyectos creados"
 
-#: deployments/models.py:409
+#: models.py:430
 msgid "message"
 msgstr "mensaje"
 
-#: deployments/models.py:414
+#: models.py:435
 msgid "Project Import"
 msgstr "Proyecto importado"
 
-#: deployments/models.py:415
+#: models.py:436
 msgid "Projects Import"
 msgstr "Proyectos importados"
 
-#: deployments/models.py:424
+#: models.py:445
 msgid "national society"
 msgstr "sociedad nacional"
 
-#: deployments/models.py:426
+#: models.py:447
 msgid "ERU type"
 msgstr "tipo de ERU"
 
-#: deployments/models.py:427
+#: models.py:448
 msgid "is personnel?"
 msgstr "¿Es personal?"
 
-#: deployments/models.py:428
+#: models.py:449
 msgid "is equipment?"
 msgstr "¿Es equipamiento?"
 
-#: deployments/models.py:433
+#: models.py:454
 msgid "ERU Readiness"
 msgstr "Preparación de ERU"
 
-#: deployments/models.py:434
+#: models.py:455
 msgid "NS-es ERU Readiness"
 msgstr "Preparación de ERU de SN-es"
 
-#: deployments/serializers.py:134
+#: serializers.py:166
 msgid "Different country found for given districts"
 msgstr "Diferente país encontrado para distritos provistos"
 
-#: deployments/serializers.py:136
-msgid "Reached total should be provided if status is completed"
-msgstr ""
-"Se debe proporcionar el total alcanzado si el estado es marcdo como "
-"completado"
-
-#: deployments/serializers.py:143
+#: serializers.py:173
 msgid ""
 "Event should be provided if operation type is Emergency Operation and "
 "programme type is Multilateral"
 msgstr ""
-"Se debe indicar el evento si el tipo de operación es Operación de Emergencia"
-" y el tipo de programa es Multilateral"
+"Se debe indicar el evento si el tipo de operación es Operación de Emergencia "
+"y el tipo de programa es Multilateral"
+
+#~ msgid "Fact"
+#~ msgstr "Fact"
+
+#~ msgid "Reached total should be provided if status is completed"
+#~ msgstr ""
+#~ "Se debe proporcionar el total alcanzado si el estado es marcdo como "
+#~ "completado"

--- a/deployments/locale/fr/LC_MESSAGES/django.po
+++ b/deployments/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-24 07:55+0000\n"
+"POT-Creation-Date: 2020-11-30 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,559 +18,558 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: deployments/admin.py:74
+#: admin.py:91
 msgid "National Society"
 msgstr "Société nationale"
 
-#: deployments/admin.py:79
+#: admin.py:96
 msgid "Country"
 msgstr "Pays"
 
-#: deployments/admin.py:106
+#: admin.py:126
 msgid "New Import"
 msgstr "Nouvelle importation"
 
-#: deployments/admin.py:109
+#: admin.py:129
 msgid "Recent Imports"
 msgstr "Importations récentes"
 
-#: deployments/admin.py:112
+#: admin.py:132
 msgid "Import Template"
 msgstr "Modèle d'importation"
 
-#: deployments/admin.py:162 deployments/models.py:365
+#: admin.py:182 models.py:386
 msgid "Projects"
 msgstr "Projets "
 
-#: deployments/apps.py:7
+#: apps.py:7
 msgid "Deployments & 3W's (Who, What, Where)"
 msgstr "Déploiements et 3W (qui, quoi, où)"
 
-#: deployments/forms.py:52 deployments/models.py:411
+#: forms.py:52 models.py:432
 msgid "file"
 msgstr "fichier"
 
-#: deployments/forms.py:53
+#: forms.py:53
 msgid "file delimiter"
 msgstr "délimiteur de fichiers"
 
-#: deployments/forms.py:54
+#: forms.py:54
 msgid "string delimiter"
 msgstr "délimiteur de chaîne"
 
-#: deployments/models.py:29
+#: models.py:29
 msgid "Basecamp"
 msgstr "Camp de base"
 
-#: deployments/models.py:30
+#: models.py:30
 msgid "IT & Telecom"
 msgstr "Informatique & Télécommunications"
 
-#: deployments/models.py:31
+#: models.py:31
 msgid "Logistics"
 msgstr "Logistique"
 
-#: deployments/models.py:32
+#: models.py:32
 msgid "RCRC Emergency Hospital"
 msgstr "Hôpital d'urgence de la Croix Rouge et du Croissant Rouge"
 
-#: deployments/models.py:33
+#: models.py:33
 msgid "RCRC Emergency Clinic"
 msgstr "Clinique d'urgence de la Croix Rouge et du Croissant Rouge"
 
-#: deployments/models.py:34
+#: models.py:34
 msgid "Relief"
 msgstr "Secours"
 
-#: deployments/models.py:35
+#: models.py:35
 msgid "Wash M15"
 msgstr "Wash M15"
 
-#: deployments/models.py:36
+#: models.py:36
 msgid "Wash MSM20"
 msgstr "Wash MSM20"
 
-#: deployments/models.py:37
+#: models.py:37
 msgid "Wash M40"
 msgstr "Wash M40"
 
-#: deployments/models.py:44
+#: models.py:44
 msgid "national society country"
 msgstr "Pays de la Société Nationale"
 
-#: deployments/models.py:47 deployments/models.py:114
-#: deployments/models.py:299 deployments/models.py:407
+#: models.py:47 models.py:114 models.py:319 models.py:428
 msgid "created at"
 msgstr "créé à"
 
-#: deployments/models.py:48 deployments/models.py:115
-#: deployments/models.py:429
+#: models.py:48 models.py:115 models.py:450
 msgid "updated at"
 msgstr "mis à jour à"
 
-#: deployments/models.py:51
+#: models.py:51
 msgid "ERUs from a National Society"
 msgstr "UIU d'une société nationale"
 
-#: deployments/models.py:52
+#: models.py:52
 msgid "ERUs"
 msgstr "UIU"
 
-#: deployments/models.py:62 deployments/models.py:158
+#: models.py:62 models.py:174
 msgid "type"
 msgstr "type"
 
-#: deployments/models.py:63
+#: models.py:63
 msgid "units"
 msgstr "unités"
 
-#: deployments/models.py:64
+#: models.py:64
 msgid "equipment units"
 msgstr "unités d'équipement"
 
-#: deployments/models.py:66
+#: models.py:66
 msgid "number of people deployed"
 msgstr "nombre de personnes déployées"
 
-#: deployments/models.py:66 deployments/models.py:75 deployments/models.py:80
-#: deployments/models.py:82 deployments/models.py:83 deployments/models.py:85
-#: deployments/models.py:103 deployments/models.py:105
-#: deployments/models.py:107 deployments/models.py:110
-#: deployments/models.py:112 deployments/models.py:113
+#: models.py:66 models.py:75 models.py:80 models.py:82 models.py:83
+#: models.py:85 models.py:103 models.py:105 models.py:107 models.py:110
+#: models.py:112 models.py:113
 msgid "still not used in frontend"
 msgstr "toujours pas utilisé en frontend"
 
-#: deployments/models.py:70 deployments/models.py:96 deployments/models.py:193
+#: models.py:70 models.py:96 models.py:213
 msgid "country deployed to"
 msgstr "Pays déployé vers"
 
-#: deployments/models.py:72 deployments/models.py:328
+#: models.py:72 models.py:348
 msgid "event"
 msgstr "évènement"
 
-#: deployments/models.py:74
+#: models.py:74
 msgid "appeal"
 msgstr "appel"
 
-#: deployments/models.py:78
+#: models.py:78
 msgid "owner"
 msgstr "propriétaire"
 
-#: deployments/models.py:80
+#: models.py:80
 msgid "supporting societies"
 msgstr "Soutien des sociétés"
 
-#: deployments/models.py:82 deployments/models.py:112
-#: deployments/models.py:128 deployments/models.py:338
+#: models.py:82 models.py:112 models.py:144 models.py:358
 msgid "start date"
 msgstr "date de démarrage"
 
-#: deployments/models.py:83 deployments/models.py:113
-#: deployments/models.py:129 deployments/models.py:339
+#: models.py:83 models.py:113 models.py:145 models.py:359
 msgid "end date"
 msgstr "date de fin"
 
-#: deployments/models.py:84
+#: models.py:84
 msgid "available"
 msgstr "disponible"
 
-#: deployments/models.py:85 deployments/models.py:105
+#: models.py:85 models.py:105
 msgid "alert date"
 msgstr "date d'alerte"
 
-#: deployments/models.py:88
+#: models.py:88
 msgid "Emergency Response Unit"
 msgstr "Unité d'Intervention d'Urgence"
 
-#: deployments/models.py:89
+#: models.py:89
 msgid "Emergency Response Units"
 msgstr "Unités d'Intervention d'Urgence"
 
-#: deployments/models.py:97
+#: models.py:97
 msgid "region deployed to"
 msgstr "région déployée vers"
 
-#: deployments/models.py:99
+#: models.py:99
 msgid "event deployed to"
 msgstr "événement déployé vers"
 
-#: deployments/models.py:102
+#: models.py:102
 msgid "appeal deployed to"
 msgstr "appel déployé vers"
 
-#: deployments/models.py:107
+#: models.py:107
 msgid "expire start date"
 msgstr "date de début d'expiration"
 
-#: deployments/models.py:110
+#: models.py:110
 msgid "end duration"
 msgstr "durée de fin"
 
-#: deployments/models.py:116
+#: models.py:116
 msgid "previous update"
 msgstr "mise à jour précédente"
 
-#: deployments/models.py:117
+#: models.py:117
 msgid "comments"
 msgstr "commentaires"
 
-#: deployments/models.py:120
+#: models.py:121
 msgid "Personnel Deployment"
 msgstr "Déploiement du personnel"
 
-#: deployments/models.py:121
+#: models.py:122
 msgid "Personnel Deployments"
 msgstr "Déploiements du personnel"
 
-#: deployments/models.py:130 deployments/models.py:298
-#: deployments/models.py:331
+#: models.py:146 models.py:318 models.py:351
 msgid "name"
 msgstr "nom"
 
-#: deployments/models.py:131
+#: models.py:147
 msgid "role"
 msgstr "Poste"
 
-#: deployments/models.py:134
+#: models.py:150
 msgid "Deployed Person"
 msgstr "Personne déployée"
 
-#: deployments/models.py:135
+#: models.py:151
 msgid "Deployed Persons"
 msgstr "Personnes déployées"
 
-#: deployments/models.py:150
-msgid "Fact"
-msgstr "Fait"
+#: models.py:166
+msgid "FACT"
+msgstr ""
 
-#: deployments/models.py:151
+#: models.py:167
 msgid "HEOP"
 msgstr "HEOP"
 
-#: deployments/models.py:152
+#: models.py:168
 msgid "RDRT"
 msgstr "RDRT"
 
-#: deployments/models.py:153
+#: models.py:169
 msgid "IFRC"
 msgstr "FICR"
 
-#: deployments/models.py:154
+#: models.py:170
 msgid "ERU HR"
 msgstr "RH UIU"
 
-#: deployments/models.py:155
+#: models.py:171
 msgid "Rapid Response"
 msgstr "Intervention Rapide"
 
-#: deployments/models.py:160
+#: models.py:176
 msgid "country from"
 msgstr "du pays"
 
-#: deployments/models.py:162
+#: models.py:178
 msgid "deployment"
 msgstr "déploiement"
 
-#: deployments/models.py:168
+#: models.py:188
 msgid "Personnel"
 msgstr "Personnel"
 
-#: deployments/models.py:169
+#: models.py:189
 msgid "Personnels"
 msgstr "Personnel"
 
-#: deployments/models.py:173 deployments/models.py:185
+#: models.py:193 models.py:205
 msgid "activity"
 msgstr "activité"
 
-#: deployments/models.py:179
+#: models.py:199
 msgid "Partner society activity"
 msgstr "Activité de la société partenaire"
 
-#: deployments/models.py:180
+#: models.py:200
 msgid "Partner society activities"
 msgstr "Activités de la société nationale"
 
-#: deployments/models.py:189
+#: models.py:209
 msgid "parent society"
 msgstr "Société mère"
 
-#: deployments/models.py:196
+#: models.py:216
 msgid "district deployed to"
 msgstr "district déployé vers"
 
-#: deployments/models.py:199
+#: models.py:219
 msgid "Partner Society Deployment"
 msgstr "Déploiement de la société partenaire"
 
-#: deployments/models.py:200
+#: models.py:220
 msgid "Partner Society Deployments"
 msgstr "Déploiements de la société partenaire"
 
-#: deployments/models.py:212
+#: models.py:232
 msgid "Bilateral"
 msgstr "Bilatéral"
 
-#: deployments/models.py:213
+#: models.py:233
 msgid "Multilateral"
 msgstr "Multilatéral"
 
-#: deployments/models.py:214
+#: models.py:234
 msgid "Domestic"
 msgstr "National"
 
-#: deployments/models.py:230 deployments/models.py:260
+#: models.py:250 models.py:280
 msgid "WASH"
 msgstr "WASH"
 
-#: deployments/models.py:231 deployments/models.py:261
+#: models.py:251 models.py:281
 msgid "PGI"
 msgstr "PGI"
 
-#: deployments/models.py:232 deployments/models.py:262
+#: models.py:252 models.py:282
 msgid "CEA"
 msgstr "CEA"
 
-#: deployments/models.py:233 deployments/models.py:263
+#: models.py:253 models.py:283
 msgid "Migration"
 msgstr "Migration"
 
-#: deployments/models.py:234
+#: models.py:254
 msgid "Health"
 msgstr "Santé"
 
-#: deployments/models.py:235 deployments/models.py:264
+#: models.py:255 models.py:284
 msgid "DRR"
 msgstr "DRR"
 
-#: deployments/models.py:236 deployments/models.py:265
+#: models.py:256 models.py:285
 msgid "Shelter"
 msgstr "Refuge"
 
-#: deployments/models.py:237 deployments/models.py:266
+#: models.py:257 models.py:286
 msgid "NS Strengthening"
 msgstr "Renforcement NS"
 
-#: deployments/models.py:238 deployments/models.py:267
+#: models.py:258 models.py:287
 msgid "Education"
 msgstr "Éducation"
 
-#: deployments/models.py:239 deployments/models.py:268
+#: models.py:259 models.py:288
 msgid "Livelihoods and basic needs"
 msgstr "Moyens d'existence et besoins de première nécessité"
 
-#: deployments/models.py:269
+#: models.py:289
 msgid "Recovery"
 msgstr "Récupération"
 
-#: deployments/models.py:270
+#: models.py:290
 msgid "Internal displacement"
 msgstr "Déplacement interne"
 
-#: deployments/models.py:271
+#: models.py:291
 msgid "Health (public)"
 msgstr "Santé (publique)"
 
-#: deployments/models.py:272
+#: models.py:292
 msgid "Health (clinical)"
 msgstr "Santé (clinique)"
 
-#: deployments/models.py:273
+#: models.py:293
 msgid "COVID-19"
 msgstr "COVID-19"
 
-#: deployments/models.py:274
+#: models.py:294
 msgid "RCCE"
 msgstr "RCCE"
 
-#: deployments/models.py:283
+#: models.py:303
 msgid "Planned"
 msgstr "Prévu"
 
-#: deployments/models.py:284
+#: models.py:304
 msgid "Ongoing"
 msgstr "en cours"
 
-#: deployments/models.py:285
+#: models.py:305
 msgid "Completed"
 msgstr "Terminé"
 
-#: deployments/models.py:293
+#: models.py:313
 msgid "Programme"
 msgstr "Programme"
 
-#: deployments/models.py:294
+#: models.py:314
 msgid "Emergency Operation"
 msgstr "Opération d'urgence"
 
-#: deployments/models.py:300 deployments/models.py:311
+#: models.py:320 models.py:331
 msgid "modified at"
 msgstr "modifié à"
 
-#: deployments/models.py:303
+#: models.py:323
 msgid "Regional Project"
 msgstr "Projet régional"
 
-#: deployments/models.py:304
+#: models.py:324
 msgid "Regional Projects"
 msgstr "Projets régionaux"
 
-#: deployments/models.py:313
+#: models.py:333
 msgid "user"
 msgstr "utilisateur"
 
-#: deployments/models.py:316
+#: models.py:336
 msgid "reporting national society"
 msgstr "Rapport Société nationale"
 
-#: deployments/models.py:320
+#: models.py:340
 msgid "country"
 msgstr "pays"
 
-#: deployments/models.py:325
+#: models.py:345
 msgid "districts"
 msgstr "districts"
 
-#: deployments/models.py:330
+#: models.py:350
 msgid "disaster type"
 msgstr "Type de catastrophe"
 
-#: deployments/models.py:332
+#: models.py:352
 msgid "programme type"
 msgstr "Type de programme"
 
-#: deployments/models.py:333
+#: models.py:353
 msgid "sector"
 msgstr "secteur"
 
-#: deployments/models.py:335
+#: models.py:355
 msgid "tags"
 msgstr "balise"
 
-#: deployments/models.py:337
+#: models.py:357
 msgid "operation type"
 msgstr "Type d’opération"
 
-#: deployments/models.py:340
+#: models.py:360
 msgid "budget amount"
 msgstr "montant du budget"
 
-#: deployments/models.py:341 deployments/models.py:410
+#: models.py:361
+msgid "actual expenditure"
+msgstr ""
+
+#: models.py:362 models.py:431
 msgid "status"
 msgstr "statut"
 
-#: deployments/models.py:344
+#: models.py:365
 msgid "target male"
 msgstr "homme ciblé"
 
-#: deployments/models.py:345
+#: models.py:366
 msgid "target female"
 msgstr "femme ciblée"
 
-#: deployments/models.py:346
+#: models.py:367
 msgid "target other"
 msgstr "autre cible"
 
-#: deployments/models.py:347
+#: models.py:368
 msgid "target total"
 msgstr "Total cible"
 
-#: deployments/models.py:350
+#: models.py:371
 msgid "reached male"
 msgstr "Homme couvert"
 
-#: deployments/models.py:351
+#: models.py:372
 msgid "reached female"
 msgstr "Femme couverte"
 
-#: deployments/models.py:352
+#: models.py:373
 msgid "reached other"
 msgstr "Couvert (autre)"
 
-#: deployments/models.py:353
+#: models.py:374
 msgid "reached total"
 msgstr "Total couvert"
 
-#: deployments/models.py:356
+#: models.py:377
 msgid "regional project"
 msgstr "Projets régionaux"
 
-#: deployments/models.py:359
+#: models.py:380
 msgid "visibility"
 msgstr "visibilité"
 
-#: deployments/models.py:364
+#: models.py:385
 msgid "Project"
 msgstr "Projet"
 
-#: deployments/models.py:399
+#: models.py:420
 msgid "Pending"
 msgstr "en attente"
 
-#: deployments/models.py:400
+#: models.py:421
 msgid "Success"
 msgstr "Succès"
 
-#: deployments/models.py:401
+#: models.py:422
 msgid "Failure"
 msgstr "Échec"
 
-#: deployments/models.py:405
+#: models.py:426
 msgid "created by"
 msgstr "créé par"
 
-#: deployments/models.py:408
+#: models.py:429
 msgid "projects created"
 msgstr "projets créés"
 
-#: deployments/models.py:409
+#: models.py:430
 msgid "message"
 msgstr "message"
 
-#: deployments/models.py:414
+#: models.py:435
 msgid "Project Import"
 msgstr "Importation de projet"
 
-#: deployments/models.py:415
+#: models.py:436
 msgid "Projects Import"
 msgstr "Importation de projets"
 
-#: deployments/models.py:424
+#: models.py:445
 msgid "national society"
 msgstr "Société nationale"
 
-#: deployments/models.py:426
+#: models.py:447
 msgid "ERU type"
 msgstr "Type UIU"
 
-#: deployments/models.py:427
+#: models.py:448
 msgid "is personnel?"
 msgstr "Est-ce personnel ? "
 
-#: deployments/models.py:428
+#: models.py:449
 msgid "is equipment?"
 msgstr "Est-ce de l’équipement ?"
 
-#: deployments/models.py:433
+#: models.py:454
 msgid "ERU Readiness"
 msgstr "Préparation UIU"
 
-#: deployments/models.py:434
+#: models.py:455
 msgid "NS-es ERU Readiness"
 msgstr "Préparation UIU NS-es"
 
-#: deployments/serializers.py:134
+#: serializers.py:166
 msgid "Different country found for given districts"
 msgstr "Différents pays trouvés pour des districts donnés"
 
-#: deployments/serializers.py:136
-msgid "Reached total should be provided if status is completed"
-msgstr "Le total couvert doit être fourni si le statut est complété"
-
-#: deployments/serializers.py:143
+#: serializers.py:173
 msgid ""
 "Event should be provided if operation type is Emergency Operation and "
 "programme type is Multilateral"
 msgstr ""
 "L'événement doit être fourni si le type d'opération est une opération "
 "d'urgence et le type de programme est multilatéral"
+
+#~ msgid "Fact"
+#~ msgstr "Fait"
+
+#~ msgid "Reached total should be provided if status is completed"
+#~ msgstr "Le total couvert doit être fourni si le statut est complété"

--- a/notifications/locale/ar/LC_MESSAGES/django.po
+++ b/notifications/locale/ar/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-24 07:55+0000\n"
+"POT-Creation-Date: 2020-11-30 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,193 +16,191 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
-#: notifications/apps.py:6
+#: apps.py:6
 msgid "notifications"
 msgstr "إشعارات ؛ إخطارات ؛ تبليغات"
 
-#: notifications/models.py:20
+#: models.py:20
 msgid "fact"
 msgstr "حقيقة"
 
-#: notifications/models.py:21
+#: models.py:21
 msgid "SIMS"
 msgstr "SIMS"
 
-#: notifications/models.py:22
+#: models.py:22
 msgid "ERU"
 msgstr "ERU"
 
-#: notifications/models.py:23
+#: models.py:23
 msgid "DHEOPS"
 msgstr "DHEOPS"
 
-#: notifications/models.py:24
+#: models.py:24
 msgid "HEOPS"
 msgstr "HEOPS"
 
-#: notifications/models.py:25
+#: models.py:25
 msgid "surge"
 msgstr "إندفاع التيار"
 
-#: notifications/models.py:26
+#: models.py:26
 msgid "rapid response"
 msgstr "سرعة التصدي"
 
-#: notifications/models.py:37
+#: models.py:37
 msgid "information"
 msgstr "المعلومات"
 
-#: notifications/models.py:38
+#: models.py:38
 msgid "deployment"
 msgstr "توزيع"
 
-#: notifications/models.py:39
+#: models.py:39
 msgid "alert"
 msgstr ""
-"إسْتِنْفار ; حَذِر ; سَهْران ; صاحٍ ; مُتَحَفّظ ; مُحْتَرِز ; مُحْتَرِس ; "
-"مُحْتاط ; مُفِيق ; مُنْتَبِه ; واعٍ ; يَقِظ"
+"إسْتِنْفار ; حَذِر ; سَهْران ; صاحٍ ; مُتَحَفّظ ; مُحْتَرِز ; مُحْتَرِس ; مُحْتاط ; مُفِيق ; مُنْتَبِه ; "
+"واعٍ ; يَقِظ"
 
-#: notifications/models.py:40
+#: models.py:40
 msgid "shelter"
 msgstr ""
-"جُنّة ; حِرْز ; حِمىً ; خِدْر ; ذَرىً ; سَقِيفَة ; سِتْر ; ظُلّة ; كُنّة ; "
-"كِنَان ; كِنّ ; مَأمَن ; مَأوى ; مَخْبأ ; مَعَاذ ; مَفْزَع"
+"جُنّة ; حِرْز ; حِمىً ; خِدْر ; ذَرىً ; سَقِيفَة ; سِتْر ; ظُلّة ; كُنّة ; كِنَان ; كِنّ ; مَأمَن ; "
+"مَأوى ; مَخْبأ ; مَعَاذ ; مَفْزَع"
 
-#: notifications/models.py:41
+#: models.py:41
 msgid "stand down"
 msgstr "انسحب, تنازل, سحب ترشيحه, ألغى حالة الإستعداد"
 
-#: notifications/models.py:46
+#: models.py:46
 msgid "alert type"
 msgstr "نوع التنبيه"
 
-#: notifications/models.py:47
+#: models.py:47
 msgid "category"
 msgstr "تصنيف"
 
-#: notifications/models.py:48
+#: models.py:48
 msgid "operation"
-msgstr ""
-"إسْتِعْمال ; تَدْوِير ; تَسْيِير ; تَشْغِيل ; سَرَيَان ; عَمَل ; عَمَلِيّة ;"
-" مَفْعُول ; نَفَاذ"
+msgstr "إسْتِعْمال ; تَدْوِير ; تَسْيِير ; تَشْغِيل ; سَرَيَان ; عَمَل ; عَمَلِيّة ; مَفْعُول ; نَفَاذ"
 
-#: notifications/models.py:49
+#: models.py:49
 msgid "message"
 msgstr "رسالة"
 
-#: notifications/models.py:50
+#: models.py:50
 msgid "deployment needed"
 msgstr "مطلوب نشر"
 
-#: notifications/models.py:51
+#: models.py:51
 msgid "is private?"
 msgstr "هو خاص؟"
 
-#: notifications/models.py:52 notifications/models.py:101
-#: notifications/models.py:141
+#: models.py:52 models.py:119 models.py:160
 msgid "event"
 msgstr "فعالية"
 
-#: notifications/models.py:55
+#: models.py:70
 msgid "created at"
 msgstr "أنشئت في"
 
-#: notifications/models.py:59
+#: models.py:74
 msgid "Surge Alert"
 msgstr "تنبيه الطفرة"
 
-#: notifications/models.py:60
+#: models.py:75
 msgid "Surge Alerts"
 msgstr "تنبيهات الطفرة"
 
-#: notifications/models.py:78
+#: models.py:96
 msgid "new"
 msgstr "جديد"
 
-#: notifications/models.py:79
+#: models.py:97
 msgid "edit"
 msgstr "تعديل"
 
-#: notifications/models.py:102
+#: models.py:120
 msgid "appeal"
 msgstr "استئناف"
 
-#: notifications/models.py:103
+#: models.py:121
 msgid "field report"
 msgstr "تقرير ميداني"
 
-#: notifications/models.py:104
+#: models.py:122
 msgid "surge alert"
 msgstr "تنبيه اندفاع"
 
-#: notifications/models.py:105 notifications/models.py:138
+#: models.py:123 models.py:157
 msgid "country"
 msgstr "البلد"
 
-#: notifications/models.py:106 notifications/models.py:139
+#: models.py:124 models.py:158
 msgid "region"
 msgstr ""
-"إقْلِيم ; أرْض ; بَلَد ; بُقْعَة ; جَنْبَة ; جِهَة ; جانِب ; دائِرَة ; رَبْع"
-" ; رَجاً ; صُقْع ; طَرَف ; قُطْر ; قِسْم ; مَحَلّة ; مَكَان"
+"إقْلِيم ; أرْض ; بَلَد ; بُقْعَة ; جَنْبَة ; جِهَة ; جانِب ; دائِرَة ; رَبْع ; رَجاً ; صُقْع ; "
+"طَرَف ; قُطْر ; قِسْم ; مَحَلّة ; مَكَان"
 
-#: notifications/models.py:107 notifications/models.py:140
+#: models.py:125 models.py:159
 msgid "disaster type"
 msgstr "نوع الكارثة"
 
-#: notifications/models.py:108
+#: models.py:126
 msgid "per due date"
 msgstr "في تاريخ الاستحقاق"
 
-#: notifications/models.py:109
+#: models.py:127
 msgid "followed event"
 msgstr "حدث متبوع"
 
-#: notifications/models.py:110
+#: models.py:128
 msgid "surge deployment messages"
 msgstr "رسائل نشر الطفرة"
 
-#: notifications/models.py:111
+#: models.py:129
 msgid "surge approaching end of mission"
 msgstr "تقترب من نهاية المهمة"
 
-#: notifications/models.py:112
+#: models.py:130
 msgid "weekly digest"
 msgstr "ملخص أسبوعي"
 
-#: notifications/models.py:113
+#: models.py:131
 msgid "new emergencies"
 msgstr "حالات طوارئ جديدة"
 
-#: notifications/models.py:114
+#: models.py:132
 msgid "new operations"
 msgstr "عمليات جديدة!"
 
-#: notifications/models.py:115
+#: models.py:133
 msgid "general announcements"
 msgstr "إعلانات عامة"
 
-#: notifications/models.py:130
+#: models.py:149
 msgid "user"
 msgstr "المستعمل"
 
-#: notifications/models.py:135
+#: models.py:154
 msgid "subscription type"
 msgstr "نوع الاشتراك"
 
-#: notifications/models.py:136
+#: models.py:155
 msgid "record type"
 msgstr "نوع السجل"
 
-#: notifications/models.py:143
+#: models.py:162
 msgid "lookup id"
 msgstr "معرف البحث"
 
-#: notifications/models.py:146
+#: models.py:165
 msgid "Subscription"
 msgstr "اشتراك"
 
-#: notifications/models.py:147
+#: models.py:166
 msgid "Subscriptions"
 msgstr "الاشتراكات"

--- a/notifications/locale/en/LC_MESSAGES/django.po
+++ b/notifications/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-24 07:55+0000\n"
+"POT-Creation-Date: 2020-11-30 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,183 +18,182 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: notifications/apps.py:6
+#: apps.py:6
 msgid "notifications"
 msgstr "notifications"
 
-#: notifications/models.py:20
+#: models.py:20
 msgid "fact"
 msgstr "fact"
 
-#: notifications/models.py:21
+#: models.py:21
 msgid "SIMS"
 msgstr "SIMS"
 
-#: notifications/models.py:22
+#: models.py:22
 msgid "ERU"
 msgstr "ERU"
 
-#: notifications/models.py:23
+#: models.py:23
 msgid "DHEOPS"
 msgstr "DHEOPS"
 
-#: notifications/models.py:24
+#: models.py:24
 msgid "HEOPS"
 msgstr "HEOPS"
 
-#: notifications/models.py:25
+#: models.py:25
 msgid "surge"
 msgstr "surge"
 
-#: notifications/models.py:26
+#: models.py:26
 msgid "rapid response"
 msgstr "rapid response"
 
-#: notifications/models.py:37
+#: models.py:37
 msgid "information"
 msgstr "information"
 
-#: notifications/models.py:38
+#: models.py:38
 msgid "deployment"
 msgstr "deployment"
 
-#: notifications/models.py:39
+#: models.py:39
 msgid "alert"
 msgstr "alert"
 
-#: notifications/models.py:40
+#: models.py:40
 msgid "shelter"
 msgstr "shelter"
 
-#: notifications/models.py:41
+#: models.py:41
 msgid "stand down"
 msgstr "stand down"
 
-#: notifications/models.py:46
+#: models.py:46
 msgid "alert type"
 msgstr "alert type"
 
-#: notifications/models.py:47
+#: models.py:47
 msgid "category"
 msgstr "category"
 
-#: notifications/models.py:48
+#: models.py:48
 msgid "operation"
 msgstr "operation"
 
-#: notifications/models.py:49
+#: models.py:49
 msgid "message"
 msgstr "message"
 
-#: notifications/models.py:50
+#: models.py:50
 msgid "deployment needed"
 msgstr "deployment needed"
 
-#: notifications/models.py:51
+#: models.py:51
 msgid "is private?"
 msgstr "is private?"
 
-#: notifications/models.py:52 notifications/models.py:101
-#: notifications/models.py:141
+#: models.py:52 models.py:119 models.py:160
 msgid "event"
 msgstr "event"
 
-#: notifications/models.py:55
+#: models.py:70
 msgid "created at"
 msgstr "created at"
 
-#: notifications/models.py:59
+#: models.py:74
 msgid "Surge Alert"
 msgstr "Surge Alert"
 
-#: notifications/models.py:60
+#: models.py:75
 msgid "Surge Alerts"
 msgstr "Surge Alerts"
 
-#: notifications/models.py:78
+#: models.py:96
 msgid "new"
 msgstr "new"
 
-#: notifications/models.py:79
+#: models.py:97
 msgid "edit"
 msgstr "edit"
 
-#: notifications/models.py:102
+#: models.py:120
 msgid "appeal"
 msgstr "appeal"
 
-#: notifications/models.py:103
+#: models.py:121
 msgid "field report"
 msgstr "field report"
 
-#: notifications/models.py:104
+#: models.py:122
 msgid "surge alert"
 msgstr "surge alert"
 
-#: notifications/models.py:105 notifications/models.py:138
+#: models.py:123 models.py:157
 msgid "country"
 msgstr "country"
 
-#: notifications/models.py:106 notifications/models.py:139
+#: models.py:124 models.py:158
 msgid "region"
 msgstr "region"
 
-#: notifications/models.py:107 notifications/models.py:140
+#: models.py:125 models.py:159
 msgid "disaster type"
 msgstr "disaster type"
 
-#: notifications/models.py:108
+#: models.py:126
 msgid "per due date"
 msgstr "per due date"
 
-#: notifications/models.py:109
+#: models.py:127
 msgid "followed event"
 msgstr "followed event"
 
-#: notifications/models.py:110
+#: models.py:128
 msgid "surge deployment messages"
 msgstr "surge deployment messages"
 
-#: notifications/models.py:111
+#: models.py:129
 msgid "surge approaching end of mission"
 msgstr "surge approaching end of mission"
 
-#: notifications/models.py:112
+#: models.py:130
 msgid "weekly digest"
 msgstr "weekly digest"
 
-#: notifications/models.py:113
+#: models.py:131
 msgid "new emergencies"
 msgstr "new emergencies"
 
-#: notifications/models.py:114
+#: models.py:132
 msgid "new operations"
 msgstr "new operations"
 
-#: notifications/models.py:115
+#: models.py:133
 msgid "general announcements"
 msgstr "general announcements"
 
-#: notifications/models.py:130
+#: models.py:149
 msgid "user"
 msgstr "user"
 
-#: notifications/models.py:135
+#: models.py:154
 msgid "subscription type"
 msgstr "subscription type"
 
-#: notifications/models.py:136
+#: models.py:155
 msgid "record type"
 msgstr "record type"
 
-#: notifications/models.py:143
+#: models.py:162
 msgid "lookup id"
 msgstr "lookup id"
 
-#: notifications/models.py:146
+#: models.py:165
 msgid "Subscription"
 msgstr "Subscription"
 
-#: notifications/models.py:147
+#: models.py:166
 msgid "Subscriptions"
 msgstr "Subscriptions"

--- a/notifications/locale/es/LC_MESSAGES/django.po
+++ b/notifications/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-24 07:55+0000\n"
+"POT-Creation-Date: 2020-11-30 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,183 +18,182 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: notifications/apps.py:6
+#: apps.py:6
 msgid "notifications"
 msgstr "notificaciones"
 
-#: notifications/models.py:20
+#: models.py:20
 msgid "fact"
 msgstr "fact"
 
-#: notifications/models.py:21
+#: models.py:21
 msgid "SIMS"
 msgstr "SIMS"
 
-#: notifications/models.py:22
+#: models.py:22
 msgid "ERU"
 msgstr "ERU"
 
-#: notifications/models.py:23
+#: models.py:23
 msgid "DHEOPS"
 msgstr "DHEOPS"
 
-#: notifications/models.py:24
+#: models.py:24
 msgid "HEOPS"
 msgstr "HEOPS"
 
-#: notifications/models.py:25
+#: models.py:25
 msgid "surge"
 msgstr "aumento"
 
-#: notifications/models.py:26
+#: models.py:26
 msgid "rapid response"
 msgstr "respuesta rápida"
 
-#: notifications/models.py:37
+#: models.py:37
 msgid "information"
 msgstr "información"
 
-#: notifications/models.py:38
+#: models.py:38
 msgid "deployment"
 msgstr "despliegue"
 
-#: notifications/models.py:39
+#: models.py:39
 msgid "alert"
 msgstr "alerta"
 
-#: notifications/models.py:40
+#: models.py:40
 msgid "shelter"
 msgstr "refugio"
 
-#: notifications/models.py:41
+#: models.py:41
 msgid "stand down"
 msgstr "cesar"
 
-#: notifications/models.py:46
+#: models.py:46
 msgid "alert type"
 msgstr "tipo de alerta"
 
-#: notifications/models.py:47
+#: models.py:47
 msgid "category"
 msgstr "categoría"
 
-#: notifications/models.py:48
+#: models.py:48
 msgid "operation"
 msgstr "operación"
 
-#: notifications/models.py:49
+#: models.py:49
 msgid "message"
 msgstr "mensaje"
 
-#: notifications/models.py:50
+#: models.py:50
 msgid "deployment needed"
 msgstr "se necesita despliegue"
 
-#: notifications/models.py:51
+#: models.py:51
 msgid "is private?"
 msgstr "¿es privado?"
 
-#: notifications/models.py:52 notifications/models.py:101
-#: notifications/models.py:141
+#: models.py:52 models.py:119 models.py:160
 msgid "event"
 msgstr "evento"
 
-#: notifications/models.py:55
+#: models.py:70
 msgid "created at"
 msgstr "creado el"
 
-#: notifications/models.py:59
+#: models.py:74
 msgid "Surge Alert"
 msgstr "Alerta Surge"
 
-#: notifications/models.py:60
+#: models.py:75
 msgid "Surge Alerts"
 msgstr "Alertas Surge"
 
-#: notifications/models.py:78
+#: models.py:96
 msgid "new"
 msgstr "nuevo"
 
-#: notifications/models.py:79
+#: models.py:97
 msgid "edit"
 msgstr "editar"
 
-#: notifications/models.py:102
+#: models.py:120
 msgid "appeal"
 msgstr "llamamiento"
 
-#: notifications/models.py:103
+#: models.py:121
 msgid "field report"
 msgstr "informe de campo"
 
-#: notifications/models.py:104
+#: models.py:122
 msgid "surge alert"
 msgstr "aumento de alerta"
 
-#: notifications/models.py:105 notifications/models.py:138
+#: models.py:123 models.py:157
 msgid "country"
 msgstr "país"
 
-#: notifications/models.py:106 notifications/models.py:139
+#: models.py:124 models.py:158
 msgid "region"
 msgstr "región"
 
-#: notifications/models.py:107 notifications/models.py:140
+#: models.py:125 models.py:159
 msgid "disaster type"
 msgstr "tipo de desastre"
 
-#: notifications/models.py:108
+#: models.py:126
 msgid "per due date"
 msgstr "fecha de vencimiento per"
 
-#: notifications/models.py:109
+#: models.py:127
 msgid "followed event"
 msgstr "evento seguido"
 
-#: notifications/models.py:110
+#: models.py:128
 msgid "surge deployment messages"
 msgstr "mensajes de despliegue surge"
 
-#: notifications/models.py:111
+#: models.py:129
 msgid "surge approaching end of mission"
 msgstr "Surge acercandose al final de la misión"
 
-#: notifications/models.py:112
+#: models.py:130
 msgid "weekly digest"
 msgstr "boletín semanal"
 
-#: notifications/models.py:113
+#: models.py:131
 msgid "new emergencies"
 msgstr "emergencias nuevas"
 
-#: notifications/models.py:114
+#: models.py:132
 msgid "new operations"
 msgstr "operaciones nuevas"
 
-#: notifications/models.py:115
+#: models.py:133
 msgid "general announcements"
 msgstr "anuncios generales"
 
-#: notifications/models.py:130
+#: models.py:149
 msgid "user"
 msgstr "usuario"
 
-#: notifications/models.py:135
+#: models.py:154
 msgid "subscription type"
 msgstr "tipo de suscripción"
 
-#: notifications/models.py:136
+#: models.py:155
 msgid "record type"
 msgstr "tipo de informe"
 
-#: notifications/models.py:143
+#: models.py:162
 msgid "lookup id"
 msgstr "búsqueda de id"
 
-#: notifications/models.py:146
+#: models.py:165
 msgid "Subscription"
 msgstr "Suscripción"
 
-#: notifications/models.py:147
+#: models.py:166
 msgid "Subscriptions"
 msgstr "Suscripciones"

--- a/notifications/locale/fr/LC_MESSAGES/django.po
+++ b/notifications/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-24 07:55+0000\n"
+"POT-Creation-Date: 2020-11-30 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,183 +18,182 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: notifications/apps.py:6
+#: apps.py:6
 msgid "notifications"
 msgstr "notifications"
 
-#: notifications/models.py:20
+#: models.py:20
 msgid "fact"
 msgstr "fait"
 
-#: notifications/models.py:21
+#: models.py:21
 msgid "SIMS"
 msgstr "SIMS"
 
-#: notifications/models.py:22
+#: models.py:22
 msgid "ERU"
 msgstr "ERU"
 
-#: notifications/models.py:23
+#: models.py:23
 msgid "DHEOPS"
 msgstr "DHEOPS"
 
-#: notifications/models.py:24
+#: models.py:24
 msgid "HEOPS"
 msgstr "HEOPS"
 
-#: notifications/models.py:25
+#: models.py:25
 msgid "surge"
 msgstr "Surge"
 
-#: notifications/models.py:26
+#: models.py:26
 msgid "rapid response"
 msgstr "intervention rapide"
 
-#: notifications/models.py:37
+#: models.py:37
 msgid "information"
 msgstr "informations"
 
-#: notifications/models.py:38
+#: models.py:38
 msgid "deployment"
 msgstr "déploiement"
 
-#: notifications/models.py:39
+#: models.py:39
 msgid "alert"
 msgstr "alerte"
 
-#: notifications/models.py:40
+#: models.py:40
 msgid "shelter"
 msgstr "refuge"
 
-#: notifications/models.py:41
+#: models.py:41
 msgid "stand down"
 msgstr "trêve"
 
-#: notifications/models.py:46
+#: models.py:46
 msgid "alert type"
 msgstr "Type d’alerte"
 
-#: notifications/models.py:47
+#: models.py:47
 msgid "category"
 msgstr "catégorie"
 
-#: notifications/models.py:48
+#: models.py:48
 msgid "operation"
 msgstr "opération"
 
-#: notifications/models.py:49
+#: models.py:49
 msgid "message"
 msgstr "message"
 
-#: notifications/models.py:50
+#: models.py:50
 msgid "deployment needed"
 msgstr "déploiement nécessaire"
 
-#: notifications/models.py:51
+#: models.py:51
 msgid "is private?"
 msgstr "est confidentiel ?"
 
-#: notifications/models.py:52 notifications/models.py:101
-#: notifications/models.py:141
+#: models.py:52 models.py:119 models.py:160
 msgid "event"
 msgstr "évènement"
 
-#: notifications/models.py:55
+#: models.py:70
 msgid "created at"
 msgstr "créé à"
 
-#: notifications/models.py:59
+#: models.py:74
 msgid "Surge Alert"
 msgstr "Alerte Surge"
 
-#: notifications/models.py:60
+#: models.py:75
 msgid "Surge Alerts"
 msgstr "Alertes Surge"
 
-#: notifications/models.py:78
+#: models.py:96
 msgid "new"
 msgstr "nouveau"
 
-#: notifications/models.py:79
+#: models.py:97
 msgid "edit"
 msgstr "modifier"
 
-#: notifications/models.py:102
+#: models.py:120
 msgid "appeal"
 msgstr "appel"
 
-#: notifications/models.py:103
+#: models.py:121
 msgid "field report"
 msgstr "rapport de terrain"
 
-#: notifications/models.py:104
+#: models.py:122
 msgid "surge alert"
 msgstr "Alerte Surge"
 
-#: notifications/models.py:105 notifications/models.py:138
+#: models.py:123 models.py:157
 msgid "country"
 msgstr "pays"
 
-#: notifications/models.py:106 notifications/models.py:139
+#: models.py:124 models.py:158
 msgid "region"
 msgstr "région"
 
-#: notifications/models.py:107 notifications/models.py:140
+#: models.py:125 models.py:159
 msgid "disaster type"
 msgstr "Type de catastrophe"
 
-#: notifications/models.py:108
+#: models.py:126
 msgid "per due date"
 msgstr "Échéance du PIE"
 
-#: notifications/models.py:109
+#: models.py:127
 msgid "followed event"
 msgstr "événement suivi"
 
-#: notifications/models.py:110
+#: models.py:128
 msgid "surge deployment messages"
 msgstr "Messages de déploiement Surge"
 
-#: notifications/models.py:111
+#: models.py:129
 msgid "surge approaching end of mission"
 msgstr "La fin de la mission Surge est proche"
 
-#: notifications/models.py:112
+#: models.py:130
 msgid "weekly digest"
 msgstr "Sélection hebdomadaire"
 
-#: notifications/models.py:113
+#: models.py:131
 msgid "new emergencies"
 msgstr "nouvelles Urgences"
 
-#: notifications/models.py:114
+#: models.py:132
 msgid "new operations"
 msgstr "nouvelles opérations"
 
-#: notifications/models.py:115
+#: models.py:133
 msgid "general announcements"
 msgstr "annonces générales"
 
-#: notifications/models.py:130
+#: models.py:149
 msgid "user"
 msgstr "utilisateur"
 
-#: notifications/models.py:135
+#: models.py:154
 msgid "subscription type"
 msgstr "type d'abonnement"
 
-#: notifications/models.py:136
+#: models.py:155
 msgid "record type"
 msgstr "type d'enregistrement"
 
-#: notifications/models.py:143
+#: models.py:162
 msgid "lookup id"
 msgstr "Identifiant de recherche"
 
-#: notifications/models.py:146
+#: models.py:165
 msgid "Subscription"
 msgstr "abonnement"
 
-#: notifications/models.py:147
+#: models.py:166
 msgid "Subscriptions"
 msgstr "abonnements"


### PR DESCRIPTION
I went into each of the apps where strings had been modified and ran `python ../manage.py makemessages -l en -l es -l -fr -l ar` - I believe these changes should be committed to then be able to import the translated strings when they come in.

@thenav56 tagging you here just in case I did something terribly wrong.

@GregoryHorvath we can hold a bit on merging this.