### PR TITLE
make admin2 tilesets low res

### DIFF
--- a/mapbox/admin2/COL-centroids.json
+++ b/mapbox/admin2/COL-centroids.json
@@ -4,7 +4,7 @@
       "go-admin2-COL-centroids": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-COL-centroids-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/COL-staging.json
+++ b/mapbox/admin2/COL-staging.json
@@ -4,7 +4,7 @@
       "go-admin2-COL-staging": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-COL-src-staging",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/COL.json
+++ b/mapbox/admin2/COL.json
@@ -4,7 +4,7 @@
       "go-admin2-COL": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-COL-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/GTM-centroids.json
+++ b/mapbox/admin2/GTM-centroids.json
@@ -4,7 +4,7 @@
       "go-admin2-GTM-centroids": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-GTM-centroids-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/GTM-staging.json
+++ b/mapbox/admin2/GTM-staging.json
@@ -4,7 +4,7 @@
       "go-admin2-GTM-staging": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-GTM-src-staging",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/GTM.json
+++ b/mapbox/admin2/GTM.json
@@ -4,7 +4,7 @@
       "go-admin2-GTM": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-GTM-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/HND-centroids.json
+++ b/mapbox/admin2/HND-centroids.json
@@ -4,7 +4,7 @@
       "go-admin2-HND-centroids": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-HND-centroids-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/HND-staging.json
+++ b/mapbox/admin2/HND-staging.json
@@ -4,7 +4,7 @@
       "go-admin2-HND-staging": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-HND-src-staging",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/HND.json
+++ b/mapbox/admin2/HND.json
@@ -4,7 +4,7 @@
       "go-admin2-HND": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-HND-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/HTI-centroids.json
+++ b/mapbox/admin2/HTI-centroids.json
@@ -4,7 +4,7 @@
       "go-admin2-HTI-centroids": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-HTI-centroids-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/HTI-staging.json
+++ b/mapbox/admin2/HTI-staging.json
@@ -4,7 +4,7 @@
       "go-admin2-HTI-staging": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-HTI-src-staging",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/HTI.json
+++ b/mapbox/admin2/HTI.json
@@ -4,7 +4,7 @@
       "go-admin2-HTI": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-HTI-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/IDN-centroids.json
+++ b/mapbox/admin2/IDN-centroids.json
@@ -4,7 +4,7 @@
       "go-admin2-IDN-centroids": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-IDN-centroids-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/IDN-staging.json
+++ b/mapbox/admin2/IDN-staging.json
@@ -4,7 +4,7 @@
       "go-admin2-IDN-staging": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-IDN-src-staging",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/IDN.json
+++ b/mapbox/admin2/IDN.json
@@ -4,7 +4,7 @@
       "go-admin2-IDN": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-IDN-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/MYS-centroids.json
+++ b/mapbox/admin2/MYS-centroids.json
@@ -4,7 +4,7 @@
       "go-admin2-MYS-centroids": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-MYS-centroids-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/MYS-staging.json
+++ b/mapbox/admin2/MYS-staging.json
@@ -4,7 +4,7 @@
       "go-admin2-MYS-staging": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-MYS-src-staging",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/MYS.json
+++ b/mapbox/admin2/MYS.json
@@ -4,7 +4,7 @@
       "go-admin2-MYS": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-MYS-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/PHL-centroids.json
+++ b/mapbox/admin2/PHL-centroids.json
@@ -4,7 +4,7 @@
       "go-admin2-PHL-centroids": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-PHL-centroids-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/PHL-staging.json
+++ b/mapbox/admin2/PHL-staging.json
@@ -4,7 +4,7 @@
       "go-admin2-PHL-staging": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-PHL-src-staging",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/PHL.json
+++ b/mapbox/admin2/PHL.json
@@ -4,7 +4,7 @@
       "go-admin2-PHL": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-PHL-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/POL-centroids.json
+++ b/mapbox/admin2/POL-centroids.json
@@ -4,7 +4,7 @@
       "go-admin2-POL-centroids": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-POL-centroids-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/POL-staging.json
+++ b/mapbox/admin2/POL-staging.json
@@ -4,7 +4,7 @@
       "go-admin2-POL-staging": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-POL-src-staging",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/POL.json
+++ b/mapbox/admin2/POL.json
@@ -4,7 +4,7 @@
       "go-admin2-POL": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-POL-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/SLV-centroids.json
+++ b/mapbox/admin2/SLV-centroids.json
@@ -4,7 +4,7 @@
       "go-admin2-SLV-centroids": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-SLV-centroids-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/SLV-staging.json
+++ b/mapbox/admin2/SLV-staging.json
@@ -4,7 +4,7 @@
       "go-admin2-SLV-staging": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-SLV-src-staging",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/SLV.json
+++ b/mapbox/admin2/SLV.json
@@ -4,7 +4,7 @@
       "go-admin2-SLV": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-SLV-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/UKR-centroids.json
+++ b/mapbox/admin2/UKR-centroids.json
@@ -4,7 +4,7 @@
       "go-admin2-UKR-centroids": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-UKR-centroids-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/UKR-staging.json
+++ b/mapbox/admin2/UKR-staging.json
@@ -4,7 +4,7 @@
       "go-admin2-UKR-staging": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-UKR-src-staging",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/UKR.json
+++ b/mapbox/admin2/UKR.json
@@ -4,7 +4,7 @@
       "go-admin2-UKR": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-UKR-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/VEN-centroids.json
+++ b/mapbox/admin2/VEN-centroids.json
@@ -4,7 +4,7 @@
       "go-admin2-VEN-centroids": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-VEN-centroids-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/VEN-staging.json
+++ b/mapbox/admin2/VEN-staging.json
@@ -4,7 +4,7 @@
       "go-admin2-VEN-staging": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-VEN-src-staging",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }

--- a/mapbox/admin2/VEN.json
+++ b/mapbox/admin2/VEN.json
@@ -4,7 +4,7 @@
       "go-admin2-VEN": {
         "source": "mapbox://tileset-source/go-ifrc/go-admin2-VEN-src",
         "minzoom": 5,
-        "maxzoom": 14
+        "maxzoom": 10
       }
     }
   }


### PR DESCRIPTION
This PR makes all the admin2 mapbox tileset recipes use low res (zoom 5-10). I've also updated the recipe on Mapbox so the next time we run tile generation, it should create only zoom 5-10.

cc @batpad @szabozoltan69 @tovari @ThomasRaffort 