### PR TITLE
Surge email notifications improvements

### DIFF
--- a/api/management/commands/index_and_notify.py
+++ b/api/management/commands/index_and_notify.py
@@ -150,8 +150,8 @@ class Command(BaseCommand):
         # Determine the front-end URL
         resource_uri = frontend_url
         if rtype == RecordType.SURGE_ALERT or rtype == RecordType.FIELD_REPORT: # Pointing to event instead of field report %s/%s/%s - Munu asked - ¤
-            belonging_event = record.event.id if record.event is not None else 57 # Very rare – giving a non-existent
-            resource_uri = '%s/emergencies/%s#overview' % (frontend_url, belonging_event)
+            belonging_event = record.event.id if record.event is not None else 57 # Very rare – giving a non-existent | manually created surge – no event
+            resource_uri = '%s/emergencies/%s#surge' % (frontend_url, belonging_event)
         elif rtype == RecordType.SURGE_DEPLOYMENT_MESSAGES:
             resource_uri = '%s/%s' % (frontend_url, 'deployments')  # can be further sophisticated
         elif rtype == RecordType.APPEAL and (


### PR DESCRIPTION
- [x] set the Read more and the Open in GO urls to the Surge tab
- [ ] Title: 1 new surge alert: Position title, Country
    e.g.: 1 new surge alert: CVA Coordinator, Haiti
- [ ] Notification body: remove (RAPID_RESPONSE, alert), add Duration and Start date
    e.g.: CVA Coordinator, Earthquake, Haiti, 2 months starting on 01.10.2021.
