### PR TITLE
add ICRC to matching over-ride list

### DIFF
--- a/api/management/commands/sync_molnix.py
+++ b/api/management/commands/sync_molnix.py
@@ -26,7 +26,8 @@ NS_MATCHING_OVERRIDES = {
     'Ifrc Americas': 'IFRC',
     'Ifrc Europe': 'IFRC',
     'IFRC': 'IFRC',
-    'Icrc Staff': 'ICRC'
+    'Icrc Staff': 'ICRC',
+    'ICRC': 'ICRC'
 }
 
 def get_unique_tags(deployments, open_positions):


### PR DESCRIPTION
Adds case to correctly match ICRC records during Molnix ingestion.

cc @szabozoltan69 