### PR TITLE
fixing event-specific failure of AggregateDeployments

### DIFF
--- a/deployments/drf_views.py
+++ b/deployments/drf_views.py
@@ -163,7 +163,7 @@ class AggregateDeployments(APIView):
         eru_qset = ERU.objects.all()
         if request.GET.get('event'):
             event_id = request.GET.get('event')
-            deployments_qset =  deployments_qset.filter(country_from__personneldeployment__event_deployed_to=event_id)
+            deployments_qset = deployments_qset.filter(country_from__personneldeployment__event_deployed_to=event_id)
             eru_qset = eru_qset.filter(event=event_id)
         active_deployments = deployments_qset.filter(
             start_date__lt=now,

--- a/deployments/drf_views.py
+++ b/deployments/drf_views.py
@@ -163,7 +163,7 @@ class AggregateDeployments(APIView):
         eru_qset = ERU.objects.all()
         if request.GET.get('event'):
             event_id = request.GET.get('event')
-            deployments_qset = deployments_qset.filter(personneldeployment__event_deployed_to=event_id)
+            deployments_qset =  deployments_qset.filter(country_from__personneldeployment__event_deployed_to=event_id)
             eru_qset = eru_qset.filter(event=event_id)
         active_deployments = deployments_qset.filter(
             start_date__lt=now,


### PR DESCRIPTION
A fix regarding to https://github.com/IFRCGo/go-frontend/issues/2011#issuecomment-908263801

This was the created query (by Django) – 
SELECT "deployments_deployedperson"."id", "deployments_deployedperson"."start_date", "deployments_deployedperson"."end_date", "deployments_deployedperson"."name", "deployments_deployedperson"."role", "deployments_deployedperson"."role_en", "deployments_deployedperson"."role_es", "deployments_deployedperson"."role_fr", "deployments_deployedperson"."role_ar", "deployments_personnel"."deployedperson_ptr_id", "deployments_personnel"."type", "deployments_personnel"."country_from_id", "deployments_personnel"."deployment_id", "deployments_personnel"."molnix_id", "deployments_personnel"."is_active" FROM "deployments_personnel" INNER JOIN "deployments_deployedperson" ON ("deployments_personnel"."deployedperson_ptr_id" = "deployments_deployedperson"."id") INNER JOIN "api_country" ON ("deployments_personnel"."country_from_id" = "api_country"."id") INNER JOIN "deployments_personneldeployment" ON ("api_country"."id" = "deployments_personneldeployment"."country_deployed_to_id") WHERE ("deployments_personnel"."is_active" = True AND "deployments_personneldeployment"."event_deployed_to_id" = 4130)