### PR TITLE
Change the names of the secrets that hold the TLS certs

### DIFF
--- a/deploy/helm/ifrcgo-helm/templates/api/ingress.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/api/ingress.yaml
@@ -13,11 +13,11 @@ spec:
   tls:
     - hosts:
       - {{ .Values.api.domain }}
-      secretName: {{ template "ifrcgo-helm.fullname" . }}-secret-api
+      secretName: {{ template "ifrcgo-helm.fullname" . }}-secret-api-cert
     {{- if .Values.api.additionalDomain }}
     - hosts:
       - {{ .Values.api.additionalDomain }}
-      secretName: {{ template "ifrcgo-helm.fullname" . }}-secret-api-additional-domain
+      secretName: {{ template "ifrcgo-helm.fullname" . }}-secret-api-additional-domain-cert
     {{- end }}
 
   rules:

--- a/deploy/helm/ifrcgo-helm/templates/api/secrets.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/api/secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "ifrcgo-helm.fullname" . }}-secret-api
+  name: {{ template "ifrcgo-helm.fullname" . }}-secret-api-cert
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .Values.secrets.API_TLS_CRT | quote}}
@@ -13,7 +13,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "ifrcgo-helm.fullname" . }}-secret-api-additional-domain
+  name: {{ template "ifrcgo-helm.fullname" . }}-secret-api-additional-domain-cert
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .Values.secrets.API_ADDITIONAL_DOMAIN_TLS_CRT | quote}}


### PR DESCRIPTION
Avoids name conflict during first deployment due to the presence of existing secrets with the same name

ref https://github.com/IFRCGo/go-api/pull/1948#issuecomment-1807670443

cc @szabozoltan69 @batpad  