### PR TITLE
Fix national society count on region page in non-english languages

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -85,7 +85,7 @@ class Region(models.Model):
         return 'region-%s' % self.id
 
     def get_national_society_count(self):
-        return Country.objects.filter(region=self, record_type=CountryType.COUNTRY).exclude(society_name='').count()
+        return Country.objects.filter(region=self, record_type=CountryType.COUNTRY).exclude(society_name_en='').count()
 
     def get_country_cluster_count(self):
         return Country.objects.filter(region=self, record_type=CountryType.CLUSTER).count()


### PR DESCRIPTION
Refs https://github.com/IFRCGo/go-frontend/issues/1621#issuecomment-738592798

cc @thenav56 - slightly interesting case, where I don't want the language localization to apply for a particular query - in general though, we should have a better way of telling whether a Country has a National Society than doing a check for empty string for the name, so this solution is likely okay for now.

cc @GregoryHorvath - please review / merge deploy when able, thanks!