### PR TITLE
Revision for frontend requests

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,3 +1,4 @@
+import reversion
 from django.utils.translation import ugettext_lazy as _
 # from django.db import models
 from django.contrib.gis.db import models
@@ -132,6 +133,7 @@ class CountryType(IntEnum):
     # update api_country set record_type=3 where name like '%egion%';
 
 
+@reversion.register()
 class Country(models.Model):
     """ A country """
 
@@ -287,6 +289,7 @@ class Admin2(models.Model):
     def __str__(self):
         return f'{self.admin1} - {self.name}'
 
+
 class CountryGeoms(models.Model):
     """ Admin0 geometries """
     geom = models.MultiPolygonField(srid=4326, blank=True, null=True)
@@ -298,10 +301,12 @@ class DistrictGeoms(models.Model):
     geom = models.MultiPolygonField(srid=4326, blank=True, null=True)
     district = models.OneToOneField(District, verbose_name=_('district'), on_delete=models.DO_NOTHING, primary_key=True)
 
+
 class Admin2Geoms(models.Model):
     """ Admin2 geometries """
     geom = models.MultiPolygonField(srid=4326, blank=True, null=True)
     admin2 = models.OneToOneField(Admin2, verbose_name=_('admin2'), on_delete=models.DO_NOTHING, primary_key=True)
+
 
 class VisibilityChoices(IntEnum):
     MEMBERSHIP = 1
@@ -333,6 +338,7 @@ class VisibilityCharChoices():
 
 # Common parent class for key figures.
 # Country/region variants inherit from this.
+@reversion.register()
 class AdminKeyFigure(models.Model):
     figure = models.CharField(verbose_name=_('figure'), max_length=100)
     deck = models.CharField(verbose_name=_('deck'), max_length=50)
@@ -390,6 +396,7 @@ class TabNumber(IntEnum):
         TAB_3 = _('Tab 3')
 
 
+@reversion.register()
 class RegionSnippet(models.Model):
     region = models.ForeignKey(Region, verbose_name=_('region'), related_name='snippets', on_delete=models.CASCADE)
     snippet = HTMLField(verbose_name=_('snippet'), null=True, blank=True)
@@ -406,6 +413,7 @@ class RegionSnippet(models.Model):
         return self.snippet
 
 
+@reversion.register()
 class RegionEmergencySnippet(models.Model):
     region = models.ForeignKey(Region, verbose_name=_('region'), related_name='emergency_snippets', on_delete=models.CASCADE)
     title = models.CharField(max_length=255, blank=True)
@@ -422,6 +430,7 @@ class RegionEmergencySnippet(models.Model):
         return self.snippet
 
 
+@reversion.register()
 class RegionPreparednessSnippet(models.Model):
     region = models.ForeignKey(Region, verbose_name=_('region'), related_name='preparedness_snippets', on_delete=models.CASCADE)
     title = models.CharField(max_length=255, blank=True)
@@ -438,6 +447,7 @@ class RegionPreparednessSnippet(models.Model):
         return self.snippet
 
 
+@reversion.register()
 class RegionProfileSnippet(models.Model):
     region = models.ForeignKey(Region, verbose_name=_('region'), related_name='profile_snippets', on_delete=models.CASCADE)
     title = models.CharField(max_length=255, blank=True)
@@ -463,6 +473,7 @@ class RegionProfileSnippet(models.Model):
 #         return self.title
 
 
+@reversion.register()
 class CountrySnippet(models.Model):
     country = models.ForeignKey(Country, verbose_name=_('country'), related_name='snippets', on_delete=models.CASCADE)
     snippet = HTMLField(verbose_name=_('snippet'), null=True, blank=True)
@@ -479,6 +490,7 @@ class CountrySnippet(models.Model):
         return self.snippet
 
 
+@reversion.register()
 class AdminLink(models.Model):
     title = models.CharField(verbose_name=_('title'), max_length=100)
     url = models.URLField(verbose_name=_('url'), max_length=300)
@@ -505,6 +517,7 @@ class CountryLink(AdminLink):
         verbose_name_plural = _('country links')
 
 
+@reversion.register()
 class AdminContact(models.Model):
     ctype = models.CharField(verbose_name=_('type'), max_length=100, blank=True)
     name = models.CharField(verbose_name=_('name'), max_length=100)
