### PR TITLE
Should not use XML2Dict==0.2.2 due to security reason. Instead: xmltodict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ Pillow==8.2.0
 PyPDF2==1.26.0
 Pygments==2.7.4
 Rx==1.6.0
-XML2Dict==0.2.2
 aiofiles==0.4.0
 aiohttp==3.7.4
 asn1crypto==0.24.0


### PR DESCRIPTION
We used in 2 ingest scripts the XML2Dict – which can be replaced by xmltodict.
https://github.com/IFRCGo/go-api/security/dependabot/requirements.txt/XML2Dict/open
There is no possibility to upgrade, XML2Dict is abandoned: https://pypi.org/project/XML2Dict/#history

ingest_who - is not used nowadays, but
ingest_gdacs is heavily used. Some parts the script had to be changed according to api/management/commands/scrape_pdfs.py

Old structure example: https://pastebin.com/bWrEh0p9
New structure example: https://pastebin.com/YBnWMVWg
Locally tested.