### PR TITLE
fix deployment counts on event page

### DIFF
--- a/api/drf_views.py
+++ b/api/drf_views.py
@@ -9,7 +9,7 @@ from django.http import Http404
 from django_filters import rest_framework as filters
 from django.contrib.auth.models import User
 from django.db import models
-from django.db.models import Prefetch, Count
+from django.db.models import Prefetch, Count, Q
 from django.utils import timezone
 
 from main.utils import is_tableau
@@ -115,12 +115,17 @@ from .logger import logger
 class DeploymentsByEventViewset(viewsets.ReadOnlyModelViewSet):
     serializer_class = DeploymentsByEventSerializer
     queryset = Event.objects.prefetch_related('personneldeployment_set__personnel_set__country_from') \
-                            .filter(personneldeployment__personnel__is_active=True) \
-                            .filter(personneldeployment__personnel__type=Personnel.RR) \
-                            .filter(personneldeployment__personnel__end_date__gt=timezone.now()) \
-                            .filter(personneldeployment__personnel__start_date__lt=timezone.now()) \
-                            .annotate(personnel__count=Count('personneldeployment__personnel')) \
-                            .filter(personnel__count__gt=0) \
+                            .annotate(
+                                personnel_count=Count(
+                                    'personneldeployment__personnel',
+                                    filter=Q(
+                                        personneldeployment__personnel__is_active=True,
+                                        personneldeployment__personnel__type=Personnel.RR,    
+                                        personneldeployment__personnel__end_date__gt=timezone.now(),
+                                        personneldeployment__personnel__start_date__lt=timezone.now()
+                                    )
+                                )
+                            ).filter(personnel_count__gt=0) \
                             .order_by('-disaster_start_date')
 
 

--- a/api/drf_views.py
+++ b/api/drf_views.py
@@ -118,6 +118,7 @@ class DeploymentsByEventViewset(viewsets.ReadOnlyModelViewSet):
                             .filter(personneldeployment__personnel__is_active=True) \
                             .filter(personneldeployment__personnel__type=Personnel.RR) \
                             .filter(personneldeployment__personnel__end_date__gt=timezone.now()) \
+                            .filter(personneldeployment__personnel__start_date__lt=timezone.now()) \
                             .annotate(personnel__count=Count('personneldeployment__personnel')) \
                             .filter(personnel__count__gt=0) \
                             .order_by('-disaster_start_date')

--- a/deployments/drf_views.py
+++ b/deployments/drf_views.py
@@ -170,8 +170,7 @@ class AggregateDeployments(APIView):
             end_date__gt=now
         ).count()
         active_erus = eru_qset.filter(
-            start_date__lt=now,
-            end_date__gt=now
+            deployed_to__isnull=False
         ).count()
         deployments_this_year = deployments_qset.filter(
             is_active=True,

--- a/deployments/drf_views.py
+++ b/deployments/drf_views.py
@@ -163,7 +163,7 @@ class AggregateDeployments(APIView):
         eru_qset = ERU.objects.all()
         if request.GET.get('event'):
             event_id = request.GET.get('event')
-            deployments_qset = deployments_qset.filter(country_from__personneldeployment__event_deployed_to=event_id)
+            deployments_qset = deployments_qset.filter(deployment__event_deployed_to=event_id)
             eru_qset = eru_qset.filter(event=event_id)
         active_deployments = deployments_qset.filter(
             start_date__lt=now,


### PR DESCRIPTION
Fixes query to get deployment counts for an Event / Emergency.

cc @szabozoltan69 

Let's not merge this yet - let's do some more debugging and also try and fix other related issues in https://github.com/IFRCGo/go-frontend/issues/2011