### PR TITLE
Run migration once; wait for migrations to run before starting api

### DIFF
--- a/deploy/helm/ifrcgo-helm/templates/api/deployment.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/api/deployment.yaml
@@ -25,6 +25,12 @@ spec:
         run: {{ .Release.Name }}-api
 
     spec:
+      initContainers:
+        - name: {{ .Chart.Name }}-wait-for-migrations
+          image: 'groundnuty/k8s-wait-for:v1.7'
+          args:
+            - job
+            - {{ template "ifrcgo-helm.fullname" . }}-migrations-job
       containers:
         - name: {{ .Chart.Name }}-api
           image: "{{ .Values.api.image.name }}:{{ .Values.api.image.tag }}"

--- a/deploy/helm/ifrcgo-helm/templates/api/migrations-job.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/api/migrations-job.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.api.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "ifrcgo-helm.fullname" . }}-migrations-job
+  labels:
+    component: api-migrations-job
+    environment: {{ .Values.environment }}
+    release: {{ .Release.Name }}
+spec:
+  backoffLimit: 0
+  selector:
+    matchLabels:
+      app: {{ template "ifrcgo-helm.name" . }}
+      release: {{ .Release.Name }}
+      run: {{ .Release.Name }}-migrations-job
+  template:
+    metadata:
+      annotations:
+        checksum/secret: {{ include (print .Template.BasePath "/config/secret.yaml") . | sha256sum }}
+        checksum/configmap: {{ include (print .Template.BasePath "/config/configmap.yaml") . | sha256sum }}
+      labels:
+        app: {{ template "ifrcgo-helm.name" . }}
+        release: {{ .Release.Name }}
+        run: {{ .Release.Name }}-migrations-job
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-migrations
+          image: "{{ .Values.api.image.name }}:{{ .Values.api.image.tag }}"
+          command: ["sh", "-c", "python manage.py migrate"]
+          envFrom:
+            - secretRef:
+                name: {{ template "ifrcgo-helm.fullname" . }}-api-secret
+            - configMapRef:
+                name: {{ template "ifrcgo-helm.fullname" . }}-api-configmap
+          resources:
+            requests:
+              cpu: {{ .Values.api.resources.requests.cpu }}
+              memory: {{ .Values.api.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.api.resources.limits.cpu }}
+              memory: {{ .Values.api.resources.limits.memory }}
+      restartPolicy: Never
+{{- end }}


### PR DESCRIPTION
Addresses https://github.com/IFRCGo/go-api/issues/1926

## Changes

- run migration in a Job to ensure only one instance of migrations is run regardless of the number of api replicas
- Use an init container to wait for migrations to finish running successfully before starting the api

We may need to tweak permissions on the api pod a bit if the default service account doesn't allow it to query for job status.

cc @batpad @szabozoltan69 