### PR TITLE
Country plan import: Only download pdf files

### DIFF
--- a/country_plan/management/commands/ingest_country_plan_file.py
+++ b/country_plan/management/commands/ingest_country_plan_file.py
@@ -1,6 +1,6 @@
 import logging
 import requests
-from typing import Union
+from typing import Union, Optional, Tuple
 from datetime import datetime
 from django.utils.timezone import make_aware
 from django.core.management.base import BaseCommand
@@ -20,38 +20,57 @@ PUBLIC_SOURCE = 'https://go-api.ifrc.org/api/publicsiteappeals?AppealsTypeID=185
 INTERNAL_SOURCE = 'https://go-api.ifrc.org/Api/FedNetAppeals?AppealsTypeId=1844&Hidden=false'
 
 
+def parse_date(text: Optional[str]) -> Optional[datetime]:
+    """
+    Convert Appeal API datetime into django datetime
+    Parameters
+    ----------
+      text : str
+          Datetime eg: 2022-11-29T11:24:00
+    """
+    if text:
+        return make_aware(
+            # NOTE: Format is assumed by looking at the data from Appeal API
+            datetime.strptime(text, '%Y-%m-%dT%H:%M:%S')
+        )
+
+
+def get_meta_from_url(url) -> Tuple[Optional[str], str]:
+    """
+    Fetch url headers and return content-type and filename
+    """
+    def _get_filename_from_headers(resp):
+        try:
+            # Eg: Content-Disposition: 'attachment;filename=UP_Botswana_2023.pdf'
+            return resp.headers.get('Content-Disposition').split(';')[1].split('=')[1]
+        except Exception:
+            return 'document.pdf'
+
+    # Check if it is a pdf file
+    resp = requests.head(url)
+    return resp.headers.get('Content-Type'), _get_filename_from_headers(resp)
+
+
 class Command(BaseCommand):
     @staticmethod
-    def parse_date(text: str) -> Union[datetime, None]:
-        """
-        Convert Appeal API datetime into django datetime
-        Parameters
-        ----------
-          text : str
-              Datetime eg: 2022-11-29T11:24:00
-        """
-        if text:
-            return make_aware(
-                # NOTE: Format is assumed by looking at the data from Appeal API
-                datetime.strptime(text, '%Y-%m-%dT%H:%M:%S')
-            )
-
-    @staticmethod
     def load_file_to_country_plan(country_plan: CountryPlan, url: str, filename: str, field_name: str):
+        """
+        Fetch file using url and save to country_plan
+        """
         with DownloadFileManager(url, suffix='.pdf') as f:
             getattr(country_plan, field_name).save(
                 filename,
                 File(f),
             )
 
-    def load_for_country(self, country_data, file_field, field_inserted_date_field):
+    def load_for_country(self, country_data: dict, file_field: str, field_inserted_date_field: str):
         country_iso2 = country_data.get('LocationCountryCode')
         country_name = country_data.get('LocationCountryName')
-        public_plan_url = country_data.get('BaseDirectory') or '' + country_data.get('BaseFileName') or ''
-        inserted_date = self.parse_date(country_data.get('Inserted'))
+        plan_url = country_data['BaseDirectory'] + country_data['BaseFileName']
+        inserted_date = parse_date(country_data.get('Inserted'))
         if (
             (country_iso2 is None and country_name is None) or
-            public_plan_url is None or
+            plan_url is None or
             inserted_date is None
         ):
             return
@@ -72,14 +91,18 @@ class Command(BaseCommand):
         if existing_inserted_date and existing_inserted_date >= inserted_date:
             # No need to do anything here
             return
-        self.stdout.write(f'- Saving data for country:: {country_plan.country.name}')
-        public_plan_url = country_data['BaseDirectory'] + country_data['BaseFileName']
+        content_type, content_name = get_meta_from_url(plan_url)
+        self.stdout.write(f'- Checking plan file for country:: {country_plan.country.name}')
+        if content_type != 'application/pdf':
+            # Only looking for PDFs
+            return
+        self.stdout.write('  - Saving data')
         setattr(country_plan, field_inserted_date_field, inserted_date)
         self.load_file_to_country_plan(
             country_plan,
-            public_plan_url,
+            plan_url,
             # NOTE: File provided are PDF,
-            f"{file_field.replace('_', '-').replace('file', '')}-{country_data['BaseFileName']}.pdf",
+            f"{file_field.replace('_', '-').replace('-file', '')}-{content_name}",
             file_field,
         )
         country_plan.is_publish = True
@@ -90,7 +113,6 @@ class Command(BaseCommand):
                 'is_publish',
             )
         )
-        return True
 
     def load(self, url: str, file_field: str, field_inserted_date_field: str):
         auth = (settings.APPEALS_USER, settings.APPEALS_PASS)


### PR DESCRIPTION
Addresses
-  Skip non-pdf files for country plan import

## Changes
* Country plan import: Only download pdf files

## NOTE
To clear out existing data imported by API
```python
from country_plan.models import CountryPlan

CountryPlan.objects.filter(internal_plan_inserted_date__isnull=False).update(
    internal_plan_inserted_date=None,
    internal_plan_file=None,
)

CountryPlan.objects.filter(public_plan_inserted_date__isnull=False).update(
    public_plan_inserted_date=None,
    public_plan_file=None,
)
```