@@ -546,6 +559,7 @@ class AlertLevel(IntEnum):
         RED = _('Red')
 
 
+@reversion.register()
 class Event(models.Model):
     """ A disaster, which could cover multiple countries """
 
@@ -681,6 +695,7 @@ class Event(models.Model):
         return self.name
 
 
+@reversion.register()
 class EventFeaturedDocument(models.Model):
     event = models.ForeignKey(
         Event,
@@ -700,6 +715,7 @@ class EventFeaturedDocument(models.Model):
     )
 
 
+@reversion.register()
 class EventLink(models.Model):
     """
     Used in emergency overview.
@@ -716,6 +732,7 @@ class EventLink(models.Model):
     url = models.URLField(verbose_name=_('url'))
 
 
+@reversion.register()
 class EventContact(models.Model):
     """ Contact for event """
 
@@ -734,6 +751,7 @@ class EventContact(models.Model):
         return '%s: %s' % (self.name, self.title)
 
 
+@reversion.register()
 class KeyFigure(models.Model):
     event = models.ForeignKey(Event, verbose_name=_('event'), related_name='key_figures', on_delete=models.CASCADE)
     number = models.CharField(verbose_name=_('number'), max_length=100, help_text=_('key figure metric'))
@@ -750,6 +768,7 @@ def snippet_image_path(instance, filename):
     return 'emergencies/%s/%s' % (instance.event.id, filename)
 
 
+@reversion.register()
 class Snippet(models.Model):
     """ Snippet of text """
     snippet = HTMLField(verbose_name=_('snippet'), null=True, blank=True)
@@ -788,6 +807,7 @@ def sitrep_document_path(instance, filename):
     return 'sitreps/%s/%s' % (instance.event.id, filename)
 
 
+@reversion.register()
 class SituationReport(models.Model):
     created_at = models.DateTimeField(verbose_name=_('created at'), auto_now_add=True)
     name = models.CharField(verbose_name=_('name'), max_length=100)
@@ -869,6 +889,7 @@ class AppealStatus(IntEnum):
         ARCHIVED = _('Archived')
 
 
+@reversion.register()
 class Appeal(models.Model):
     """ An appeal for a disaster and country, containing documents """
 
@@ -1025,6 +1046,7 @@ class AppealHistory(models.Model):
         return self.aid
 
 
+@reversion.register()
 class AppealDocument(models.Model):
     # Don't set `auto_now_add` so we can modify it on save
     created_at = models.DateTimeField(verbose_name=_('created at'))
@@ -1048,6 +1070,7 @@ class AppealDocument(models.Model):
         return '%s - %s' % (self.appeal, self.name)
 
 
+@reversion.register()
 class AppealFilter(models.Model):
     name = models.CharField(verbose_name=_('name'), max_length=100)
     value = models.CharField(verbose_name=_('value'), max_length=1000)
@@ -1109,6 +1132,7 @@ class EPISourceChoices(IntEnum):
         OTHER = _('OTHER')
 
 
+@reversion.register()
 class ExternalPartner(models.Model):
     ''' Dropdown items for COVID Field Reports '''
 
@@ -1177,6 +1201,7 @@ class UserRegion(models.Model):
         return self.user.get_username()
 
 
+@reversion.register()
 class FieldReport(models.Model):
     """ A field report for a disaster and country, containing documents """
 
@@ -1412,6 +1437,7 @@ class FieldReport(models.Model):
         return '%s - %s' % (self.id, summary)
 
 
+@reversion.register()
 class FieldReportContact(models.Model):
     """ Contact for field report """
 
@@ -1474,6 +1500,7 @@ class ActionCategory:
     )
 
 
+@reversion.register()
 class Action(models.Model):
     """ Action taken """
     name = models.CharField(verbose_name=_('name'), max_length=400)
@@ -1499,6 +1526,7 @@ class Action(models.Model):
         return self.name
 
 
+@reversion.register()
 class ActionsTaken(models.Model):
     """ All the actions taken by an organization """
 
@@ -1532,6 +1560,7 @@ class SourceType(models.Model):
         return self.name
 
 
+@reversion.register()
 class Source(models.Model):
     """ Source of information """
     stype = models.ForeignKey(SourceType, verbose_name=_('type'), on_delete=models.PROTECT)
@@ -1548,6 +1577,7 @@ class Source(models.Model):
         return '%s: %s' % (self.stype.name, self.spec)
 
 
+@reversion.register()
 class Profile(models.Model):
     """ Holds location and identifying information about users """
     NTLS = 'NTLS'
@@ -1593,6 +1623,7 @@ class Profile(models.Model):
         return self.user.username
 
 
+@reversion.register()
 class EmergencyOperationsBase(models.Model):
     """Common fields used by EmergencyOperations* Tables"""
     is_validated = models.BooleanField(
@@ -1901,6 +1932,7 @@ class EmergencyOperationsFR(EmergencyOperationsBase):
         return self.raw_file_name
 
 
+@reversion.register()
 class MainContact(models.Model):
     ''' Contacts on the Resources page '''
     extent = models.CharField(verbose_name=_('extent'), max_length=300)
@@ -1930,6 +1962,7 @@ class CronJobStatus(IntEnum):
         ERRONEOUS = _('Erroneous')
 
 
+@reversion.register()
 class CronJob(models.Model):
     """ CronJob log row about jobs results """
     name = models.CharField(verbose_name=_('name'), max_length=100, default='')

--- a/deployments/models.py
+++ b/deployments/models.py
@@ -1,3 +1,4 @@
+import reversion
 from datetime import datetime
 from enumfields import EnumIntegerField
 from enumfields import IntEnum
@@ -68,6 +69,7 @@ class ERUType(IntEnum):
         BASECAMP_L = _('Base Camp – L')
 
 
+@reversion.register()
 class ERUOwner(models.Model):
     """ A resource that may or may not be deployed """
 
@@ -88,6 +90,7 @@ class ERUOwner(models.Model):
         return self.national_society_country.name
 
 
+@reversion.register()
 class ERU(models.Model):
     """ A resource that can be deployed """
     type = EnumIntegerField(ERUType, verbose_name=_('type'), default=0)
@@ -123,6 +126,7 @@ class ERU(models.Model):
         return str(self.type.label)
 
 
+@reversion.register()
 class PersonnelDeployment(models.Model):
     country_deployed_to = models.ForeignKey(Country, verbose_name=_('country deployed to'), on_delete=models.CASCADE)
     region_deployed_to = models.ForeignKey(Region, verbose_name=_('region deployed to'), null=True, on_delete=models.SET_NULL)
@@ -156,6 +160,7 @@ class PersonnelDeployment(models.Model):
         return '%s, %s' % (self.country_deployed_to, self.region_deployed_to)
 
 
+@reversion.register()
 class MolnixTag(models.Model):
     '''
     We store tags from molnix in its own model, to make m2m relations
@@ -172,6 +177,7 @@ class MolnixTag(models.Model):
         return self.name
 
 
+@reversion.register()
 class DeployedPerson(models.Model):
     start_date = models.DateTimeField(verbose_name=_('start date'), null=True)
     end_date = models.DateTimeField(verbose_name=_('end date'), null=True)
@@ -246,6 +252,7 @@ class Personnel(DeployedPerson):
         names = [tag['name'] for tag in tags]
         return ", ".join(names)
 
+@reversion.register()
 class PartnerSocietyActivities(models.Model):
     activity = models.CharField(verbose_name=_('activity'), max_length=50)
 
@@ -369,6 +376,7 @@ class OperationTypes(IntEnum):
         EMERGENCY_OPERATION = _('Emergency Operation')
 
 
+@reversion.register()
 class RegionalProject(models.Model):
     name = models.CharField(verbose_name=_('name'), max_length=100)
     created_at = models.DateTimeField(verbose_name=_('created at'), auto_now_add=True)
@@ -383,6 +391,7 @@ class RegionalProject(models.Model):
 
 
 # 3W
+@reversion.register()
 class Project(models.Model):
     modified_at = models.DateTimeField(verbose_name=_('modified at'), auto_now=True)
     modified_by = models.ForeignKey(
@@ -486,6 +495,7 @@ class Project(models.Model):
         )
 
 
+@reversion.register()
 class ProjectImport(models.Model):
     """
     Track Project Imports (For Django Admin Panel)
