### PR TITLE
Save disk config in a k8s configmap

### DIFF
--- a/deploy/terraform/resources/aks.tf
+++ b/deploy/terraform/resources/aks.tf
@@ -41,3 +41,27 @@ resource "azurerm_role_assignment" "storage" {
   role_definition_name = "Storage Account Contributor"
   principal_id         = azurerm_kubernetes_cluster.ifrcgo.identity[0].principal_id
 }
+
+# create k8s configmaps and secrets
+
+provider "kubernetes" {
+  host                   = azurerm_kubernetes_cluster.ifrcgo.kube_config.0.host
+  client_certificate     = base64decode(azurerm_kubernetes_cluster.ifrcgo.kube_config.0.client_certificate)
+  client_key             = base64decode(azurerm_kubernetes_cluster.ifrcgo.kube_config.0.client_key)
+  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.ifrcgo.kube_config.0.cluster_ca_certificate)
+}
+
+resource "kubernetes_config_map" "ifrcgo_elasticsearch_disk_config" {
+  metadata {
+    name = "ifrcgo-elasticsearch-disk-config"
+  }
+
+  depends_on = [
+    azurerm_managed_disk.ifrcgo
+  ]
+
+  data = {
+    "name" = "${local.prefix}-disk"
+    "uri"  = azurerm_managed_disk.ifrcgo.id
+  }
+}

--- a/deploy/terraform/resources/providers.tf
+++ b/deploy/terraform/resources/providers.tf
@@ -12,5 +12,9 @@ terraform {
       source = "hashicorp/helm"
       version = "=2.5.1"
     }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = "=2.24.0"
+    }
   }
 }


### PR DESCRIPTION
## Changes

Saves disk config in a k8s configmap.

We will use this configmap as the intermediate link between terraform and helm where we store terraform artifacts used in the go-api helm chart. Later on we will use this configmap in helm when we decouple the go-api helm chart from terraform