### PR TITLE
Fix country uppercase migration issue

### DIFF
--- a/api/migrations/0101_uppercase_iso.py
+++ b/api/migrations/0101_uppercase_iso.py
@@ -1,27 +1,20 @@
+from django.db.models.functions import Upper
 from django.db import migrations, models
 
-def uppercase_iso(apps, schema_editor):
-  Country = apps.get_model('api', 'Country')
-  for country in Country.objects.all():
-    if country.iso:
-      country.iso = country.iso.upper()
-      country.save()
 
-    if country.iso3:
-      country.iso3 = country.iso3.upper()
-      country.save()
-  
-  District = apps.get_model('api', 'District')
-  for district in District.objects.all():
-    if district.country_iso:
-      district.country_iso = district.country_iso.upper()
-      district.save()
+def uppercase_iso(apps, schema_editor):
+    Country = apps.get_model('api', 'Country')
+    District = apps.get_model('api', 'District')
+
+    Country.objects.update(iso3=Upper('iso3'), iso=Upper('iso'))
+    District.objects.update(country_iso=Upper('country_iso'))
+
 
 class Migration(migrations.Migration):
-  dependencies = [
-    ('api', '0100_auto_20201130_0954'),
-  ]
+    dependencies = [
+        ('api', '0100_auto_20201130_0954'),
+    ]
 
-  operations = [
-    migrations.RunPython(uppercase_iso),
-  ]
+    operations = [
+        migrations.RunPython(uppercase_iso),
+    ]


### PR DESCRIPTION
Addresses https://github.com/IFRCGo/go-api/issues/1048 

## Changes

* Update migration using `objects.update`.