### PR TITLE
get personnel counts more directly rather than using annotate, fix co…

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -42,6 +42,7 @@ from .models import (
     FieldReport,
 )
 from notifications.models import Subscription
+from deployments.models import Personnel
 
 
 class DisasterTypeSerializer(ModelSerializer):
@@ -495,7 +496,7 @@ class ListEventDeploymentsSerializer(serializers.Serializer):
 
 
 class DeploymentsByEventSerializer(ModelSerializer):
-    personnel_count = serializers.IntegerField(source='personnel__count')
+    personnel_count = serializers.SerializerMethodField()
     organizations_from = serializers.SerializerMethodField()
 
     def get_organizations_from(self, obj):
@@ -505,6 +506,9 @@ class DeploymentsByEventSerializer(ModelSerializer):
             for p in d.personnel_set.all():
                 personnels.append(p)
         return [p.country_from.society_name for p in personnels if p.country_from and p.country_from.society_name != '']
+
+    def get_personnel_count(self, obj):
+        return Personnel.objects.filter(type=Personnel.RR).filter(deployment__event=obj.id).count()
 
     class Meta:
         model = Event


### PR DESCRIPTION
Turns out the ORM query doing counts via annotate was just not returning counts as expected.

This is slightly less efficient in the DB, but should fix this and we can investigate a more optimal way to do this later.

cc @GregoryHorvath 