### PR TITLE
Optimizing EmergencyProjectViewSet

### DIFF
--- a/deployments/drf_views.py
+++ b/deployments/drf_views.py
@@ -698,10 +698,10 @@ class EmergencyProjectViewSet(
     # ReadOnlyVisibilityViewsetMixin,  # FIXME: This is required?
     viewsets.ModelViewSet,
 ):
-    # FIXME: N+1 Query
-    queryset = EmergencyProject.objects.order_by('-modified_at').prefetch_related(
-        'created_by', 'reporting_ns', 'districts', 'event', 'country'
-    ).all()
+    queryset = EmergencyProject.objects.\
+        select_related('created_by', 'reporting_ns', 'event', 'country', 'deployed_eru', 'modified_by').\
+        prefetch_related('districts', 'activities').\
+        order_by('-modified_at').all()
     # Intentionally not IsAuthenticated. Anons should see public EmergencyProjects:
     permission_classes = []
     filterset_class = EmergencyProjectFilter

--- a/deployments/serializers.py
+++ b/deployments/serializers.py
@@ -539,7 +539,12 @@ class EmergencyProjectSerializer(
 
     class Meta:
         model = EmergencyProject
-        fields = '__all__'
+        fields = ('created_by_details', 'modified_by_details', 'reporting_ns_details',
+                  'deployed_eru_details', 'districts_details', 'activities', 'event_details',
+                  'activity_lead_display', 'status_display', 'country_details', 'visibility_display',
+                  'title', 'activity_lead', 'reporting_ns', 'event', 'country',
+                  'created_at', 'modified_at', 'start_date', 'end_date',
+                  ) # '__all__'
         read_only_fields = (
             'created_by',
             'created_at',


### PR DESCRIPTION
The /api/v2/emergency-project/ endpoint is quite resource-intensive. Keeps minutes until it gets all the data.

Some experiments to make it faster:
- to put into EmergencyProjectViewSet's prefetch_related part all the entities that is called (it means 'activities', 'deployed_eru', 'modified_by' in plus)
- to avoid fields = '\_\_all\_\_', but using the needed ones.
Fortunately MiniEventSerializer is used here, which does not contain FR references (as the Surge optimization bottleneck did).