### PR TITLE
Fix country association with Molnix imports

### DIFF
--- a/api/management/commands/sync_molnix.py
+++ b/api/management/commands/sync_molnix.py
@@ -189,7 +189,7 @@ def sync_deployments(molnix_deployments):
             if incoming_name in NS_MATCHING_OVERRIDES:
                 country_name = NS_MATCHING_OVERRIDES[incoming_name]
                 try:
-                    country_from = Country.objects.get(name_en=country_name, independent=True)
+                    country_from = Country.objects.get(name_en=country_name)
                 except:
                     warning = 'Mismatch in NS name: %s' % md['incoming']['name']
                     logger.warning(warning)


### PR DESCRIPTION
Should fix associating a deployment with IFRC: don't check for independent flag when matching by country name.

@vdeak could you merge to develop / deploy whenever possible? (no rush)