### PR TITLE
Add in_search init set management command

### DIFF
--- a/api/management/commands/set_in_search_init.py
+++ b/api/management/commands/set_in_search_init.py
@@ -1,0 +1,21 @@
+from django.core.management.base import BaseCommand
+from api.models import Country
+from django.db import transaction
+from django.db.models import Q
+from api.logger import logger
+
+
+class Command(BaseCommand):
+    help = 'Update Countries initially to set/revoke their in_search field (probably one-time run only)'
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        try:
+            # Update countries which should appear in search
+            inc_c = Country.objects.filter(disputed=False, record_type=1).update(in_search=True)
+            # Update countries which should NOT appear in search
+            exc_c = Country.objects.filter(Q(disputed=True) | ~Q(record_type=1)).update(in_search=False)
+            logger.info('Successfully set in_search for Countries')
+        except Exception as ex:
+            logger.error(f'Failed to set in_search for Countries. Error: {str(ex)}')
+

--- a/api/management/commands/set_in_search_init.py
+++ b/api/management/commands/set_in_search_init.py
@@ -12,9 +12,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         try:
             # Update countries which should appear in search
-            inc_c = Country.objects.filter(disputed=False, record_type=1).update(in_search=True)
+            inc_c = Country.objects.filter(independent=True, is_deprecated=False, record_type=1).update(in_search=True)
             # Update countries which should NOT appear in search
-            exc_c = Country.objects.filter(Q(disputed=True) | ~Q(record_type=1)).update(in_search=False)
+            # independent can be null too thus why negated check
+            exc_c = Country.objects.filter(~Q(independent=True) | Q(is_deprecated=True) | ~Q(record_type=1)).update(in_search=False)
             logger.info('Successfully set in_search for Countries')
         except Exception as ex:
             logger.error(f'Failed to set in_search for Countries. Error: {str(ex)}')


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-frontend/issues/1643#issuecomment-774510978

To be initially ran script, to include/exclude Countries from search.

Included conditions:
- `independent = True`
- `is_deprecated = False`
- `record_type = 1` (record type = Country)