### PR TITLE
add endpoint to fetch deployents aggregated by emergency

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -494,6 +494,24 @@ class ListEventDeploymentsSerializer(serializers.Serializer):
     deployments = serializers.IntegerField()
 
 
+class DeploymentsByEventSerializer(ModelSerializer):
+    personnel_count = serializers.IntegerField(source='personnel__count')
+    organizations_from = serializers.SerializerMethodField()
+
+    def get_organizations_from(self, obj):
+        deployments = [d for d in obj.personneldeployment_set.all()]
+        personnels = []
+        for d in deployments:
+            for p in d.personnel_set.all():
+                personnels.append(p)
+        return [p.country_from.society_name for p in personnels if p.country_from and p.country_from.society_name != '']
+
+    class Meta:
+        model = Event
+        fields = (
+            'id', 'name', 'personnel_count', 'organizations_from',
+        )
+
 class DetailEventSerializer(EnumSupportSerializerMixin, ModelSerializer):
     appeals = RelatedAppealSerializer(many=True, read_only=True)
     contacts = EventContactSerializer(many=True, read_only=True)

--- a/main/urls.py
+++ b/main/urls.py
@@ -90,6 +90,7 @@ router.register(r'featured_event_deployments', api_views.EventDeploymentsViewset
 router.register(r'eru_owner', deployment_views.ERUOwnerViewset)
 router.register(r'personnel_deployment', deployment_views.PersonnelDeploymentViewset)
 router.register(r'personnel', deployment_views.PersonnelViewset)
+router.register(r'personnel_by_event', api_views.DeploymentsByEventViewset)
 router.register(r'partner_deployment', deployment_views.PartnerDeploymentViewset)
 router.register(r'surge_alert', notification_views.SurgeAlertViewset)
 router.register(r'subscription', notification_views.SubscriptionViewset, base_name='subscription')


### PR DESCRIPTION
Addresses https://github.com/IFRCGo/go-frontend/issues/1666

To support the new table on the Deployments page which lists deployments grouped by emergencies, a new end-point to return Emergencies with counts of deployments and a list of organizations deploying to that emergency.

The new endpoint is `/api/v2/personnel_by_event` returns a list of events, with the following info:

id, name, organizations_from, and personnel_count

This will be consumed by the frontend to show the new deployments table on the deployments page.



## Changes

* New URL, Serializer and Viewset for `/personnel_by_event` end-point
