### PR TITLE
Use GO design/generic_notification template for 3W

### DIFF
--- a/main/frontend.py
+++ b/main/frontend.py
@@ -4,3 +4,7 @@ frontend_url = os.environ.get('FRONTEND_URL')
 if frontend_url == 'prddsgoproxyapp.azurewebsites.net':
     # We use a nicer frontend URL:
     frontend_url = 'go.ifrc.org'
+
+
+def get_project_url(id):
+    return f'https://{frontend_url}/three-w/{id}/'

--- a/notifications/notification.py
+++ b/notifications/notification.py
@@ -88,7 +88,9 @@ def send_notification(subject, recipients, html, mailtype=''):
             'No username and/or API endpoint set as environment variables.'
         )
         if settings.DEBUG:
+            print('-' * 22, 'EMAIL START', '-' * 22)
             print(f'subject={subject}\nrecipients={recipients}\nhtml={html}\nmailtype={mailtype}')
+            print('-' * 22, 'EMAIL END -', '-' * 22)
         return
 
     # If it's not PROD only able to use test e-mail addresses which are set in the env var

--- a/notifications/templates/design/foot1.html
+++ b/notifications/templates/design/foot1.html
@@ -10,9 +10,11 @@
                           <td class="text-default td-smaller-font-style text-right pl-10 pr-10" style="color: #000000;font-family:'Lato', Arial, sans-serif;border-right:1px solid #000;font-size: 16px;text-align: right;padding-left: 10px;padding-right: 10px;">
                             <a href="https://go.ifrc.org/login" target="_blank" class="link" style="font-family: 'Lato', Arial, sand-serif;text-decoration: underline;color: #000;">Login to IFRC GO</a>
                           </td>
+{% if not hide_preferences %}
                           <td class="text-default td-smaller-font-style pl-10 pr-10" style="color: #000000;font-family:'Lato', Arial, sans-serif;font-size: 16px;padding-left: 10px;padding-right: 10px;">
                             <a href="https://go.ifrc.org/account#notifications" target="_blank" class="link" style="font-family: 'Lato', Arial, sand-serif;text-decoration: underline;color: #000;">Unsubscribe</a>
                           </td>
+{% endif %}
                         </tr>
                       </table>
                     </td>

--- a/notifications/templates/design/main1.html
+++ b/notifications/templates/design/main1.html
@@ -36,11 +36,13 @@
 {% endif %}
                           </td>
                         </tr>
+{% if not hide_preferences %}
                         <tr>
                           <td class="text-default td-global-font-style text-center text-italic pb-30">
                             You are receiving this update based on your selected preferences.<br/><a href="https://go.ifrc.org/account#notifications" target="_blank" class="link">Update your preferences</a>
                           </td>
                         </tr>
+{% endif %}
                       </table>
                     </td>
                   </tr>

--- a/notifications/templates/email/deployments/project_status_complete_pre_alert.html
+++ b/notifications/templates/email/deployments/project_status_complete_pre_alert.html
@@ -1,5 +1,0 @@
-<p>
-    <b>{{project.name}}</b> project end date is in 5 days ({{end_date}}).
-    Please note that the project status will automatically change to <i>Completed</i>, when the end date passes.
-    You can update the end date to further keep the project in <i>Ongoing</i> status.
-</p>


### PR DESCRIPTION
Addresses https://github.com/IFRCGo/go-api/issues/1061#issuecomment-869505733 

## Changes

* Use GO design/generic_notification template for 3W project notification.
* Add `hide_preferences` in generic_notification template to hide subscription/preferences urls.
* Using `https://{frontend_url}/three-w/{id}/` for open in go URL. @frozenhelium will implement the route in go-frontend.

## Preview
![2021-07-04-151138](https://user-images.githubusercontent.com/7059255/124380035-4f848c00-dcda-11eb-94f2-7708e46c227b.png)
cc: @tovari 