### PR TITLE
Use specific terraform docker image tag

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:latest
+FROM hashicorp/terraform:1.6.5
 
 RUN apk update
 RUN apk add wget unzip curl \


### PR DESCRIPTION
Address issue
- https://dev.azure.com/IFRC/IFRC_GO/_build/results?buildId=22904&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=08703039-49d0-5b78-7691-5b9414c62c1d&s=96ac2280-8cb4-5df5-99de-dd2da759617d

![Thu Dec 14 02:02:28 PM +0545 2023](https://github.com/IFRCGo/go-api/assets/7059255/acc22093-2009-4faf-8f64-80f79ff43d8a)

> NOTE: This is a quick fix. 

Changes:
- Newer has issue with python system `This environment is externally managed`