### PR TITLE
Create ai-plugin.json and openapi.yml to experiment with ChatGPT plugin

### DIFF
--- a/go-static/well-known/ai-plugin.json
+++ b/go-static/well-known/ai-plugin.json
@@ -1,0 +1,18 @@
+{
+    "schema_version": "v1",
+    "name_for_model": "International Federation of the Red Cross Data Platform",
+    "name_for_human": "IFRC GO",
+    "description_for_model": "Plugin to search for information on the GO Platform, maintained by the International Federation of the Red Cross. You can use this API to ask questions about various past an ongoing humanitarian emergencies around the World, and details of Red Cross national societies and their capacity.",
+    "description_for_human": "Search through the GO API",
+    "auth": {
+      "type": "none"
+    },
+    "api": {
+      "type": "openapi",
+      "url": "https://goadmin-stage.ifrc.org/.well-known/openapi.yaml",
+      "has_user_authentication": false
+    },
+    "logo_url": "https://go.ifrc.org/assets/graphics/layout/go-logo-2020.svg",
+    "contact_email": "im@ifrc.org", 
+    "legal_info_url": "https://www.ifrc.org/disclaimer"
+  }

--- a/go-static/well-known/openapi.yml
+++ b/go-static/well-known/openapi.yml
@@ -1,0 +1,45 @@
+openapi: 3.0.0
+info:
+  title: Search API
+  version: 1.0.0
+paths:
+  /api/v1/search:
+    get:
+      summary: Search resources
+      description: Allows users to search through the available resources.
+      parameters:
+        - name: keyword
+          in: query
+          description: The query string for searching.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  regions:
+                    type: object
+                    description: Continental regions matching the search term.
+                  district_province_response:
+                    type: object
+                    description: Admin2 boundaries matching the search term.
+                  countries:
+                    type: object
+                    description: Countries matching the search term.
+                  emergencies:
+                    type: object
+                    description: Emergency objects of various past and ongoing emergencies matching the search term.
+                  surge_alerts:
+                    type: object
+                    description: Various alerts and calls for personnel to be deployed to various emergencies matching the search term.
+                  reports:
+                    type: object
+                    description: Field reports filed by national societies about emergencies matching the search term.
+                  rapid_response_deployments:
+                    type: object
+                    description: Details of various personnel deployments to ongoing emergencies matching the search term.

--- a/main/urls.py
+++ b/main/urls.py
@@ -237,6 +237,14 @@ urlpatterns = [
     url(r"^favicon\.ico$", RedirectView.as_view(url="/static/favicon.ico")),
     url(r"^server-error-for-devs", DummyHttpStatusError.as_view()),
     url(r"^exception-error-for-devs", DummyExceptionError.as_view()),
+    path(".well-known/ai-plugin.json", serve, {
+        "document_root": settings.STATICFILES_DIRS[0],
+        'path': 'well-known/ai-plugin.json'
+    }),
+    path(".well-known/openapi.yml", serve, {
+        "document_root": settings.STATICFILES_DIRS[0],
+        'path': 'well-known/openapi.yml'
+    }),
     path("i18n/", include("django.conf.urls.i18n")),
 ]
 


### PR DESCRIPTION
Addresses https://github.com/IFRCGo/go-frontend/issues/2790

## Changes

 - Adds an ai-plugin.json
 - Adds an openapi.yml
 - needs to be served at `/.well-known/ai-plugin.json` and `/.well-known/openapi.yml`
 
This should allow us to connect ChatGPT to GO as a "plugin" and start experimenting with queries.

cc @thenav56 @szabozoltan69 - I just need to figure out how best to serve these static files at `/.well-known/` ..

See also: https://platform.openai.com/docs/plugins/getting-started/plugin-manifest