### PR TITLE
Per/export results

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -157,7 +157,7 @@ urlpatterns = [
     url(r'^api/v2/', include(router.urls)),
     url(r'^api/v2/event/(?P<pk>\d+)', api_views.EventViewset.as_view({'get': 'retrieve'})),
     url(r'^api/v2/event/(?P<slug>[-\w]+)', api_views.EventViewset.as_view({'get': 'retrieve'}, lookup_field='slug')),
-    url(r'^api/v2/exportperresults/(?P<id>\d+)', per_views.ExportAssessmentToCSVViewset.as_view()),
+    url(r'^api/v2/exportperresults/', per_views.ExportAssessmentToCSVViewset.as_view()),
     url(r'^docs/', include_docs_urls(title='IFRC Go API')),
     url(r'^tinymce/', include('tinymce.urls')),
     url(r'^admin/', RedirectView.as_view(url='/')),

--- a/main/urls.py
+++ b/main/urls.py
@@ -157,7 +157,7 @@ urlpatterns = [
     url(r'^api/v2/', include(router.urls)),
     url(r'^api/v2/event/(?P<pk>\d+)', api_views.EventViewset.as_view({'get': 'retrieve'})),
     url(r'^api/v2/event/(?P<slug>[-\w]+)', api_views.EventViewset.as_view({'get': 'retrieve'}, lookup_field='slug')),
-    url(r'^api/v2/exportperresults/(?P<id>\d+)', per_views.ExportAssessmentToCSVViewset.as_view({'get': 'retrieve'})),
+    url(r'^api/v2/exportperresults/(?P<id>\d+)', per_views.ExportAssessmentToCSVViewset.as_view()),
     url(r'^docs/', include_docs_urls(title='IFRC Go API')),
     url(r'^tinymce/', include('tinymce.urls')),
     url(r'^admin/', RedirectView.as_view(url='/')),

--- a/main/urls.py
+++ b/main/urls.py
@@ -157,7 +157,7 @@ urlpatterns = [
     url(r'^api/v2/', include(router.urls)),
     url(r'^api/v2/event/(?P<pk>\d+)', api_views.EventViewset.as_view({'get': 'retrieve'})),
     url(r'^api/v2/event/(?P<slug>[-\w]+)', api_views.EventViewset.as_view({'get': 'retrieve'}, lookup_field='slug')),
-    url(r'^api/v2/exportperresults/(?P<id>\d+)', per_views.ExportAssessmentToCSVViewset.as_view()),
+    url(r'^api/v2/exportperresults/(?P<id>\d+)', per_views.ExportAssessmentToCSVViewset.as_view({'get': 'retrieve'})),
     url(r'^docs/', include_docs_urls(title='IFRC Go API')),
     url(r'^tinymce/', include('tinymce.urls')),
     url(r'^admin/', RedirectView.as_view(url='/')),

--- a/main/urls.py
+++ b/main/urls.py
@@ -157,6 +157,7 @@ urlpatterns = [
     url(r'^api/v2/', include(router.urls)),
     url(r'^api/v2/event/(?P<pk>\d+)', api_views.EventViewset.as_view({'get': 'retrieve'})),
     url(r'^api/v2/event/(?P<slug>[-\w]+)', api_views.EventViewset.as_view({'get': 'retrieve'}, lookup_field='slug')),
+    url(r'^api/v2/exportperresults/(?P<id>\d+)', per_views.ExportAssessmentToCSVViewset.as_view()),
     url(r'^docs/', include_docs_urls(title='IFRC Go API')),
     url(r'^tinymce/', include('tinymce.urls')),
     url(r'^admin/', RedirectView.as_view(url='/')),

--- a/per/drf_views.py
+++ b/per/drf_views.py
@@ -560,12 +560,13 @@ class ExportAssessmentToCSVViewset(APIView):
     serializer_class = LatestCountryOverviewSerializer
 
     def get(self, request):
+        # TODO: Add Overview data too
         overview_id = request.GET.get('overview_id', None)
-        user = request.user
+        # user = request.user
 
         if overview_id:
-            # FIXME: permissions, instead of user, check for PER group / country
-            ov = Overview.objects.filter(id=overview_id, user=user).first()
+            # FIXME: permissions, check for PER group / country
+            ov = Overview.objects.filter(id=overview_id).first()
             if not ov:
                 return None
 
@@ -583,7 +584,12 @@ class ExportAssessmentToCSVViewset(APIView):
                     'selected_answer'
                 )
                 .filter(form__overview__id=ov.id)
-                .order_by('question__component__component_num', 'question__question_num')
+                .order_by(
+                    'question__component__component_num',
+                    'question__question_num',
+                    'question__is_epi',
+                    'question__is_benchmark'
+                )
             )
             for fd in form_data:
                 bench_epi = ''
@@ -595,7 +601,7 @@ class ExportAssessmentToCSVViewset(APIView):
                     fd.question.component.component_num,
                     fd.question.question_num,
                     bench_epi,
-                    fd.selected_answer.text,
+                    fd.selected_answer.text if fd.selected_answer else '',
                     fd.notes
                 ])
 

--- a/per/drf_views.py
+++ b/per/drf_views.py
@@ -1,6 +1,7 @@
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework import viewsets
+from rest_framework.views import APIView
 from django.http import HttpResponse
 from django_filters import rest_framework as filters
 from django.db.models import Q
@@ -553,14 +554,14 @@ class LatestCountryOverviewViewset(viewsets.ReadOnlyModelViewSet):
         return None
 
 
-class ExportAssessmentToCSVViewset(viewsets.ReadOnlyModelViewSet):
+class ExportAssessmentToCSVViewset(APIView):
     authentication_classes = (TokenAuthentication,)
     permission_classes = (IsAuthenticated,)
     serializer_class = LatestCountryOverviewSerializer
 
-    def get_queryset(self):
-        overview_id = self.request.GET.get('overview_id', None)
-        user = self.request.user
+    def get(self, request):
+        overview_id = request.GET.get('overview_id', None)
+        user = request.user
 
         if overview_id:
             # FIXME: permissions, instead of user, check for PER group / country


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-frontend/issues/1667

# Changes
- Add CSV export endpoint for PER which contains all the forms' submitted data (Overview excluded)