### PR TITLE
Allow header for sentry Distributed Tracing

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -243,6 +243,7 @@ AUTHENTICATION_BACKENDS = (
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_HEADERS = list(default_headers) + [
     'sentry-trace',
+    'baggage',
 ]
 
 ROOT_URLCONF = 'main.urls'


### PR DESCRIPTION
Allow `baggage` header
https://docs.sentry.io/platforms/javascript/usage/distributed-tracing/#basic-example