### PR TITLE
Disabling celery

### DIFF
--- a/lang/tasks.py
+++ b/lang/tasks.py
@@ -1,5 +1,5 @@
 import logging
-from celery import shared_task
+#ς from celery import shared_task
 from modeltranslation.translator import translator
 from modeltranslation.utils import build_localized_fieldname
 from modeltranslation import settings as mt_settings
@@ -10,7 +10,7 @@ from django.db.models import Q
 from django.conf import settings
 from functools import reduce
 
-from main.celery import Queues
+#ς from main.celery import Queues
 from .translation import (
     AmazonTranslate,
     AVAILABLE_LANGUAGES,
@@ -173,7 +173,7 @@ class ModelTranslator():
                 index += 1
 
 
-@shared_task(queue=Queues.CRONJOB)
+#ς @shared_task(queue=Queues.CRONJOB)
 def translate_remaining_models_fields():
     # Disabled in DEBUG/Development
     if settings.DEBUG:
@@ -182,14 +182,14 @@ def translate_remaining_models_fields():
     ModelTranslator().run(batch_size=100)
 
 
-@shared_task(queue=Queues.DEFAULT)
+#ς @shared_task(queue=Queues.DEFAULT)
 def translate_model_fields(model_name, pk):
     model = django_apps.get_model(model_name)
     obj = model.objects.get(pk=pk)
     ModelTranslator().translate_model_fields(obj)
 
 
-@shared_task(queue=Queues.HEAVY)
+#ς @shared_task(queue=Queues.HEAVY)
 def translate_model_fields_in_bulk(model_name, pks):
     model = django_apps.get_model(model_name)
     for obj in model.objects.filter(pk__in=pks):

--- a/main/__init__.py
+++ b/main/__init__.py
@@ -1,6 +1,6 @@
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
-from .celery import app as celery_app
+#ς from .celery import app as celery_app
 
-__all__ = ['celery_app']
+#ς __all__ = ['celery_app']
 __version__ = '1.1.415'

--- a/main/celery.py
+++ b/main/celery.py
@@ -1,6 +1,6 @@
 import os
 #ς import celery
-#ς : this greek sigma (ς) shows the celery-comments everywhere
+#ς : this greek sigma (ς) shows the (searchable) celery-comments everywhere
 
 
 #ς class Celery(celery.Celery):

--- a/main/celery.py
+++ b/main/celery.py
@@ -1,24 +1,25 @@
 import os
-import celery
+#ς import celery
+#ς : this greek sigma (ς) shows the celery-comments everywhere
 
 
-class Celery(celery.Celery):
-    pass
+#ς class Celery(celery.Celery):
+#ς     pass
 
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "main.settings")
 
-app = Celery('main')
+#ς app = Celery('main')
 
-# Using a string here means the worker doesn't have to serialize
-# the configuration object to child processes.
-# - namespace='CELERY' means all celery-related configuration keys
-#   should have a `CELERY_` prefix.
-app.config_from_object('django.conf:settings', namespace='CELERY')
+#ς # Using a string here means the worker doesn't have to serialize
+#ς # the configuration object to child processes.
+#ς # - namespace='CELERY' means all celery-related configuration keys
+#ς #   should have a `CELERY_` prefix.
+#ς app.config_from_object('django.conf:settings', namespace='CELERY')
 
-# Load task modules from all registered Django app configs.
-app.autodiscover_tasks()
+#ς # Load task modules from all registered Django app configs.
+#ς app.autodiscover_tasks()
 
 
 class Queues():
@@ -33,6 +34,6 @@ class Queues():
     )
 
 
-@app.task(bind=True)
-def debug_task(self):
-    print('Request: {0!r}'.format(self.request))
+#ς @app.task(bind=True)
+#ς def debug_task(self):
+#ς     print('Request: {0!r}'.format(self.request))

--- a/main/settings.py
+++ b/main/settings.py
@@ -86,7 +86,7 @@ INSTALLED_APPS = [
     # Utils Apps
     'tinymce',
     'admin_auto_filters',
-    # 'django_celery_beat',
+    #ς 'django_celery_beat',
 
     # Logging
     'reversion',
@@ -355,12 +355,12 @@ AWS_TRANSLATE_REGION = os.environ.get('AWS_TRANSLATE_REGION')
 
 TEST_RUNNER = 'snapshottest.django.TestRunner'
 
-# CELERY CONFIG
-CELERY_REDIS_URL = os.environ.get('CELERY_REDIS_URL', 'redis://redis:6379/0')  # "redis://:{password}@{host}:{port}/{db}"
-CELERY_BROKER_URL = CELERY_REDIS_URL
-CELERY_RESULT_BACKEND = CELERY_REDIS_URL
-CELERY_TIMEZONE = TIME_ZONE
-CELERY_ACKS_LATE = True
+#ς # CELERY CONFIG
+#ς CELERY_REDIS_URL = os.environ.get('CELERY_REDIS_URL', 'redis://redis:6379/0')  # "redis://:{password}@{host}:{port}/{db}"
+#ς CELERY_BROKER_URL = CELERY_REDIS_URL
+#ς CELERY_RESULT_BACKEND = CELERY_REDIS_URL
+#ς CELERY_TIMEZONE = TIME_ZONE
+#ς CELERY_ACKS_LATE = True
 
 # CELERY_BEAT_SCHEDULE = {
 #     'translate_remaining_models_fields': {

--- a/main/settings.py
+++ b/main/settings.py
@@ -86,7 +86,7 @@ INSTALLED_APPS = [
     # Utils Apps
     'tinymce',
     'admin_auto_filters',
-    'django_celery_beat',
+    # 'django_celery_beat',
 
     # Logging
     'reversion',

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ azure-storage==0.36.0
 beautifulsoup4==4.6.3
 boto3==1.13.20
 bs4==0.0.1
-celery[redis]==4.4.6
+#ς celery[redis]==4.4.6
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4
@@ -29,7 +29,7 @@ coverage==4.4.2
 cryptography==3.3.2
 django-admin-autocomplete-filter==0.5
 django-admin-list-filter-dropdown==1.0.2
-django-celery-beat==2.0.0
+#ς django-celery-beat==2.0.0
 django-cors-headers==2.2.0
 django-coverage==1.2.4
 django-debug-toolbar==2.2.1


### PR DESCRIPTION
Not clear, why this error message arrives in cirle-ci, while locally it does not (due to the commented parts):
```
  File "/home/ifrc/go-api/lang/serializers.py", line 13, in <module>
    from .tasks import translate_model_fields, translate_model_fields_in_bulk
  File "/home/ifrc/go-api/lang/tasks.py", line 2, in <module>
    from celery import shared_task
ModuleNotFoundError: No module named 'celery'


Exited with code exit status 1

CircleCI received exit code 1
```