### PR TITLE
Avoid double https prefix in project update notifications

### DIFF
--- a/main/frontend.py
+++ b/main/frontend.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 
 def get_project_url(id):
-    return f'https://{settings.FRONTEND_URL}/three-w/{id}/'
+    return f'{settings.FRONTEND_URL}/three-w/{id}/'
 
 
 def get_flash_update_url(id):


### PR DESCRIPTION
Refers to https://github.com/IFRCGo/go-api/issues/1694