### PR TITLE
Configure terraform to ignore changes to cert-manager

### DIFF
--- a/deploy/terraform/resources/helm-cert-manager.tf
+++ b/deploy/terraform/resources/helm-cert-manager.tf
@@ -1,4 +1,8 @@
 resource "helm_release" "ifrcgo-cert-manager" {
+  lifecycle {
+    ignore_changes = all
+  }
+
   name             = "cert-manager"
   repository       = "https://charts.jetstack.io"
   chart            = "cert-manager"


### PR DESCRIPTION
We will try to remove cert-manager again. But this time by following [the official instructions](https://cert-manager.io/docs/installation/helm/#uninstalling-with-helm) via helm instead of deleting cert-manager resources via Terraform.

So for now, we configure Terraform to ignore changes to the cert-manager installation.

ref https://github.com/IFRCGo/go-api/pull/2005

cc @batpad @szabozoltan69 