### PR TITLE
Send reminder to Regional Admins only if reg email was verified

### DIFF
--- a/api/management/commands/user_registration_reminder.py
+++ b/api/management/commands/user_registration_reminder.py
@@ -20,6 +20,7 @@ class Command(BaseCommand):
             region_admin_emails = list(UserRegion.objects.filter(region_id=region_id).values_list("user__email", flat=True))
             pending3days = (
                 Pending.objects.filter(user__profile__country__region_id=region_id)
+                .filter(email_verified=True)
                 .filter(reminder_sent_to_admin=False)
                 .filter(created_at__lte=time_diff_3_day)
             )


### PR DESCRIPTION
No need to bother Regional Admins in 3 days when the registering user did not validate their own email.