### PR TITLE
Upgrade cryptography to version 3.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ chardet==3.0.4
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.4.2
-cryptography==2.6.1
+cryptography==3.2.1
 django-admin-autocomplete-filter==0.5
 django-admin-list-filter-dropdown==1.0.2
 django-celery-beat==2.0.0


### PR DESCRIPTION
Resolves security alert
https://github.com/IFRCGo/go-api/network/alert/requirements.txt/cryptography/open

cc @batpad 