### PR TITLE
return event id and not name in appeals serializer

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -667,7 +667,7 @@ class AppealHistorySerializer(EnumSupportSerializerMixin, ModelSerializer):
     sector = serializers.CharField(source='appeal.sector', read_only=True)
     created_at = serializers.CharField(source='appeal.created_at', read_only=True)
     modified_at = serializers.CharField(source='appeal.modified_at', read_only=True)
-    event = serializers.CharField(source='appeal.event', read_only=True)
+    event = serializers.IntegerField(source='appeal.event_id', read_only=True)
     id = serializers.CharField(source='appeal.id', read_only=True)
     name = serializers.CharField(source='appeal.name', read_only=True)
 


### PR DESCRIPTION
Addresses https://github.com/IFRCGo/go-api/issues/1129

## Changes

It looks like we inadvertently changed the response for `event` on the appeals endpoint to the event name instead of `id` when we moved to the new AppealHistory serializer.

This sets the `event` on the appeals endpoint back to returning an id.

@vdeak will be great to get this as well as https://github.com/IFRCGo/go-api/pull/1128 merged into develop + deployed to production soon.

cc @thenav56 