### PR TITLE
Query params for SurgeAlert

### DIFF
--- a/notifications/drf_views.py
+++ b/notifications/drf_views.py
@@ -21,6 +21,8 @@ class SurgeAlertFilter(filters.FilterSet):
         model = SurgeAlert
         fields = {
             'created_at': ('exact', 'gt', 'gte', 'lt', 'lte'),
+            'end': ('exact', 'gt', 'gte', 'lt', 'lte'),
+            'is_stood_down': ('exact',),
             'is_active': ('exact',)
         }
 


### PR DESCRIPTION
To be able to use a query like this from frontend:
```
.../api/v2/surge_alert/?limit=10&ordering=is_stood_down&is_active=true&is_stood_down=false&end__lte=2021-11-01T00:00&offset=0
```