### PR TITLE
for surge alerts, by default show all, add filter to show only active

### DIFF
--- a/notifications/drf_views.py
+++ b/notifications/drf_views.py
@@ -19,12 +19,13 @@ class SurgeAlertFilter(filters.FilterSet):
         model = SurgeAlert
         fields = {
             'created_at': ('exact', 'gt', 'gte', 'lt', 'lte'),
+            'is_active': ('exact',)
         }
 
 
 class SurgeAlertViewset(viewsets.ReadOnlyModelViewSet):
     authentication_classes = (TokenAuthentication,)
-    queryset = SurgeAlert.objects.filter(is_active=True)
+    queryset = SurgeAlert.objects.all()
     filterset_class = SurgeAlertFilter
     ordering_fields = ('created_at', 'atype', 'category', 'event',)
 


### PR DESCRIPTION
Addresses https://github.com/IFRCGo/go-frontend/issues/1965

## Changes

 - Do not filter out `is_active=False` surge alerts by default
 - Add an explicit `is_active` filter to show only active alerts

cc @szabozoltan69 