### PR TITLE
[Hotfix] Include request_assistance in 'mini' Field Report serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 1.1.307
+
+### Added
+ - Hotfix to add request_assistance to FR serializer
+
 ## 1.1.306
 
 ### Added
@@ -1307,7 +1312,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 0.1.20
 
-[Unreleased]: https://github.com/IFRCGo/go-api/compare/1.2.306...HEAD
+[Unreleased]: https://github.com/IFRCGo/go-api/compare/1.2.307...HEAD
+[1.2.307]: https://github.com/IFRCGo/go-api/compare/1.2.306...1.1.307
 [1.2.306]: https://github.com/IFRCGo/go-api/compare/1.2.305...1.1.306
 [1.2.305]: https://github.com/IFRCGo/go-api/compare/1.2.304...1.1.305
 [1.2.304]: https://github.com/IFRCGo/go-api/compare/1.2.303...1.1.304

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -360,7 +360,7 @@ class MiniFieldReportSerializer(EnumSupportSerializerMixin, ModelSerializer):
             'gov_num_highest_risk', 'other_num_highest_risk', 'affected_pop_centres', 'gov_affected_pop_centres',
             'other_affected_pop_centres', 'epi_cases', 'epi_suspected_cases', 'epi_probable_cases', 'epi_confirmed_cases',
             'epi_figures_source', 'epi_figures_source_display',
-            'visibility', 'visibility_display',
+            'visibility', 'visibility_display', 'request_assistance', 'ns_request_assistance'
         )
 
 

--- a/main/__init__.py
+++ b/main/__init__.py
@@ -3,5 +3,4 @@
 from .celery import app as celery_app
 
 __all__ = ['celery_app']
-__version__ = '1.1.305'
-__version__ = '1.1.306'
+__version__ = '1.1.307'


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-frontend/issues/1789

## Changes
- Added `request_assistance` and `ns_request_assistance` fields to the `MiniFieldReportSerializer`