### PR TITLE
filter deployment counts by end date

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,4 +1,5 @@
 import json
+import datetime
 from rest_framework import serializers
 from django.contrib.auth.models import User
 from enumfields.drf.serializers import EnumSupportSerializerMixin
@@ -508,7 +509,10 @@ class DeploymentsByEventSerializer(ModelSerializer):
         return [p.country_from.society_name for p in personnels if p.country_from and p.country_from.society_name != '']
 
     def get_personnel_count(self, obj):
-        return Personnel.objects.filter(type=Personnel.RR).filter(deployment__event_deployed_to=obj.id).count()
+        return Personnel.objects.filter(type=Personnel.RR) \
+                                .filter(deployment__event_deployed_to=obj.id)\
+                                .filter(end_date__gte=datetime.datetime.now())\
+                                .count()
 
     class Meta:
         model = Event


### PR DESCRIPTION
Adds date filter to deployment counts to only show counts for active deployments.

@GregoryHorvath 