### PR TITLE
filter out non-independent countries when matching NS names

### DIFF
--- a/api/management/commands/sync_molnix.py
+++ b/api/management/commands/sync_molnix.py
@@ -189,15 +189,17 @@ def sync_deployments(molnix_deployments):
             if incoming_name in NS_MATCHING_OVERRIDES:
                 country_name = NS_MATCHING_OVERRIDES[incoming_name]
                 try:
-                    country_from = Country.objects.get(name_en=country_name)
+                    country_from = Country.objects.get(name_en=country_name, independent=True)
                 except:
                     warning = 'Mismatch in NS name: %s' % md['incoming']['name']
                     logger.warning(warning)
                     warnings.append(warning)
             else:
                 try:
-                    country_from = Country.objects.get(society_name=incoming_name)
+                    country_from = Country.objects.get(society_name=incoming_name, independent=True)
                 except:
+                    #FIXME: Catch possibility of .get() returning multiple records
+                    # even though that should ideally never happen
                     warning = 'NS Name not found for Deployment ID: %d with secondment_incoming %s' % (md['id'], md['incoming']['name'],)
                     logger.warning(warning)
                     warnings.append(warning)


### PR DESCRIPTION
Countries data on staging has been updated so that there can now be multiple "Country" entities in the db with the same National Society name. This was causing the ingestion to fail as we need to match to a single country.

This adds a check for `independent=True` as we never want to associate Deployments with non-Independent countries - they should always be associated with the "main" independent=True country entity.

cc @vdeak @szabozoltan69 - sorry for the constant small bugfixes on this - these have been hard to reproduce when developing locally. Please let me know if you're able to deploy this to staging sometime. Thank you!!