### PR TITLE
Fix/remove celery beat

### DIFF
--- a/api/management/commands/run_celery_dev.py
+++ b/api/management/commands/run_celery_dev.py
@@ -9,8 +9,7 @@ from main.celery import Queues
 
 all_queues = ','.join([q for q in Queues.DEV_QUEUES])
 CMD = (
-    f'celery -A main worker -Q {all_queues} '
-    '-B --concurrency=2 -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler'
+    f'celery -A main worker -Q {all_queues} --concurrency=2 -l info'
 )
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ x-server: &base_server_setup
     APPEALS_USER: ${APPEALS_USER}
     APPEALS_PASS: ${APPEALS_PASS}
     # Sentry
-    SENTRY_DSN: ${SENTRY_DSN}
+    SENTRY_DSN: ${SENTRY_DSN:-}
     SENTRY_SAMPLE_RATE: ${SENTRY_SAMPLE_RATE:-0.2}
     # Maintenance mode
     DJANGO_READ_ONLY: ${DJANGO_READ_ONLY:-false}

--- a/main/settings.py
+++ b/main/settings.py
@@ -5,7 +5,6 @@ from datetime import datetime
 import environ
 
 from django.utils.translation import gettext_lazy as _
-# from celery.schedules import crontab
 from urllib3.util.retry import Retry
 from corsheaders.defaults import default_headers
 
@@ -166,7 +165,6 @@ INSTALLED_APPS = [
     # Utils Apps
     'tinymce',
     'admin_auto_filters',
-    # 'django_celery_beat',
     'haystack',
 
     # Logging
@@ -459,14 +457,6 @@ CELERY_BROKER_URL = CELERY_REDIS_URL
 CELERY_RESULT_BACKEND = CELERY_REDIS_URL
 CELERY_TIMEZONE = TIME_ZONE
 CELERY_ACKS_LATE = True
-
-# CELERY_BEAT_SCHEDULE = {
-#     'translate_remaining_models_fields': {
-#         'task': 'lang.tasks.translate_remaining_models_fields',
-#         # Every 6 hour
-#         'schedule': crontab(minute=0, hour="*/6"),
-#     },
-# }
 
 RETRY_STRATEGY = Retry(
     total=3,


### PR DESCRIPTION
## Changes

* Remove celery-beat from go-api
* Fix duplicate ingest_appeal_docs in docker-compose
   ```bash
   yaml: unmarshal errors:
  line 139: mapping key "ingest_appeal_docs" already defined at line 135
   ```
* Skip SENTRY_DNS not defined warning
   ```
   WARN[0000] The "SENTRY_DSN" variable is not set. Defaulting to a blank string.
   ```