### PR TITLE
before marking position as inactive, check status on Molnix

### DIFF
--- a/api/molnix_utils.py
+++ b/api/molnix_utils.py
@@ -75,6 +75,15 @@ class MolnixApi:
         }
         return self.call_api_paginated(path='deployments', response_key='deployments', params=params)
 
+    '''
+        WARNING: If position is not found or generates an error, we return None
+    '''
+    def get_position(self, id):
+        try:
+            return self.call_api(path='positions/%d' % id)
+        except:
+            return None
+
     def logout(self):
         self.call_api('logout')
         return True


### PR DESCRIPTION
Refs https://github.com/IFRCGo/go-frontend/issues/1638#issuecomment-742330436

When a position is marked as "Unfilled" in Molnix, it is removed from Open Positions. For these, we do not want to mark them inactive and remove them from GO, but rather mark the status as "unfilled" so that the frontend can display alerts that are "unfilled" as Stand-Downs.

