### PR TITLE
add filename argument to parser for update admin0 management command

### DIFF
--- a/api/management/commands/update-admin0-with-id.py
+++ b/api/management/commands/update-admin0-with-id.py
@@ -12,6 +12,8 @@ class Command(BaseCommand):
 
     missing_args_message = "Filename is missing."
 
+    def add_arguments(self, parser):
+        parser.add_argument('filename', nargs='+', type=str)
 
     @transaction.atomic
     def handle(self, *args, **options):


### PR DESCRIPTION
Add argument parser so that arguments are recognized as valid for update-admin0-with-id command.

cc @geohacker @vdeak 