### PR TITLE
clearer verbose names for regional snippet inlines

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -410,18 +410,22 @@ class CountrySnippetInline(admin.TabularInline, TranslationInlineModelAdmin):
 
 class RegionSnippetInline(admin.TabularInline, TranslationInlineModelAdmin):
     model = models.RegionSnippet
+    verbose_name_plural = 'Regional Snippets shown in Additional Tab'
     extra = 1
 
 class RegionEmergencySnippetInline(admin.StackedInline, TranslationInlineModelAdmin):
     model = models.RegionEmergencySnippet
+    verbose_name_plural = 'Snippets shown in Operations / Emergencies Tab'
     extra = 1
 
 class RegionProfileSnippetInline(admin.StackedInline, TranslationInlineModelAdmin):
     model = models.RegionProfileSnippet
+    verbose_name_plural = 'Snippets shown in Regional Profile Tab'
     extra = 1
 
 class RegionPreparednessSnippetInline(admin.StackedInline, TranslationInlineModelAdmin):
     model = models.RegionPreparednessSnippet
+    verbose_name_plural = 'Snippets shown in Preparedness Tab'
     extra = 1
 
 class CountryLinkInline(admin.TabularInline):


### PR DESCRIPTION
Clearer verbose names for the Regional Snippets in the Admin, clearly indicating which tab the snippets will appear in.

Refs https://github.com/IFRCGo/go-frontend/issues/1621

@GregoryHorvath please approve / merge / deploy whenever possible, thanks!