### PR TITLE
filter event personnel table by active deployments

### DIFF
--- a/api/drf_views.py
+++ b/api/drf_views.py
@@ -1,3 +1,4 @@
+import datetime
 from rest_framework.status import HTTP_201_CREATED, HTTP_200_OK
 from rest_framework.generics import GenericAPIView, CreateAPIView, UpdateAPIView
 from rest_framework.response import Response
@@ -111,6 +112,7 @@ class DeploymentsByEventViewset(viewsets.ReadOnlyModelViewSet):
     queryset = Event.objects.annotate(personnel__count=Count('personneldeployment__personnel')) \
                             .prefetch_related('personneldeployment_set__personnel_set__country_from') \
                             .filter(personnel__count__gt=0) \
+                            .filter(personneldeployment__personnel__end_date__gt=datetime.datetime.now()) \
                             .order_by('-disaster_start_date')
 
 


### PR DESCRIPTION
In the personnel-by-event view, only show active deployments (i.e. filter by date).

cc @GregoryHorvath 