### PR TITLE
Add global endpoint for fetching enums

### DIFF
--- a/api/drf_views.py
+++ b/api/drf_views.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from pytz import utc
 from rest_framework.status import HTTP_201_CREATED, HTTP_200_OK
 from rest_framework.generics import GenericAPIView, CreateAPIView, UpdateAPIView
+from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
@@ -14,8 +15,10 @@ from django.db import models
 from django.db.models import Prefetch, Count, Q, OuterRef
 from django.utils import timezone
 from django.utils.translation import get_language as django_get_language
+from drf_spectacular.utils import extend_schema
 
 from main.utils import is_tableau
+from main.enums import GlobalEnumSerializer, get_enum_values
 from main.translation import TRANSLATOR_ORIGINAL_LANGUAGE_FIELD_NAME
 from deployments.models import Personnel
 from databank.serializers import CountryOverviewSerializer
@@ -1194,3 +1197,16 @@ class UsersViewset(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         return User.objects.filter(is_active=True)
+
+
+class GlobalEnumView(APIView):
+    """
+    Provide a single endpoint to fetch enum metadata
+    """
+
+    @extend_schema(responses=GlobalEnumSerializer)
+    def get(self, _):
+        """
+        Return a list of all enums.
+        """
+        return Response(get_enum_values())

--- a/api/enums.py
+++ b/api/enums.py
@@ -1,0 +1,21 @@
+from . import models
+
+enum_register = {
+    'region_name': models.RegionName,
+    'country_type': models.CountryType,
+    'visibility_choices': models.VisibilityChoices,
+    'visibility_char_choices': models.VisibilityCharChoices,
+    'position_type': models.PositionType,
+    'tab_number': models.TabNumber,
+    'alert_level': models.AlertLevel,
+    'appeal_type': models.AppealType,
+    'appeal_status': models.AppealStatus,
+    'request_choices': models.RequestChoices,
+    'episource_choices': models.EPISourceChoices,
+    'field_report_status': models.FieldReport.Status,
+    'field_report_recent_affected': models.FieldReport.RecentAffected,
+    'action_org': models.ActionOrg,
+    'action_type': models.ActionType,
+    'action_category': models.ActionCategory,
+    'profile_org_types': models.Profile.OrgTypes,
+}

--- a/api/test_views.py
+++ b/api/test_views.py
@@ -565,3 +565,10 @@ class DistrictTest(APITestCase):
         country.save()
         response = self.client.get('/api/v2/district/').json()
         self.assertEqual(response['count'], 2)
+
+
+class GlobalEnumEndpointTest(APITestCase):
+    def test_200_response(self):
+        response = self.client.get('/api/v2/global-enums/')
+        self.assert_200(response)
+        self.assertIsNotNone(response.json())

--- a/dref/enums.py
+++ b/dref/enums.py
@@ -1,0 +1,11 @@
+from . import models
+
+enum_register = {
+    'national_society_action_title': models.NationalSocietyAction.Title,
+    'identified_need_title': models.IdentifiedNeed.Title,
+    'planned_intervention_title': models.PlannedIntervention.Title,
+    'dref_dref_type': models.Dref.DrefType,
+    'dref_onset_type': models.Dref.OnsetType,
+    'dref_disaster_category': models.Dref.DisasterCategory,
+    'dref_status': models.Dref.Status,
+}

--- a/dref/models.py
+++ b/dref/models.py
@@ -16,7 +16,6 @@ from api.models import Country, DisasterType, District, FieldReport
 
 @reversion.register()
 class NationalSocietyAction(models.Model):
-    # NOTE: Replace `TextChoices` to `models.TextChoices` after upgrade to Django version 3
     class Title(models.TextChoices):
         NATIONAL_SOCIETY_READINESS = "national_society_readiness", _("National Society Readiness")
         ASSESSMENT = "assessment", _("Assessment")

--- a/flash_update/enums.py
+++ b/flash_update/enums.py
@@ -1,0 +1,5 @@
+from . import models
+
+enum_register = {
+    'flash_update_flash_share_with': models.FlashUpdate.FlashShareWith,
+}

--- a/main/urls.py
+++ b/main/urls.py
@@ -237,6 +237,8 @@ urlpatterns = [
     url(r"^server-error-for-devs", DummyHttpStatusError.as_view()),
     url(r"^exception-error-for-devs", DummyExceptionError.as_view()),
     path("i18n/", include("django.conf.urls.i18n")),
+    # Enums
+    url(r"^api/v2/global-enums/", api_views.GlobalEnumView.as_view(), name="global_enums"),
     # Docs
     path("docs/", SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
     path("api-docs/", SpectacularAPIView.as_view(), name='schema'),


### PR DESCRIPTION
## Changes
Add valid enum values for each enum so that the typing is included for the frontend.
- To fetch enums http://localhost:8000/api/v2/global-enums/
- Global Enum schema http://localhost:8000/api-docs/swagger-ui/#/api/api_v2_global_enums_retrieve

![2023-07-10-114918](https://github.com/IFRCGo/go-api/assets/7059255/df04ba69-3039-4b9f-969e-59696cb26587)
![2023-07-10-114951](https://github.com/IFRCGo/go-api/assets/7059255/fcbc8681-f611-475c-9267-81e40df82b6a)


## Later if needed
- [ ] Add filter to specify enums