### PR TITLE
Hotfix - log4j, django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.2.24
+Django==2.2.25
 Jinja2==2.11.3
 Markdown==3.3.4
 MarkupSafe==1.1.1
@@ -47,7 +47,7 @@ djangorestframework-csv==2.1.0
 djangorestframework-guardian==0.1.1
 djangorestframework==3.11.2
 # upgrade elasticsearch? Keep synched with init-es.sh: a new docker image (es vm) is also needed. Then manage.py index_elasticsearch!
-elasticsearch==6.3.0
+elasticsearch==6.8.2
 factory_boy==2.12.0
 futures==3.1.1
 fuzzywuzzy==0.17.0


### PR DESCRIPTION
-Django==2.2.24
+Django==2.2.25

-elasticsearch==6.3.0
+elasticsearch==6.8.2 (to be friendly with the new, log4j-fixed ES image version, 6.8.21)
