### PR TITLE
Link from OpsLearning to related DREF Final Report

### DIFF
--- a/api/templates/admin/opslearning_change_form.html
+++ b/api/templates/admin/opslearning_change_form.html
@@ -1,0 +1,7 @@
+{% extends "admin/change_form.html" %}
+{% block object-tools-items %}
+<li>
+    <a href="/admin/dref/dreffinalreport/?q={{ original.appeal_code }}" target="_blank" class="historylink">Related DREF Final Report</a>
+</li>
+{{ block.super }}
+{% endblock %}

--- a/dref/admin.py
+++ b/dref/admin.py
@@ -68,7 +68,7 @@ class DrefAdmin(
     TranslationAdmin,
     admin.ModelAdmin
 ):
-    search_fields = ("title",)
+    search_fields = ("title", "appeal_code")
     list_display = (
         "title",
         "national_society",
@@ -125,6 +125,7 @@ class DrefAdmin(
 @admin.register(DrefOperationalUpdate)
 class DrefOperationalUpdateAdmin(CompareVersionAdmin, TranslationAdmin, admin.ModelAdmin):
     list_display = ("title", "national_society", "disaster_type")
+    search_fields = ("title", "national_society__name", "appeal_code")
     autocomplete_fields = (
         "national_society",
         "disaster_type",
@@ -203,7 +204,7 @@ class DrefFinalReportAdmin(
         "risk_security",
     )
     list_filter = ["dref"]
-    search_fields = ["title", "national_society__name"]
+    search_fields = ["title", "national_society__name", "appeal_code"]
 
     def get_queryset(self, request):
         return (

--- a/per/admin.py
+++ b/per/admin.py
@@ -161,6 +161,7 @@ class OpsLearningAdmin(GotoNextModelAdmin):
     list_filter = ("sector", "sector_validated", "per_component", "per_component_validated")
     list_display = ("learning", "appeal_code", "is_validated")
     autocomplete_fields = ("sector", "sector_validated", "per_component", "per_component_validated")
+    change_form_template = "admin/opslearning_change_form.html"
 
     def get_fields(self, request, obj=None):
         if obj and obj.is_validated:


### PR DESCRIPTION
Refers to this request from OpsLearning team:
Add the link to the DREF Final report. We have the MDR code already, but the team was wondering if we link it to the DREF Final Report ID in GO we would be able to 'click' directly to access the report.