### PR TITLE
Use general user role for project visibility

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -266,6 +266,7 @@ class DistrictGeoms(models.Model):
     geom = models.MultiPolygonField(srid=4326, blank=True, null=True)
     district = models.OneToOneField(District, verbose_name=_('district'), on_delete=models.DO_NOTHING, primary_key=True)
 
+
 class VisibilityChoices(IntEnum):
     MEMBERSHIP = 1
     IFRC = 2

--- a/api/test_views.py
+++ b/api/test_views.py
@@ -192,12 +192,7 @@ class VisibilityTest(APITestCase):
 
         # perform the request with an ifrc user
         user2 = User.objects.create(username='bar')
-        ifrc_permission = Permission.objects.create(
-            codename='ifrc_admin',
-            name='IFRC Admin',
-            content_type=ContentType.objects.get_for_model(models.Country),
-        )
-        user2.user_permissions.add(ifrc_permission)
+        user2.user_permissions.add(self.ifrc_permission)
         self.client.force_authenticate(user=user2)
         response = self.client.get('/api/v2/country_snippet/').json()
         self.assertEqual(response['count'], 2)

--- a/deployments/models.py
+++ b/deployments/models.py
@@ -399,15 +399,6 @@ class Project(models.Model):
             for value in self.secondary_sectors or []
         ]
 
-    @classmethod
-    def get_for(cls, user, queryset=None):
-        qs = cls.objects.all() if queryset is None else queryset
-        if user.is_authenticated:
-            if user.email and user.email.endswith('@ifrc.org'):
-                return qs
-            return qs.exclude(visibility=VisibilityCharChoices.IFRC)
-        return qs.filter(visibility=VisibilityCharChoices.PUBLIC)
-
 
 class ProjectImport(models.Model):
     """

--- a/main/test_case.py
+++ b/main/test_case.py
@@ -5,8 +5,11 @@ from rest_framework.authtoken.models import Token
 from rest_framework import test, status
 
 from django.core import management
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.db import DEFAULT_DB_ALIAS, connections
 
+from api.models import Country
 from deployments.factories.user import UserFactory
 
 from lang.translation import AmazonTranslate
@@ -47,6 +50,13 @@ class GoAPITestMixin():
             email='jon@@ifrc.org',
         )
         self.aws_translator = AmazonTranslate()
+
+        self.ifrc_permission = Permission.objects.create(
+            codename='ifrc_admin',
+            content_type=ContentType.objects.get_for_model(Country),
+            name='IFRC Admin',
+        )
+        self.ifrc_user.user_permissions.add(self.ifrc_permission)
 
     def authenticate(self, user=None):
         if user is None:


### PR DESCRIPTION
Addresses 3w: Unify user roles to match rest of Go IFRCGO/go-frontend#1312  

## Changes

* Use `ReadOnlyVisibility` and `is_user_ifrc` logic for role check for visibility.