### PR TITLE
process all positions from Molnix, not just open ones

### DIFF
--- a/api/management/commands/sync_molnix.py
+++ b/api/management/commands/sync_molnix.py
@@ -363,7 +363,7 @@ def sync_open_positions(molnix_positions, molnix_api, countries):
         go_alert.closes = get_datetime(position['closes'])
         go_alert.start = get_datetime(position['start'])
         go_alert.end = get_datetime(position['end'])
-        go_alert.is_active = True
+        go_alert.is_active = position['status'] == 'active'
         go_alert.save()
         add_tags_to_obj(go_alert, position['tags'])
         if created:

--- a/api/molnix_utils.py
+++ b/api/molnix_utils.py
@@ -59,8 +59,20 @@ class MolnixApi:
         return self.call_api(path='tags/edit/%d' % id)['tag']['groups']
 
     def get_open_positions(self):
-        #return self.call_api_paginated(path='positions', response_key='positions')
-        return self.call_api(path='positions/open')
+        positions_filter = {
+            "positionoperator": "",
+            "orderBy": "start",
+            "orderType": "DESC",
+            "status": [
+                "active",
+                "archived",
+                "unfilled"
+            ]
+        }
+        params = {
+            "filter": json.dumps(positions_filter)
+        }
+        return self.call_api_paginated(path='positions', response_key='positions', params=params)
 
     def get_deployments(self):
         deployments_filter = {


### PR DESCRIPTION
cc @szabozoltan69 

This makes a change to fetch all historical positions from Molnix, not just open ones. This is because currently if there are any updates made to historical positions, we do not get those updates on GO.
