### PR TITLE
Change datetime.datetime to timezone in DeploymentsByEventViewset

### DIFF
--- a/api/drf_views.py
+++ b/api/drf_views.py
@@ -115,7 +115,7 @@ class DeploymentsByEventViewset(viewsets.ReadOnlyModelViewSet):
     serializer_class = DeploymentsByEventSerializer
     queryset = Event.objects.prefetch_related('personneldeployment_set__personnel_set__country_from') \
                             .filter(personneldeployment__personnel__type=Personnel.RR) \
-                            .filter(personneldeployment__personnel__end_date__gt=datetime.datetime.now()) \
+                            .filter(personneldeployment__personnel__end_date__gt=timezone.now()) \
                             .annotate(personnel__count=Count('personneldeployment__personnel')) \
                             .filter(personnel__count__gt=0) \
                             .order_by('-disaster_start_date')


### PR DESCRIPTION
To avoid bootup warning about naive datetime:
/usr/local/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1427: RuntimeWarning: DateTimeField DeployedPerson.end_date received a naive datetime (2021-04-25 19:56:19.470989) while time zone support is active.