@@ -517,6 +527,7 @@ class ProjectImport(models.Model):
 
 
 # -------------- Emergency 3W [Start]
+@reversion.register()
 class EmergencyProject(models.Model):
     class ActivityLead(TextChoices):
         NATIONAL_SOCIETY = 'national_society', _('National Society')
@@ -624,6 +635,7 @@ class EmergencyProject(models.Model):
         return self.title
 
 
+@reversion.register()
 class EmergencyProjectActivitySector(models.Model):
     title = models.CharField(max_length=255, verbose_name=_('title'))
     order = models.SmallIntegerField(default=0)
@@ -632,6 +644,7 @@ class EmergencyProjectActivitySector(models.Model):
         return self.title
 
 
+@reversion.register()
 class EmergencyProjectActivityAction(models.Model):
     sector = models.ForeignKey(
         EmergencyProjectActivitySector,
@@ -648,6 +661,7 @@ class EmergencyProjectActivityAction(models.Model):
         return self.title
 
 
+@reversion.register()
 class EmergencyProjectActivityActionSupply(models.Model):
     action = models.ForeignKey(
         EmergencyProjectActivityAction,
@@ -662,6 +676,7 @@ class EmergencyProjectActivityActionSupply(models.Model):
         return self.title
 
 
+@reversion.register()
 class EmergencyProjectActivityLocation(models.Model):
     # Location Data
     latitude = models.FloatField(verbose_name=_('latitude'))
@@ -672,6 +687,7 @@ class EmergencyProjectActivityLocation(models.Model):
         return f'{self.latitude} - {self.longitude}'
 
 
+@reversion.register()
 class EmergencyProjectActivity(models.Model):
     class PeopleHouseholds(TextChoices):
         PEOPLE = 'people', _('People'),
@@ -781,6 +797,7 @@ class EmergencyProjectActivity(models.Model):
 
 
 # -------------- Emergency 3W [END]
+@reversion.register()
 class ERUReadiness(models.Model):
     """ ERU Readiness concerning personnel and equipment """
     national_society = models.ForeignKey(

--- a/dref/models.py
+++ b/dref/models.py
@@ -1,3 +1,4 @@
+import reversion
 import os
 
 from pdf2image import convert_from_path
@@ -17,6 +18,7 @@ from api.models import (
 from .enums import TextChoices, IntegerChoices
 
 
+@reversion.register()
 class NationalSocietyAction(models.Model):
     # NOTE: Replace `TextChoices` to `models.TextChoices` after upgrade to Django version 3
     class Title(TextChoices):
@@ -71,6 +73,7 @@ class NationalSocietyAction(models.Model):
         return request.build_absolute_uri(static(os.path.join('images/dref', title_static_map[title])))
 
 
+@reversion.register()
 class IdentifiedNeed(models.Model):
     class Title(TextChoices):
         SHELTER_AND_BASIC_HOUSEHOLD_ITEMS = 'shelter_and_basic_household_items', _('Shelter And Basic Household Items')
@@ -114,6 +117,7 @@ class IdentifiedNeed(models.Model):
         return request.build_absolute_uri(static(os.path.join('images/dref', title_static_map[title])))
 
 
+@reversion.register()
 class PlannedIntervention(models.Model):
     class Title(TextChoices):
         SHELTER_AND_BASIC_HOUSEHOLD_ITEMS = 'shelter_and_basic_household_items', _('Shelter And Basic Household Items')
@@ -161,6 +165,7 @@ class PlannedIntervention(models.Model):
         return request.build_absolute_uri(static(os.path.join('images/dref', title_static_map[title])))
 
 
+@reversion.register()
 class Dref(models.Model):
 
     class OnsetType(IntegerChoices):
@@ -545,6 +550,7 @@ class Dref(models.Model):
         super().save(*args, **kwargs)
 
 
+@reversion.register()
 class DrefCountryDistrict(models.Model):
     dref = models.ForeignKey(Dref, verbose_name=_('dref'),
                              on_delete=models.CASCADE)

--- a/flash_update/models.py
+++ b/flash_update/models.py
@@ -1,3 +1,4 @@
+import reversion
 from tinymce import HTMLField
 
 from django.db import models
@@ -18,6 +19,7 @@ from api.models import (
 from main.enums import TextChoices
 
 
+@reversion.register()
 class FlashGraphicMap(models.Model):
     file = models.FileField(
         verbose_name=_('file'),
@@ -35,6 +37,7 @@ class FlashGraphicMap(models.Model):
         verbose_name_plural = _('flash graphic maps')
 
 
+@reversion.register()
 class FlashReferences(models.Model):
     date = models.DateField(verbose_name=_('date'), blank=True)
     source_description = models.CharField(verbose_name=_('Name or Source Description'), max_length=225, blank=True)
@@ -55,6 +58,7 @@ class FlashReferences(models.Model):
         return f'{self.source_description} - {self.date}'
 
 
+@reversion.register()
 class FlashUpdate(models.Model):
     '''
     This is a base model for Flas Update
@@ -131,6 +135,7 @@ class FlashUpdate(models.Model):
         return f'{self.title}'
 
 
+@reversion.register()
 class FlashCountryDistrict(models.Model):
     flash_update = models.ForeignKey(
         FlashUpdate, on_delete=models.CASCADE,
@@ -155,6 +160,7 @@ class FlashCountryDistrict(models.Model):
         return f'{self.country} - {self.district}'
 
 
+@reversion.register()
 class FlashAction(models.Model):
     """ Action taken for Flash Update """
 
@@ -182,6 +188,7 @@ class FlashAction(models.Model):
         return self.name
 
 
+@reversion.register()
 class FlashActionsTaken(models.Model):
     """ All the actions taken by an organization in Flash Update """
 
@@ -204,6 +211,7 @@ class FlashActionsTaken(models.Model):
         return f'{self.organization} - {self.actions}'
 
 
+@reversion.register()
 class FlashEmailSubscriptions(models.Model):
     share_with = models.CharField(
         max_length=50, choices=FlashUpdate.FlashShareWith.choices,
@@ -219,6 +227,7 @@ class FlashEmailSubscriptions(models.Model):
         return self.share_with
 
 
+@reversion.register()
 class DonorGroup(models.Model):
     name = models.CharField(max_length=255, verbose_name=_('name'))
 
@@ -226,6 +235,7 @@ class DonorGroup(models.Model):
         return self.name
 
 
+@reversion.register()
 class Donors(models.Model):
     organization_name = models.CharField(max_length=500, blank=True, null=True)
     first_name = models.CharField(max_length=300, blank=True, null=True)
@@ -241,6 +251,7 @@ class Donors(models.Model):
         return self.organization_name
 
 
+@reversion.register()
 class FlashUpdateShare(models.Model):
     flash_update = models.ForeignKey(FlashUpdate, on_delete=models.CASCADE, related_name='flash_update_share')
     donors = models.ManyToManyField(Donors, blank=True)

--- a/main/settings.py
+++ b/main/settings.py
@@ -197,6 +197,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'middlewares.middlewares.RequestMiddleware',
+    'reversion.middleware.RevisionMiddleware',
 ]
 
 AUTHENTICATION_BACKENDS = (

--- a/middlewares/middlewares.py
+++ b/middlewares/middlewares.py
@@ -4,6 +4,7 @@ from rest_framework import permissions
 from django.conf import settings
 from django.http import JsonResponse
 from django.utils.translation import ugettext, get_language
+# from reversion.middleware import RevisionMiddleware
 
 
 _threadlocal = threading.local()
@@ -67,3 +68,14 @@ class RequestMiddleware:
                     'method': request.method
                 },
             }, status=405)
+
+
+# Without this class the 'request revision' still works fine.
+# TODO: how to make it effective?
+# class BypassRevisionMiddleware(RevisionMiddleware):
+#
+#     def request_creates_revision(self, request):
+#         # Bypass the revision according to ...
+#         silent = request.META.get("HTTP_X_NOREVISION", "false")
+#         return super().request_creates_revision(request) and \
+#             silent != "true"

--- a/per/models.py
+++ b/per/models.py
@@ -1,3 +1,4 @@
+import reversion
 from api.models import Country
 from django.db import models
 from django.conf import settings
@@ -25,6 +26,7 @@ class ProcessPhase(IntEnum):
         ACTION_AND_ACCOUNTABILITY = _('action and accountability')
 
 
+@reversion.register()
 class NSPhase(models.Model):
     """ NS PER Process Phase """
     # default=1 needed only for the migration, can be deleted later
@@ -79,6 +81,7 @@ class Language(IntEnum):
         ENGLISH = _('english')
 
 
+@reversion.register()
 class FormArea(models.Model):
     """ PER Form Areas (top level) """
     title = models.CharField(verbose_name=_('title'), max_length=250)
@@ -88,6 +91,7 @@ class FormArea(models.Model):
         return f'Area {self.area_num} - {self.title}'
 
 
+@reversion.register()
 class FormComponent(models.Model):
     """ PER Form Components inside Areas """
     area = models.ForeignKey(FormArea, verbose_name=_('area'), on_delete=models.PROTECT)
@@ -100,6 +104,7 @@ class FormComponent(models.Model):
         return f'Component {self.component_num} - {self.title}'
 
 
+@reversion.register()
 class FormAnswer(models.Model):
     """ PER Form answer possibilities """
     text = models.CharField(verbose_name=_('text'), max_length=40)
@@ -108,6 +113,7 @@ class FormAnswer(models.Model):
         return self.text
 
 
+@reversion.register()
 class FormQuestion(models.Model):
     """ PER Form individual questions inside Components """
     component = models.ForeignKey(FormComponent, verbose_name=_('component'), on_delete=models.PROTECT)
@@ -136,6 +142,7 @@ class CAssessmentType(IntEnum):
         POST_OPERATIONAL = _('post operational')
 
 
+@reversion.register()
 class AssessmentType(models.Model):
     name = models.CharField(verbose_name=_('name'), max_length=200)
 
@@ -147,6 +154,7 @@ class AssessmentType(models.Model):
         return self.name
 
 
+@reversion.register()
 class Overview(models.Model):
     assessment_number = models.IntegerField(verbose_name=_('assessment number'), default=1)
     branches_involved = models.CharField(verbose_name=_('branches involved'), max_length=400, null=True, blank=True)
@@ -214,6 +222,7 @@ class Overview(models.Model):
         return f'{name}{fpname}'
 
 
+@reversion.register()
 class Form(models.Model):
     """ Individually submitted PER Forms """
     area = models.ForeignKey(FormArea, verbose_name=_('area'), null=True, on_delete=models.PROTECT)
@@ -237,6 +246,7 @@ def question_details(question_id, code):
     return questions.get(q, '')
 
 
+@reversion.register()
 class FormData(models.Model):
     """ PER form data """
     form = models.ForeignKey(Form, verbose_name=_('form'), related_name='form_data', on_delete=models.CASCADE)
@@ -292,6 +302,7 @@ class WorkPlanStatus(IntEnum):
         CLOSED = _('closed')
 
 
+@reversion.register()
 class WorkPlan(models.Model):
     prioritization = EnumIntegerField(PriorityValue, verbose_name=_('prioritization'))
     components = models.CharField(verbose_name=_('components'), max_length=900, null=True, blank=True)
@@ -337,6 +348,7 @@ def nice_document_path(instance, filename):
     return 'perdocs/%s/%s' % (instance.country.id, filename)
 
 
+@reversion.register()
 class NiceDocument(models.Model):
     created_at = models.DateTimeField(verbose_name=_('created at'), auto_now_add=True)
     name = models.CharField(verbose_name=_('name'), max_length=100)

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -1,3 +1,4 @@
+import reversion
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 from django.db import models
@@ -58,6 +59,7 @@ class Recovery(models.Model):
         return self.user.username
 
 
+@reversion.register()
 class DomainWhitelist(models.Model):
     """ Whitelisted domains """
     domain_name = models.CharField(verbose_name=_('domain name'), max_length=200)


### PR DESCRIPTION
Using https://django-reversion.readthedocs.io/en/stable/middleware.html as a sample.
(Strange that there is "true", "false" in the code, instead of True, False.)

Maybe some more filtering would be fine (to give which models do we want to save).
This way Field Report changes via frontend are saved – local test:
![kép](https://user-images.githubusercontent.com/6050643/160831279-9ab8b8ea-5ce7-44e4-b653-c68727054115.png)
