### PR TITLE
set replica count on prod to 2

### DIFF
--- a/deploy/helm/ifrcgo-helm/values-production.yaml
+++ b/deploy/helm/ifrcgo-helm/values-production.yaml
@@ -1,4 +1,5 @@
 api:
+  replicaCount: 2
   resources:
     requests:
       cpu: "2"

--- a/deploy/helm/ifrcgo-helm/values-staging.yaml
+++ b/deploy/helm/ifrcgo-helm/values-staging.yaml
@@ -1,4 +1,5 @@
 api:
+  replicaCount: 1
   resources:
     requests:
       cpu: "2"


### PR DESCRIPTION
Set the replica count on prod to two to mitigate any issues with restarting containers.

@szabozoltan69 doing this temporarily as I noticed a couple of restarts of the API container. When you are back we can test @sunu's work and solve the migration issue.