### PR TITLE
Add custom permission for Translation Dashboard

### DIFF
--- a/api/drf_views.py
+++ b/api/drf_views.py
@@ -10,16 +10,14 @@ from django.http import Http404
 from django_filters import rest_framework as filters
 from django.contrib.auth.models import User
 from django.db import models
-from django.db.models import Prefetch, Q, Count
+from django.db.models import Prefetch, Count
 from django.utils import timezone
 from .event_sources import SOURCES
 from .exceptions import BadRequest
-from .utils import is_user_ifrc
 from main.utils import is_tableau
 from .view_filters import ListFilter
 from .visibility_class import ReadOnlyVisibilityViewset
 from deployments.models import Personnel
-from per.models import Overview
 
 from .models import (
     DisasterType,
@@ -36,7 +34,6 @@ from .models import (
 
     District,
 
-    Snippet,
     Event,
     Snippet,
     SituationReport,
@@ -64,13 +61,11 @@ from .serializers import (
     ExternalPartnerSerializer,
     SupportedActivitySerializer,
 
-    RegionSerializer,
     RegionGeoSerializer,
     RegionKeyFigureSerializer,
     RegionSnippetSerializer,
     RegionRelationSerializer,
 
-    CountrySerializer,
     CountryGeoSerializer,
     MiniCountrySerializer,
     CountryKeyFigureSerializer,
@@ -78,7 +73,6 @@ from .serializers import (
     CountryRelationSerializer,
 
     DistrictSerializer,
-    MiniDistrictSerializer,
     MiniDistrictGeoSerializer,
 
     SnippetSerializer,
@@ -113,6 +107,7 @@ from .serializers import (
 )
 from .logger import logger
 
+
 class DeploymentsByEventViewset(viewsets.ReadOnlyModelViewSet):
     serializer_class = DeploymentsByEventSerializer
     queryset = Event.objects.prefetch_related('personneldeployment_set__personnel_set__country_from') \
@@ -121,7 +116,6 @@ class DeploymentsByEventViewset(viewsets.ReadOnlyModelViewSet):
                             .annotate(personnel__count=Count('personneldeployment__personnel')) \
                             .filter(personnel__count__gt=0) \
                             .order_by('-disaster_start_date')
-
 
 
 class EventDeploymentsViewset(viewsets.ReadOnlyModelViewSet):
@@ -664,7 +658,7 @@ class GenericFieldReportView(GenericAPIView):
                     data[prop] = model.objects.get(pk=data[prop])
                 except Exception:
                     raise BadRequest('Valid %s is required' % prop)
-            elif prop is not 'event':
+            elif prop != 'event':
                 raise BadRequest('Valid %s is required' % prop)
 
         return data

--- a/api/management/commands/make_permissions.py
+++ b/api/management/commands/make_permissions.py
@@ -1,21 +1,30 @@
+from collections import defaultdict
+
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.auth import get_permission_codename
 from django.core.management.base import BaseCommand
 from django.contrib.auth.models import Group, Permission
-from django.contrib.contenttypes.models import ContentType
+from django.conf import settings
+
 from api.models import Country, Region
+from lang.models import String
+
 
 class Command(BaseCommand):
     help = 'Create standard geographic permissions classes and groups'
 
     def handle(self, *args, **options):
+        print('- Creating/Updating permissions/groups for countries')
         country_content_type = ContentType.objects.get_for_model(Country)
         countries = Country.objects.all()
         for country in countries:
+            print(f'\t-> {country}')
             codename = 'country_admin_%s' % country.id
             name = 'Admin for %s' % country.name
             permission, created = Permission.objects.get_or_create(
                 codename=codename,
-                name=name,
-                content_type=country_content_type
+                content_type=country_content_type,
+                defaults=dict(name=name),
             )
             # If it's a new permission, create a group for it
             group, created = Group.objects.get_or_create(
@@ -23,15 +32,17 @@ class Command(BaseCommand):
             )
             group.permissions.add(permission)
 
+        print('- Creating/Updating permissions/groups for regions')
         region_content_type = ContentType.objects.get_for_model(Region)
         regions = Region.objects.all()
         for region in regions:
+            print(f'\t-> {region}')
             codename = 'region_admin_%s' % region.id
             name = 'Admin for %s' % region.name
             permission, created = Permission.objects.get_or_create(
                 codename=codename,
-                name=name,
-                content_type=region_content_type
+                content_type=region_content_type,
+                defaults=dict(name=name),
             )
             # If it's a new permission, create a group for it
             group, created = Group.objects.get_or_create(
@@ -39,6 +50,7 @@ class Command(BaseCommand):
             )
             group.permissions.add(permission)
 
+        print('- Creating/Updating permissions/groups for IFRC Admin')
         # Create an IFRC permission and attach it to a group
         ifrc_permission, perm_created = Permission.objects.get_or_create(
             codename='ifrc_admin',
@@ -50,3 +62,24 @@ class Command(BaseCommand):
             name='IFRC Admins'
         )
         ifrc_group.permissions.add(ifrc_permission)
+
+        print('- Creating/Updating permissions/groups for Language')
+        # Language permission
+        string_content_type = ContentType.objects.get_for_model(String)
+        lang_permissions = defaultdict(list)
+        for lang_code, _ in settings.LANGUAGES:
+            print(f'\t-> {lang_code}')
+            lang_permission, _ = Permission.objects.get_or_create(
+                codename=f'lang__string__maintain__{lang_code}',
+                content_type=string_content_type,
+                defaults=dict(name=f'Language <{lang_code}> (API Level Access)'),
+            )
+            lang_permissions[lang_code] = lang_permission
+
+        language_maintainers_group, _ = Group.objects.get_or_create(name='Language maintainers (Admin Panel)')
+        language_maintainers_group.permissions.add(
+            *[
+                Permission.objects.get(codename=get_permission_codename(action, String._meta))
+                for action in ['view', 'add', 'change', 'delete']
+            ]
+        )

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import User
 from enumfields.drf.serializers import EnumSupportSerializerMixin
 
 from lang.serializers import ModelSerializer
+from lang.models import String
 from .models import (
     DisasterType,
     ExternalPartner,
@@ -33,7 +34,6 @@ from .models import (
     SituationReport,
 
     Appeal,
-    AppealType,
     AppealDocument,
 
     Profile,
@@ -275,10 +275,10 @@ class RegionRelationSerializer(EnumSupportSerializerMixin, ModelSerializer):
 
     def get_national_society_count(self, obj):
         return obj.get_national_society_count()
-    
+
     def get_country_cluster_count(self, obj):
         return obj.get_country_cluster_count()
-        
+
     class Meta:
         model = Region
         fields = ('links', 'contacts', 'snippets', 'emergency_snippets',
@@ -524,6 +524,7 @@ class DeploymentsByEventSerializer(ModelSerializer):
             'id', 'name', 'personnel_count', 'organizations_from',
         )
 
+
 class DetailEventSerializer(EnumSupportSerializerMixin, ModelSerializer):
     appeals = RelatedAppealSerializer(many=True, read_only=True)
     contacts = EventContactSerializer(many=True, read_only=True)
@@ -538,8 +539,8 @@ class DetailEventSerializer(EnumSupportSerializerMixin, ModelSerializer):
         fields = (
             'name', 'dtype', 'countries', 'districts', 'summary', 'num_affected', 'tab_two_title', 'tab_three_title',
             'disaster_start_date', 'created_at', 'auto_generated', 'appeals', 'contacts', 'key_figures', 'is_featured',
-            'is_featured_region', 'field_reports', 'hide_attached_field_reports', 'hide_field_report_map', 'updated_at', 'id', 'slug', 'tab_one_title',
-            'ifrc_severity_level', 'ifrc_severity_level_display', 'parent_event', 'glide',
+            'is_featured_region', 'field_reports', 'hide_attached_field_reports', 'hide_field_report_map', 'updated_at',
+            'id', 'slug', 'tab_one_title', 'ifrc_severity_level', 'ifrc_severity_level_display', 'parent_event', 'glide',
         )
         lookup_field = 'slug'
 
@@ -683,10 +684,13 @@ class UserNameSerializer(UserSerializer):
 class UserMeSerializer(UserSerializer):
     is_admin_for_countries = serializers.SerializerMethodField()
     is_admin_for_regions = serializers.SerializerMethodField()
+    lang_permissions = serializers.SerializerMethodField()
 
     class Meta:
         model = User
-        fields = UserSerializer.Meta.fields + ('is_admin_for_countries', 'is_admin_for_regions')
+        fields = UserSerializer.Meta.fields + (
+            'is_admin_for_countries', 'is_admin_for_regions', 'lang_permissions'
+        )
 
     def get_is_admin_for_countries(self, user):
         return set([
@@ -699,6 +703,9 @@ class UserMeSerializer(UserSerializer):
             int(permission[17:]) for permission in user.get_all_permissions()
             if ('api.region_admin_' in permission and permission[17:].isdigit())
         ])
+
+    def get_lang_permissions(self, user):
+        return String.get_user_permissions_per_language(user)
 
 
 class ActionSerializer(ModelSerializer):
@@ -927,4 +934,3 @@ class MainContactSerializer(ModelSerializer):
     class Meta:
         model = MainContact
         fields = '__all__'
-

--- a/lang/admin.py
+++ b/lang/admin.py
@@ -17,7 +17,7 @@ from django.shortcuts import redirect
 from django.urls import path
 from django.utils.translation import get_language
 
-from middlewares.middlewares import get_signal_request
+# from middlewares.middlewares import get_signal_request
 
 from .translation import AVAILABLE_LANGUAGES
 from .serializers import TranslatedModelSerializerMixin

--- a/lang/models.py
+++ b/lang/models.py
@@ -17,3 +17,19 @@ class String(models.Model):
 
     def __str__(self):
         return '{} ({})'.format(self.value, self.language)
+
+    @classmethod
+    def _get_permission_per_language_codename(cls, lang_code):
+        # NOTE: Make sure this is equivalent to the customly created permission code
+        return f"{cls._meta.app_label}.lang__string__maintain__{lang_code}"
+
+    @classmethod
+    def has_perm(cls, user, lang_code):
+        return user.has_perm(cls._get_permission_per_language_codename(lang_code))
+
+    @classmethod
+    def get_user_permissions_per_language(cls, user):
+        return {
+            lang_code: user.has_perm(cls._get_permission_per_language_codename(lang_code))
+            for lang_code, _ in settings.LANGUAGES
+        }

--- a/lang/permissions.py
+++ b/lang/permissions.py
@@ -1,0 +1,18 @@
+from rest_framework import permissions
+from .models import String
+
+
+class LangStringPermission(permissions.BasePermission):
+    """
+    Custom permission to only users to maintain strings
+    """
+
+    def has_permission(self, request, view):
+        # Read permissions are allowed to any request,
+        # so we'll always allow GET, HEAD or OPTIONS requests. (`view` is allowed for all)
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        return String.has_perm(request.user, view.kwargs['pk'])
+
+    def has_object_permission(self, request, view, obj):
+        return self.has_permission(self, request, view)

--- a/lang/tests.py
+++ b/lang/tests.py
@@ -1,4 +1,7 @@
 from django.conf import settings
+from django.core import management
+from django.contrib.auth import get_permission_codename
+from django.contrib.auth.models import User, Permission
 from main.test_case import APITestCase
 
 from .serializers import LanguageBulkActionSerializer
@@ -9,8 +12,9 @@ class LangTest(APITestCase):
 
     def setUp(self):
         super().setUp()
+        management.call_command('make_permissions')
 
-    def test_list_languages(self, **kwargs):
+    def test_list_languages(self):
         self.authenticate(self.user)
         resp = self.client.get('/api/v2/language/')
         j_resp = resp.json()
@@ -18,7 +22,7 @@ class LangTest(APITestCase):
         self.assertEqual(len(j_resp['results']), len(settings.LANGUAGES))
         self.assertEqual(j_resp['count'], len(settings.LANGUAGES))
 
-    def test_list_strings(self, **kwargs):
+    def test_list_strings(self):
         language = settings.LANGUAGES[0][0]
         current_strings_count = String.objects.filter(language=language).count()
         String.objects.create(language=language, key='random-key-for-language-test1', value='Random value', hash='random hash')
@@ -28,7 +32,7 @@ class LangTest(APITestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(j_resp['strings']), current_strings_count + 1)
 
-    def test_bulk_action(self, **kwargs):
+    def test_bulk_action(self):
         language = settings.LANGUAGES[0][0]
         string_1 = {
             'key': 'new-string-101',
@@ -74,3 +78,79 @@ class LangTest(APITestCase):
         second_string.pop('id')
         self.assertEqual(second_string, {**string_2, 'language': language})
         self.assertEqual(first_string_key, string_1['key'])
+
+    def test_user_me(self):
+        user = User.objects.create_user(
+            username='user@test.com',
+            first_name='User',
+            last_name='Toot',
+            password='user123',
+            email='user@test.com',
+        )
+
+        self.authenticate(user)
+
+        resp = self.client.get('/api/v2/user/me/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data['lang_permissions'], {
+            'en': False, 'es': False, 'ar': False, 'fr': False,
+        })
+
+        # Change permission and check
+        user.user_permissions.add(
+            Permission.objects.filter(codename='lang__string__maintain__en').first(),
+            Permission.objects.filter(codename='lang__string__maintain__ar').first(),
+        )
+
+        resp = self.client.get('/api/v2/user/me/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data['lang_permissions'], {
+            'en': True, 'es': False, 'ar': True, 'fr': False,
+        })
+
+        # For superuser all should be true
+        self.authenticate(self.root_user)
+        resp = self.client.get('/api/v2/user/me/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data['lang_permissions'], {
+            'en': True, 'es': True, 'ar': True, 'fr': True,
+        })
+
+    def test_lang_api_permissions(self):
+        user = User.objects.create_user(
+            username='user@test.com',
+            first_name='User',
+            last_name='Toot',
+            password='user123',
+            email='user@test.com',
+        )
+
+        language = settings.LANGUAGES[0][0]
+        string_1 = {
+            'key': 'new-string-101',
+            'value': 'New Value 101',
+            'hash': 'new-hash-101',
+        }
+        string_2 = {
+            'key': 'new-string-102',
+            'value': 'New Value 102',
+            'hash': 'new-hash-102',
+        }
+        data = {
+            'actions': [
+                {'action': LanguageBulkActionSerializer.SET, **string_1},
+                {'action': LanguageBulkActionSerializer.SET, **string_2}
+            ],
+        }
+
+        self.authenticate(user)
+        resp = self.client.post(f'/api/v2/language/{language}/bulk-action/', data, format='json')
+        self.assertEqual(resp.status_code, 403)
+
+        user.user_permissions.add(
+            Permission.objects.filter(codename=f'lang__string__maintain__{language}').first(),
+        )
+
+        self.authenticate(user)
+        resp = self.client.post(f'/api/v2/language/{language}/bulk-action/', data, format='json')
+        self.assertEqual(resp.status_code, 200)

--- a/lang/views.py
+++ b/lang/views.py
@@ -1,4 +1,6 @@
 from django.db import transaction
+
+from rest_framework.authentication import TokenAuthentication
 from rest_framework.decorators import action as djaction
 from rest_framework import (
     viewsets,
@@ -6,21 +8,19 @@ from rest_framework import (
 )
 
 from django.conf import settings
-from main.permissions import ModifyBySuperAdminOnly
+from .permissions import LangStringPermission
 from .serializers import (
     StringSerializer,
     LanguageBulkActionSerializer,
     LanguageBulkActionsSerializer,
 )
-from .models import (
-    String,
-)
+from .models import String
 
 
 class LanguageViewSet(viewsets.ViewSet):
-    # TODO: Add permission level
     # TODO: Cache retrive response to file
-    permission_classes = (ModifyBySuperAdminOnly,)
+    authentication_classes = (TokenAuthentication,)
+    permission_classes = (LangStringPermission,)
     lookup_url_kwarg = 'pk'
 
     def list(self, request, version=None):
@@ -50,7 +50,8 @@ class LanguageViewSet(viewsets.ViewSet):
 
     @transaction.atomic
     @djaction(
-        detail=True, url_path='bulk-action',
+        detail=True,
+        url_path='bulk-action',
         methods=('post',),
     )
     def bulk_action(self, request, pk=None, *args, **kwargs):


### PR DESCRIPTION
Addresses  #1052  

## Changes

* Add language level permission for translation dashboard.

![image](https://user-images.githubusercontent.com/7059255/114982074-b1d5a980-9eae-11eb-85e4-e86ae9b3cbda.png)



New permissions are added using `make_permission` command.
```bash
docker-compose exec serve bash -c 'python3 manage.py make_permissions'
```

cc: @frozenhelium 