### PR TITLE
handle case where we fail to find a country in GO db with ISO code

### DIFF
--- a/api/management/commands/sync_molnix.py
+++ b/api/management/commands/sync_molnix.py
@@ -110,7 +110,11 @@ def get_go_country(countries, country_id):
     if not country_id in countries:
         return None
     iso = countries[country_id]
-    country = Country.objects.get(iso=iso, independent=True)
+    try:
+        country = Country.objects.get(iso=iso, independent=True)
+    except:
+        logger.warning('Country with unknown ISO: %s' % iso)
+        return None
     return country
 
 def get_datetime(datetime_string):


### PR DESCRIPTION
@szabozoltan69 I think this is the best we can do when we get an ISO code from Molnix that we don't have in GO: log a warning, and continue importing the rest of the data.
