### PR TITLE
filter personnel by event endpoint for Rapid Response personnel

### DIFF
--- a/api/drf_views.py
+++ b/api/drf_views.py
@@ -112,6 +112,7 @@ class DeploymentsByEventViewset(viewsets.ReadOnlyModelViewSet):
     queryset = Event.objects.annotate(personnel__count=Count('personneldeployment__personnel')) \
                             .prefetch_related('personneldeployment_set__personnel_set__country_from') \
                             .filter(personnel__count__gt=0) \
+                            .filter(personneldeployment__personnel__type=Personnel.RR) \
                             .filter(personneldeployment__personnel__end_date__gt=datetime.datetime.now()) \
                             .order_by('-disaster_start_date')
 


### PR DESCRIPTION
This should fix filtering for only Rapid Response deployments on the Personnel by Emergencies table on the Deployments page.

Let's wait for a ticket and a check on what the data and expected results look like before we deploy this.

cc @GregoryHorvath 