### PR TITLE
Allow login with email besides username, validations

### DIFF
--- a/api/authentication_backend.py
+++ b/api/authentication_backend.py
@@ -9,7 +9,13 @@ class EmailBackend(ModelBackend):
         To allow to authenticate with email too without needing
         to implement a custom User model at this point
     """
+
     def authenticate(self, request, username=None, password=None, **kwargs):
+        '''
+            Overriding: https://github.com/django/django/blob/master/django/contrib/auth/backends.py#L36
+            most of it is working the same, only added a few more checks needed for the email auth
+        '''
+
         # To make 'finally' work becase we have 'MultipleObjectsReturned' exception
         # which could still result in a valid login
         user = None
@@ -19,6 +25,8 @@ class EmailBackend(ModelBackend):
             user = UserModel.objects.get(Q(username__iexact=username) | Q(email__iexact=username))
         except UserModel.DoesNotExist:
             shouldcheck = False
+            # Run the default password hasher once to reduce the timing
+            # difference between an existing and a nonexistent user (#20760).
             UserModel().set_password(password)
         except MultipleObjectsReturned:
             user = User.objects.filter(Q(username__iexact=username) | Q(email__iexact=username)).order_by('id').first()

--- a/api/authentication_backend.py
+++ b/api/authentication_backend.py
@@ -1,0 +1,38 @@
+from django.contrib.auth.backends import ModelBackend, UserModel
+from django.contrib.auth.models import User
+from django.core.exceptions import MultipleObjectsReturned
+from django.db.models import Q
+
+
+class EmailBackend(ModelBackend):
+    """
+        To allow to authenticate with email too without needing
+        to implement a custom User model at this point
+    """
+    def authenticate(self, request, username=None, password=None, **kwargs):
+        # To make 'finally' work becase we have 'MultipleObjectsReturned' exception
+        # which could still result in a valid login
+        user = None
+        shouldcheck = True
+
+        try:
+            user = UserModel.objects.get(Q(username__iexact=username) | Q(email__iexact=username))
+        except UserModel.DoesNotExist:
+            shouldcheck = False
+            UserModel().set_password(password)
+        except MultipleObjectsReturned:
+            user = User.objects.filter(Q(username__iexact=username) | Q(email__iexact=username)).order_by('id').first()
+
+        if shouldcheck and \
+                user and \
+                user.check_password(password) and \
+                self.user_can_authenticate(user):
+            return user
+
+    def get_user(self, user_id):
+        try:
+            user = UserModel.objects.get(pk=user_id)
+        except UserModel.DoesNotExist:
+            return None
+
+        return user if self.user_can_authenticate(user) else None

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -662,6 +662,7 @@ class UserSerializer(ModelSerializer):
             profile.save()
         instance.first_name = validated_data.get('first_name', instance.first_name)
         instance.last_name = validated_data.get('last_name', instance.last_name)
+        instance.email = validated_data.get('email', instance.email)
         instance.save()
         return instance
 

--- a/api/views.py
+++ b/api/views.py
@@ -10,6 +10,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import User
+from django.contrib.auth.password_validation import validate_password
 from django.conf import settings
 from django.views import View
 from django.db.models.functions import TruncMonth, TruncYear
@@ -316,9 +317,13 @@ class ChangePassword(APIView):
         if username is None or (password is None and token is None):
             return bad_request('Must include a `username` and either a `password` or `token`')
 
-        # TODO validate password
         if new_pass is None:
             return bad_request('Must include a `new_password` property')
+        try:
+            validate_password(new_pass)
+        except Exception as exc:
+            ers = ' '.join(str(err) for err in exc)
+            return bad_request(ers)
 
         user = User.objects.filter(username__iexact=username).first()
         if user is None:

--- a/api/views.py
+++ b/api/views.py
@@ -275,11 +275,6 @@ class GetAuthToken(APIView):
         if username is None or password is None:
             return bad_request('Body must contain `email/username` and `password`')
 
-        # Get the case-correct username for authenticate()
-        # casecorr_uname = User.objects.filter(username__iexact=username).values_list('username', flat=True).first()
-        # if casecorr_uname is None:
-        #     return bad_request('Invalid email/username or password')  # definitely username issue
-
         user = authenticate(username=username, password=password)
         if user is not None:
             api_key, created = Token.objects.get_or_create(user=user)

--- a/api/views.py
+++ b/api/views.py
@@ -272,15 +272,14 @@ class GetAuthToken(APIView):
         password = request.data.get('password', None)
 
         if username is None or password is None:
-            return bad_request('Body must contain `username` and `password`')
+            return bad_request('Body must contain `email/username` and `password`')
 
         # Get the case-correct username for authenticate()
-        casecorr_uname = User.objects.filter(username__iexact=username).values_list('username', flat=True).first()
-        if casecorr_uname is None:
-            return bad_request('Invalid username or password')  # definitely username issue
+        # casecorr_uname = User.objects.filter(username__iexact=username).values_list('username', flat=True).first()
+        # if casecorr_uname is None:
+        #     return bad_request('Invalid email/username or password')  # definitely username issue
 
-        # User model's __str__ is its username
-        user = authenticate(username=casecorr_uname, password=password)
+        user = authenticate(username=username, password=password)
         if user is not None:
             api_key, created = Token.objects.get_or_create(user=user)
 

--- a/api/views.py
+++ b/api/views.py
@@ -14,7 +14,7 @@ from django.contrib.auth.password_validation import validate_password
 from django.conf import settings
 from django.views import View
 from django.db.models.functions import TruncMonth, TruncYear
-from django.db.models import Count, Sum
+from django.db.models import Count, Sum, Q
 from django.utils import timezone
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.crypto import get_random_string
@@ -399,7 +399,10 @@ class ResendValidation(APIView):
         username = request.data.get('username', None)
 
         if username:
-            pending_user = Pending.objects.select_related('user').filter(user__username__iexact=username).first()
+            # Now we allow requesting with either email or username
+            pending_user = Pending.objects.select_related('user')\
+                                          .filter(Q(user__username__iexact=username) | Q(user__email__iexact=username))\
+                                          .first()
             if pending_user:
                 if pending_user.user.is_active is True:
                     return bad_request('Your registration is already active, \

--- a/main/settings.py
+++ b/main/settings.py
@@ -149,7 +149,8 @@ MIDDLEWARE = [
 ]
 
 AUTHENTICATION_BACKENDS = (
-    'django.contrib.auth.backends.ModelBackend',
+    # 'django.contrib.auth.backends.ModelBackend',
+    'api.authentication_backend.EmailBackend',
     'guardian.backends.ObjectPermissionBackend',
 )
 

--- a/registrations/test_views.py
+++ b/registrations/test_views.py
@@ -26,9 +26,10 @@ class TwoGatekeepersTest(APITestCase):
         # 1. Created two users to function as gatekeepers (with checkable email)
         # 2a. Making a request to views.NewRegistration with new user request
         country = Country.objects.get(name='country')
-        newusr = 'pe'
+        # We started to use the email as the username for new registrations
+        newusr = 'pe@doesnotexist.hu'
         body = {
-            'email': 'pe@doesnotexist.hu',
+            'email': newusr,
             'username': newusr,
             'password': '87654321',
             'country': country.pk,
@@ -91,9 +92,10 @@ class TwoGatekeepersTest(APITestCase):
     def test_official_email(self):
         # 2b. Making a request to views.NewRegistration with new user request
         country = Country.objects.get(name='country')
-        newusr = 'pet'
+        # We started to use the email as the username for new registrations
+        newusr = 'pet@voroskereszt.hu'
         body = {
-            'email': 'pet@voroskereszt.hu',
+            'email': newusr,
             'username': newusr,
             'password': '87654321',
             'country': country.pk,

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -77,7 +77,7 @@ class NewRegistration(APIView):
     def post(self, request):
         required_fields = (
             'email',
-            'username',
+            # 'username',
             'password',
             'country',
             'organizationType',
@@ -91,7 +91,9 @@ class NewRegistration(APIView):
             return bad_request('Could not complete request. Please submit %s' % ', '.join(missing_fields))
 
         email = request.data.get('email', None)
-        username = request.data.get('username', None)
+        # Since username is a required field we still need to fill it in
+        # but now only email is being used for new registrations
+        username = request.data.get('email', None)
         password = request.data.get('password', None)
         firstname = request.data.get('firstname', None)
         lastname = request.data.get('lastname', None)


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-frontend/issues/1663

## Changes

- Added new Authentication Backend to also check against `email` when authenticating. This is also a workaround to have a `CustomUser` model (`username` is a required field by default in Django's `User` model) which would mean we would need to migrate existing User data (and their relations) to this new model.
- Added validation for password reset/change, so now users should get an error message whenever they try to use an invalid password. Currently even invalid passwords are getting saved, yet the application won't let them login with that password.
- Removed `username` / added `email`, from/to required fields where they were needed.
- New registrations now automatically fill in the `username` with the `email`.
- Adjusted New Registration tests to follow this scheme.