### PR TITLE
Created_at into notification details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+ - Notification GUID details - also created_at
  - Flash update notification
  - Real_data_update date comparison to appeal endpoint
  - Rich Text Editor enhancements

--- a/notifications/admin.py
+++ b/notifications/admin.py
@@ -27,7 +27,7 @@ class NotificationGUIDAdmin(admin.ModelAdmin):
     list_display = ('api_guid', 'email_type', 'created_at',)
     list_filter = ('email_type',)
     search_fields = ('email_type',)
-    readonly_fields = ('api_guid', 'email_type', 'to_list',)
+    readonly_fields = ('api_guid', 'email_type', 'to_list', 'created_at',)
 
     def get_actions(self, request):
         actions = super().get_actions(request)


### PR DESCRIPTION
In the detailed view we need the **creation datetime** also.
@tovari – as we discussed it.