### PR TITLE
Make sure deploys only run when build succeeds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,11 +36,13 @@ jobs:
       addSpnToEnvironment: true
       useGlobalConfig: true
 
-  - bash: $(Pipeline.Workspace)/go-api/deploy/scripts/cipublish
+  - job: BuildAndPush
+    bash: $(Pipeline.Workspace)/go-api/deploy/scripts/cipublish
     displayName: "Build and Push"
 
   - bash: $(Pipeline.Workspace)/go-api/deploy/scripts/cideploy --staging
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/develop')
+    dependsOn: BuildAndPush
     displayName: "Deploy Staging"
     env:
       environment: staging
@@ -112,6 +114,7 @@ jobs:
   - bash: $(Pipeline.Workspace)/go-api/deploy/scripts/cideploy --production
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
     displayName: "Deploy Production"
+    dependsOn: BuildAndPush
     env:
       environment: production
       TF_VAR_username: github

--- a/deploy/helm/ifrcgo-helm/values.yaml
+++ b/deploy/helm/ifrcgo-helm/values.yaml
@@ -64,8 +64,8 @@ api:
   replicaCount: 1
   containerPort: 80
   image:
-    name: 'chartpress_replace'
-    tag: 'chartpress_replace'
+    name: 'SET-BY-CHARTPRESS'
+    tag: 'set-by-chartpress'
   resources:
     requests:
       cpu: "2"


### PR DESCRIPTION
Adds a dependsOn condition in azure pipelines to make sure the deploy only happens if the build runs successfully.

cc @szabozoltan69 @sunu 