### PR TITLE
Fixing conflicting python packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ django-tinymce4-lite==1.7.4
 djangorestframework-csv==2.1.0
 djangorestframework-guardian==0.1.1
 djangorestframework==3.11.2
-elasticsearch==6.0.0
+elasticsearch==6.3.0
 factory_boy==2.12.0
 futures==3.1.1
 fuzzywuzzy==0.17.0
@@ -88,6 +88,6 @@ tabula-py==1.2.0
 typing==3.6.2
 unicodecsv==0.14.1
 uritemplate==3.0.0
-urllib3==1.26.5
+urllib3==1.26.7
 wheel==0.30.0
 xmltodict==0.11.0


### PR DESCRIPTION
Bump up elasticsearch to 6.3.0, urllib3 to 1.26.7