### PR TITLE
Elasticsearch - index Countries, skip empty society_names, refactors

### DIFF
--- a/api/management/commands/index_elasticsearch.py
+++ b/api/management/commands/index_elasticsearch.py
@@ -4,6 +4,7 @@ from elasticsearch.client import IndicesClient
 from elasticsearch.helpers import bulk
 from elasticsearch import Elasticsearch
 
+from utils.elasticsearch import construct_es_data
 from api.esconnection import ES_CLIENT
 from api.indexes import GenericMapping, GenericSetting, ES_PAGE_NAME
 from api.models import Region, Country, Event, Appeal, FieldReport
@@ -45,24 +46,15 @@ class Command(BaseCommand):
     def push_table_to_index(self, model):
         if model.__name__ == 'Event':
             query = model.objects.filter(parent_event__isnull=True)
+        elif model.__name__ == 'Country':
+            query = model.objects.filter(society_name__isnull=False)
         else:
             query = model.objects.all()
         data = [
-            self.convert_for_bulk(s) for s in list(query)
+            construct_es_data(s, is_create=True) for s in list(query)
         ]
         created, errors = bulk(client=ES_CLIENT, actions=data)
         logger.info('Created %s records' % created)
         if len(errors):
             logger.error('Produced the following errors:')
             logger.error('[%s]' % ', '.join(map(str, errors)))
-
-    def convert_for_bulk(self, model_object):
-        data = model_object.indexing()
-        metadata = {
-            '_op_type': 'create',
-            '_index': ES_PAGE_NAME,
-            '_type': 'page',
-            '_id': model_object.es_id(),
-        }
-        data.update(**metadata)
-        return data

--- a/utils/elasticsearch.py
+++ b/utils/elasticsearch.py
@@ -1,0 +1,55 @@
+from api.logger import logger
+from api.indexes import ES_PAGE_NAME
+from api.esconnection import ES_CLIENT
+from elasticsearch.helpers import bulk
+
+
+def log_errors(errors):
+    if len(errors):
+        logger.error('Produced the following errors:')
+        logger.error('[%s]' % ', '.join(map(str, errors)))
+
+
+def delete_es_index(instance):
+    ''' instance needs an es_id() '''
+    if hasattr(instance, 'es_id'):
+        try:
+            deleted, errors = bulk(client=ES_CLIENT, actions=[{
+                '_op_type': 'delete',
+                '_index': ES_PAGE_NAME,
+                '_type': 'page',
+                '_id': instance.es_id()
+            }])
+            logger.info(f'Deleted {deleted} records')
+            log_errors(errors)
+        except Exception:
+            logger.error('Could not reach Elasticsearch server or index was already missing.')
+    else:
+        logger.warn('instance does not have an es_id() method')
+
+
+def construct_es_data(instance, is_create=False):
+    data = instance.indexing()
+    metadata = {
+        '_op_type': 'create' if is_create else 'update',
+        '_index': ES_PAGE_NAME,
+        '_type': 'page',
+        '_id': instance.es_id(),
+    }
+    if (is_create):
+        metadata.update(**data)
+    else:
+        metadata['doc'] = data
+    return metadata
+
+
+def create_es_index(instance):
+    created, errors = bulk(client=ES_CLIENT, actions=[construct_es_data(instance, True)])
+    logger.info(f'Created {created} records')
+    log_errors(errors)
+
+
+def update_es_index(instance):
+    updated, errors = bulk(client=ES_CLIENT, actions=[construct_es_data(instance)])
+    logger.info('Updated {updated} records')
+    log_errors(errors)

--- a/utils/elasticsearch.py
+++ b/utils/elasticsearch.py
@@ -12,20 +12,23 @@ def log_errors(errors):
 
 def delete_es_index(instance):
     ''' instance needs an es_id() '''
-    if hasattr(instance, 'es_id'):
-        try:
-            deleted, errors = bulk(client=ES_CLIENT, actions=[{
-                '_op_type': 'delete',
-                '_index': ES_PAGE_NAME,
-                '_type': 'page',
-                '_id': instance.es_id()
-            }])
-            logger.info(f'Deleted {deleted} records')
-            log_errors(errors)
-        except Exception:
-            logger.error('Could not reach Elasticsearch server or index was already missing.')
-    else:
-        logger.warn('instance does not have an es_id() method')
+
+    if ES_CLIENT and ES_PAGE_NAME:
+        # To make sure it doesn't run for tests
+        if hasattr(instance, 'es_id'):
+            try:
+                deleted, errors = bulk(client=ES_CLIENT, actions=[{
+                    '_op_type': 'delete',
+                    '_index': ES_PAGE_NAME,
+                    '_type': 'page',
+                    '_id': instance.es_id()
+                }])
+                logger.info(f'Deleted {deleted} records')
+                log_errors(errors)
+            except Exception:
+                logger.error('Could not reach Elasticsearch server or index was already missing.')
+        else:
+            logger.warn('instance does not have an es_id() method')
 
 
 def construct_es_data(instance, is_create=False):
@@ -44,12 +47,20 @@ def construct_es_data(instance, is_create=False):
 
 
 def create_es_index(instance):
-    created, errors = bulk(client=ES_CLIENT, actions=[construct_es_data(instance, True)])
-    logger.info(f'Created {created} records')
-    log_errors(errors)
+    ''' Creates an Elasticsearch index from the record instance '''
+
+    if ES_CLIENT and ES_PAGE_NAME:
+        # To make sure it doesn't run for tests
+        created, errors = bulk(client=ES_CLIENT, actions=[construct_es_data(instance, True)])
+        logger.info(f'Created {created} records')
+        log_errors(errors)
 
 
 def update_es_index(instance):
-    updated, errors = bulk(client=ES_CLIENT, actions=[construct_es_data(instance)])
-    logger.info('Updated {updated} records')
-    log_errors(errors)
+    ''' Updates the Elasticsearch index from the record instance '''
+
+    if ES_CLIENT and ES_PAGE_NAME:
+        # To make sure it doesn't run for tests
+        updated, errors = bulk(client=ES_CLIENT, actions=[construct_es_data(instance)])
+        logger.info(f'Updated {updated} records')
+        log_errors(errors)


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-frontend/issues/1673#issuecomment-749554798

## Changes

- Refactored the base Elasticsearch functions into `utils/elasticsearch.py`: `create_es_index`, `update_es_index`, `delete_es_index`
- Added a filter to skip indexing of Countries with an empty `society_name`
- Added a receiver to handle Country indices
- Refactor a small part of `index_and_notify` to use the util function instead