### PR TITLE
Prevent deploy timing out when chartpress fails to run

### DIFF
--- a/deploy/helm/ifrcgo-helm/values.yaml
+++ b/deploy/helm/ifrcgo-helm/values.yaml
@@ -64,8 +64,8 @@ api:
   replicaCount: 1
   containerPort: 80
   image:
-    name: 'chartpress_replace'
-    tag: 'chartpress_replace'
+    name: 'SET-BY-CHARTPRESS'
+    tag: 'set-by-chartpress'
   resources:
     requests:
       cpu: "2"


### PR DESCRIPTION
It's a bit unclear why, but it seems there are often times when the Build process fails to complete / run on Azure Pipelines but the deploy still goes ahead. We should still investigate that further, but this PR should prevent the problem where then Helm time-outs trying to install an invalid image. This sets the image name to values that are invalid image name and tag, so helm will fail to install and not be stuck in a timeout condition.

Let's merge this on staging when we can.

cc @szabozoltan69 @sunu 