### PR TITLE
Make docker-compose setup compatible with Apple M1 chips

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '2'
 services:
   base_django_setup: &base_django_setup
     image: ifrcgo/go-api:latest
+    platform: linux/amd64
     environment:
       DJANGO_DB_NAME: test
       DJANGO_SECRET_KEY: test
@@ -30,9 +31,11 @@ services:
   base:
     build: .
     image: ifrcgo/go-api:latest
+    platform: linux/amd64
 
   db:
     image: mdillon/postgis:9.6-alpine
+    platform: linux/amd64
     environment:
       POSTGRES_PASSWORD: test
       POSTGRES_USER: test
@@ -42,6 +45,7 @@ services:
 
   redis:
     image: redis:latest
+    platform: linux/amd64
     volumes:
       - redis-data:/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 services:
   base_django_setup: &base_django_setup


### PR DESCRIPTION
Make possible to build the docker-compose images in Apple M1 chips.

## Changes

* Add `platform: linux/amd64` to all images in the `docker-compose.yml` file

## Checklist 
Things that should succeed before merging.

- [ ] Check if it impacts the current deployment infrastructure