### PR TITLE
use molnix id instead of pk while marking deployments inactive

### DIFF
--- a/api/management/commands/sync_molnix.py
+++ b/api/management/commands/sync_molnix.py
@@ -231,7 +231,7 @@ def sync_deployments(molnix_deployments):
     # Mark Personnel entries no longer in Molnix as inactive:
 
     for id in inactive_ids:
-        personnel = Personnel.objects.get(pk=id)
+        personnel = Personnel.objects.get(molnix_id=id)
         personnel.is_active = False
         personnel.save()
 


### PR DESCRIPTION
@szabozoltan69 sorry, this was a really silly mistake :-(

This should fix the issue where we were not correctly marking Deployments as inactive if they had been deleted from the Molnix system.

We can run this a bit on staging and if it all seems fine, maybe do a hotfix soon.

Thanks!