### PR TITLE
Use specific version for reportlab

### DIFF
--- a/informal_update/utils.py
+++ b/informal_update/utils.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.template.loader import render_to_string
 from django.contrib.auth.models import User
 
-# from xhtml2pdf import pisa
+from xhtml2pdf import pisa
 
 from notifications.notification import send_notification
 from main.frontend import get_project_url
@@ -13,7 +13,6 @@ from .models import InformalUpdate, Donors
 def render_to_pdf(template_src, context_dict={}):
     html = render_to_string(template_src, context_dict)
     result = BytesIO()
-    return  # temporary by zol
     pdf = pisa.pisaDocument(BytesIO(html.encode("ISO-8859-1")), result)
     if not pdf.err:
         file = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -94,3 +94,4 @@ urllib3==1.26.8
 wheel==0.30.0
 xmltodict==0.11.0
 xhtml2pdf==0.2.5
+reportlab==3.6.6  # XXX: Used by xhtml2pdf reportlab==3.6.7 breaks for now


### PR DESCRIPTION
Addresses reportlab build issue. 

## Changes

xhtml2pdf is broken with reportlab==3.6.7
```
File "/usr/local/lib/python3.8/site-packages/xhtml2pdf/xhtml2pdf_reportlab.py", line 20, in <module>
ImportError: cannot import name 'getStringIO' from 'reportlab.lib.utils'
```

## Checklist 
Things that should succeed before merging.

- [ ] Updated/ran unit tests
- [ ] Updated CHANGELOG.md

## Release

If there is a version update, make sure to tag the repository with the latest version.