### PR TITLE
Sentry Cron Job Monitoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,13 @@ jobs:
               exit 1;
             }
       - run:
+          name: Validate SentryMonitor config
+          command: |
+            docker-compose run --rm serve ./manage.py cron_job_monitor --validate-only || {
+              echo 'There are some changes to be reflected in the SentryMonitor. Make sure to update SentryMonitor';
+              exit 1;
+            }
+      - run:
           name: Run tests
           command: |
             time docker-compose run --rm serve ./manage.py test --keepdb -v 2 --pattern="test_fake.py" &&

--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ For updating the index
 ```(bash)
 docker-compose exec serve bash python manage.py update_index
 ```
+## Sentry
+
+For updating the cron monitored tasks
+```(bash)
+docker-compose exec serve bash ./manage.py cron_job_monitor
+```
 
 ## See logs from Kubernetes
 There are a few different ways to see logs in the new Kubernetes based stack. Both of the options require `kubectl`, access to the cluster. Once the cluster is added to your local kubernetes context, follow the steps below:

--- a/api/management/commands/cron_job_monitor.py
+++ b/api/management/commands/cron_job_monitor.py
@@ -3,43 +3,64 @@ import logging
 
 from urllib.parse import urlparse
 from django.core.management.base import BaseCommand
-from main.sentry import SentryMonitor
+from django.conf import settings
 
 from main.settings import SENTRY_DSN
+from main.sentry import SentryMonitor
 
 logger = logging.getLogger(__name__)
 
+
 class Command(BaseCommand):
 
-    help = "This command is used to create a cron job monitor for sentry"
+    help = 'This command is used to create a cron job monitor for sentry'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--validate-only',
+            dest='validate_only',
+            action='store_true',
+        )
 
     def handle(self, *args, **options):
+        SentryMonitor.validate_config()
+
         if not SENTRY_DSN:
-            logger.error("SENTRY_DSN is not set in the environment variables. Exiting...")
+            logger.error('SENTRY_DSN is not set in the environment variables. Exiting...')
             return
+
+        if options.get('validate_only'):
+            return
+
         parsed_url = urlparse(SENTRY_DSN)
-        project_id = parsed_url.path.strip("/")
+        project_id = parsed_url.path.strip('/')
         api_key = parsed_url.username
 
-        SENTRY_INGEST = f"https://{parsed_url.hostname}"
+        SENTRY_INGEST = f'https://{parsed_url.hostname}'
 
         for cronjob in SentryMonitor.choices:
             job, schedule = cronjob
-            SENTRY_CRONS = f"{SENTRY_INGEST}/api/{project_id}/cron/{job}/{api_key}/"
+            SENTRY_CRONS = f'{SENTRY_INGEST}/api/{project_id}/cron/{job}/{api_key}/'
 
             payload = {
-                "monitor_config": {
-                    "schedule": {
-                        "type": "crontab",
-                        "value": str(schedule)
-                    }
+                'monitor_config': {
+                    'schedule': {
+                        'type': 'crontab',
+                        'value': str(schedule),
+                    },
                 },
-                'environment':'development',
-                "status": "ok",
+                'environment': settings.GO_ENVIRONMENT,
+                'status': 'ok',
             }
 
-            response = requests.post(SENTRY_CRONS, json=payload, headers={"Content-Type": "application/json"})
+            response = requests.post(SENTRY_CRONS, json=payload, headers={'Content-Type': 'application/json'})
             if response.status_code == 202:
-                logger.info(f"Successfully created cron job for {job}")
+                self.stdout.write(
+                    self.style.SUCCESS(f'Successfully created cron job for {job}')
+                )
             else:
-                logger.error(f"Failed to create cron job for {job} with status code {response.status_code}")
+                self.stdout.write(
+                    self.style.ERROR(
+                        f'Failed to create cron job for {job} with status code {response.status_code}: {response.content}'
+                    )
+                )

--- a/api/management/commands/cron_job_monitor.py
+++ b/api/management/commands/cron_job_monitor.py
@@ -3,7 +3,7 @@ import logging
 
 from urllib.parse import urlparse
 from django.core.management.base import BaseCommand
-from main.sentry import CRON_JOBS_MONITOR_SCHEDULE
+from main.sentry import SentryMonitor
 
 from main.settings import SENTRY_DSN
 
@@ -23,14 +23,15 @@ class Command(BaseCommand):
 
         SENTRY_INGEST = f"https://{parsed_url.hostname}"
 
-        for job, schedule in CRON_JOBS_MONITOR_SCHEDULE:
+        for cronjob in SentryMonitor.choices:
+            job, schedule = cronjob
             SENTRY_CRONS = f"{SENTRY_INGEST}/api/{project_id}/cron/{job}/{api_key}/"
 
             payload = {
                 "monitor_config": {
                     "schedule": {
                         "type": "crontab",
-                        "value": schedule
+                        "value": str(schedule)
                     }
                 },
                 'environment':'development',

--- a/api/management/commands/index_and_notify.py
+++ b/api/management/commands/index_and_notify.py
@@ -1,6 +1,6 @@
 import html
 from datetime import datetime, timezone, timedelta
-from main.sentry import INDEX_AND_NOTIFY
+from main.sentry import SentryMonitor
 from sentry_sdk.crons import monitor
 from django.db.models import Q, F, ExpressionWrapper, DurationField, Sum
 from django.db.models.query import QuerySet
@@ -57,7 +57,7 @@ RTYPE_NAMES = {
     14: "General Announcement",
 }
 
-@monitor(monitor_slug=INDEX_AND_NOTIFY)
+@monitor(monitor_slug=SentryMonitor.INDEX_AND_NOTIFY)
 class Command(BaseCommand):
     help = "Index and send notifications about new/changed records"
 

--- a/api/management/commands/index_and_notify.py
+++ b/api/management/commands/index_and_notify.py
@@ -1,6 +1,7 @@
 import html
 from datetime import datetime, timezone, timedelta
-
+from main.sentry import INDEX_AND_NOTIFY
+from sentry_sdk.crons import monitor
 from django.db.models import Q, F, ExpressionWrapper, DurationField, Sum
 from django.db.models.query import QuerySet
 from django.core.management.base import BaseCommand
@@ -56,7 +57,7 @@ RTYPE_NAMES = {
     14: "General Announcement",
 }
 
-
+@monitor(monitor_slug=INDEX_AND_NOTIFY)
 class Command(BaseCommand):
     help = "Index and send notifications about new/changed records"
 

--- a/api/management/commands/ingest_appeals.py
+++ b/api/management/commands/ingest_appeals.py
@@ -11,7 +11,7 @@ from api.models import AppealType, Appeal, AppealFilter, Region, Country, Disast
 from api.fixtures.dtype_map import DISASTER_TYPE_MAPPING
 from api.logger import logger
 from api.create_cron import create_cron_record
-from main.sentry import INGEST_APPEALS
+from main.sentry import SentryMonitor
 
 
 CRON_NAME = "ingest_appeals"
@@ -20,7 +20,7 @@ DTYPE_KEYS = [a.lower() for a in DISASTER_TYPE_MAPPING.keys()]
 DTYPE_VALS = [a.lower() for a in DISASTER_TYPE_MAPPING.values()]
 GEC_CODES = GECCode.objects.select_related("country").all()
 
-@monitor(monitor_slug=INGEST_APPEALS)
+@monitor(monitor_slug=SentryMonitor.INGEST_APPEALS)
 class Command(BaseCommand):
     help = "Add new entries from Access database file"
 

--- a/api/management/commands/ingest_appeals.py
+++ b/api/management/commands/ingest_appeals.py
@@ -1,5 +1,6 @@
 import os
 import json
+from sentry_sdk.crons import monitor
 from requests import Session, exceptions as reqexc
 from requests.adapters import HTTPAdapter
 from datetime import datetime, timezone, timedelta
@@ -10,6 +11,7 @@ from api.models import AppealType, Appeal, AppealFilter, Region, Country, Disast
 from api.fixtures.dtype_map import DISASTER_TYPE_MAPPING
 from api.logger import logger
 from api.create_cron import create_cron_record
+from main.sentry import INGEST_APPEALS
 
 
 CRON_NAME = "ingest_appeals"
@@ -18,7 +20,7 @@ DTYPE_KEYS = [a.lower() for a in DISASTER_TYPE_MAPPING.keys()]
 DTYPE_VALS = [a.lower() for a in DISASTER_TYPE_MAPPING.values()]
 GEC_CODES = GECCode.objects.select_related("country").all()
 
-
+@monitor(monitor_slug=INGEST_APPEALS)
 class Command(BaseCommand):
     help = "Add new entries from Access database file"
 

--- a/api/management/commands/revoke_staff_status.py
+++ b/api/management/commands/revoke_staff_status.py
@@ -1,11 +1,13 @@
 import requests
+from sentry_sdk.crons import monitor
 from django.core.management.base import BaseCommand
 from django.contrib.auth.models import User, Group
 from api.logger import logger
+from main.sentry import REVOKE_STAFF_STATUS
 
 # from registrations.views import is_valid_domain
 
-
+@monitor(monitor_slug=REVOKE_STAFF_STATUS)
 class Command(BaseCommand):
     help = 'Update staff status in auth_user table according to "Read only" group'
 

--- a/api/management/commands/revoke_staff_status.py
+++ b/api/management/commands/revoke_staff_status.py
@@ -3,11 +3,11 @@ from sentry_sdk.crons import monitor
 from django.core.management.base import BaseCommand
 from django.contrib.auth.models import User, Group
 from api.logger import logger
-from main.sentry import REVOKE_STAFF_STATUS
+from main.sentry import SentryMonitor
 
 # from registrations.views import is_valid_domain
 
-@monitor(monitor_slug=REVOKE_STAFF_STATUS)
+@monitor(monitor_slug=SentryMonitor.REVOKE_STAFF_STATUS)
 class Command(BaseCommand):
     help = 'Update staff status in auth_user table according to "Read only" group'
 

--- a/api/management/commands/sync_appealdocs.py
+++ b/api/management/commands/sync_appealdocs.py
@@ -1,6 +1,8 @@
 import requests
 from datetime import datetime, timezone
 from dateutil.relativedelta import relativedelta
+from main.sentry import SYNC_APPEALDOCS
+from sentry_sdk.crons import monitor
 from django.core.management.base import BaseCommand
 from django.core.exceptions import ObjectDoesNotExist
 from api.models import Appeal, AppealDocument, CronJob, CronJobStatus
@@ -12,7 +14,7 @@ CRON_NAME = "sync_appealdocs"
 PUBLIC_SOURCE = "https://go-api.ifrc.org/api/publicsiteappeals?Hidden=false&Appealnumber="
 FEDNET_SOURCE = "https://go-api.ifrc.org/Api/FedNetAppeals?Hidden=false&Appealnumber="
 
-
+@monitor(monitor_slug=SYNC_APPEALDOCS)
 class Command(BaseCommand):
     help = "Ingest existing appeal documents"
 

--- a/api/management/commands/sync_appealdocs.py
+++ b/api/management/commands/sync_appealdocs.py
@@ -1,7 +1,7 @@
 import requests
 from datetime import datetime, timezone
 from dateutil.relativedelta import relativedelta
-from main.sentry import SYNC_APPEALDOCS
+from main.sentry import SentryMonitor
 from sentry_sdk.crons import monitor
 from django.core.management.base import BaseCommand
 from django.core.exceptions import ObjectDoesNotExist
@@ -14,7 +14,7 @@ CRON_NAME = "sync_appealdocs"
 PUBLIC_SOURCE = "https://go-api.ifrc.org/api/publicsiteappeals?Hidden=false&Appealnumber="
 FEDNET_SOURCE = "https://go-api.ifrc.org/Api/FedNetAppeals?Hidden=false&Appealnumber="
 
-@monitor(monitor_slug=SYNC_APPEALDOCS)
+@monitor(monitor_slug=SentryMonitor.SYNC_APPEALDOCS)
 class Command(BaseCommand):
     help = "Ingest existing appeal documents"
 

--- a/api/management/commands/sync_molnix.py
+++ b/api/management/commands/sync_molnix.py
@@ -1,11 +1,13 @@
 from dateutil import parser as date_parser
 import json
+from sentry_sdk.crons import monitor
 from django.db import transaction
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 from api.molnix_utils import MolnixApi
 from api.logger import logger
 from deployments.models import MolnixTag, MolnixTagGroup, PersonnelDeployment, Personnel
+from main.sentry import SYNC_MOLNIX
 from notifications.models import SurgeAlert, SurgeAlertType, SurgeAlertCategory
 from api.models import Event, Country, CronJobStatus
 from api.create_cron import create_cron_record
@@ -514,7 +516,7 @@ def sync_open_positions(molnix_positions, molnix_api, countries):
     ]
     return messages, warnings, successful_creates
 
-
+@monitor(monitor_slug=SYNC_MOLNIX)
 class Command(BaseCommand):
     help = "Sync data from Molnix API to GO db"
 

--- a/api/management/commands/sync_molnix.py
+++ b/api/management/commands/sync_molnix.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from api.molnix_utils import MolnixApi
 from api.logger import logger
 from deployments.models import MolnixTag, MolnixTagGroup, PersonnelDeployment, Personnel
-from main.sentry import SYNC_MOLNIX
+from main.sentry import SentryMonitor
 from notifications.models import SurgeAlert, SurgeAlertType, SurgeAlertCategory
 from api.models import Event, Country, CronJobStatus
 from api.create_cron import create_cron_record
@@ -516,7 +516,7 @@ def sync_open_positions(molnix_positions, molnix_api, countries):
     ]
     return messages, warnings, successful_creates
 
-@monitor(monitor_slug=SYNC_MOLNIX)
+@monitor(monitor_slug=SentryMonitor.SYNC_MOLNIX)
 class Command(BaseCommand):
     help = "Sync data from Molnix API to GO db"
 

--- a/api/management/commands/user_registration_reminder.py
+++ b/api/management/commands/user_registration_reminder.py
@@ -1,11 +1,13 @@
 from datetime import datetime, timezone, timedelta
 from django.core.management.base import BaseCommand
 from django.template.loader import render_to_string
+from sentry_sdk.crons import monitor
 from api.models import UserRegion, Region
+from main.sentry import USER_REGISTRATION_REMINDER
 from registrations.models import Pending
 from notifications.notification import send_notification
 
-
+@monitor(monitor_slug=USER_REGISTRATION_REMINDER)
 class Command(BaseCommand):
     help = "Send reminder about the pending registrations"
 

--- a/api/management/commands/user_registration_reminder.py
+++ b/api/management/commands/user_registration_reminder.py
@@ -3,11 +3,11 @@ from django.core.management.base import BaseCommand
 from django.template.loader import render_to_string
 from sentry_sdk.crons import monitor
 from api.models import UserRegion, Region
-from main.sentry import USER_REGISTRATION_REMINDER
+from main.sentry import SentryMonitor
 from registrations.models import Pending
 from notifications.notification import send_notification
 
-@monitor(monitor_slug=USER_REGISTRATION_REMINDER)
+@monitor(monitor_slug=SentryMonitor.USER_REGISTRATION_REMINDER)
 class Command(BaseCommand):
     help = "Send reminder about the pending registrations"
 

--- a/country_plan/management/commands/ingest_country_plan_file.py
+++ b/country_plan/management/commands/ingest_country_plan_file.py
@@ -7,6 +7,8 @@ from django.core.management.base import BaseCommand
 from django.core.files.base import File
 from django.conf import settings
 from django.db import models
+from sentry_sdk.crons import monitor
+from main.sentry import INGEST_COUNTRY_PLAN_FILE
 
 from main.utils import DownloadFileManager
 from api.models import Country
@@ -50,7 +52,7 @@ def get_meta_from_url(url) -> Tuple[Optional[str], str]:
     resp = requests.head(url)
     return resp.headers.get('Content-Type'), _get_filename_from_headers(resp)
 
-
+@monitor(monitor_slug=INGEST_COUNTRY_PLAN_FILE)
 class Command(BaseCommand):
     @staticmethod
     def load_file_to_country_plan(country_plan: CountryPlan, url: str, filename: str, field_name: str):

--- a/country_plan/management/commands/ingest_country_plan_file.py
+++ b/country_plan/management/commands/ingest_country_plan_file.py
@@ -8,7 +8,7 @@ from django.core.files.base import File
 from django.conf import settings
 from django.db import models
 from sentry_sdk.crons import monitor
-from main.sentry import INGEST_COUNTRY_PLAN_FILE
+from main.sentry import SentryMonitor
 
 from main.utils import DownloadFileManager
 from api.models import Country
@@ -52,7 +52,7 @@ def get_meta_from_url(url) -> Tuple[Optional[str], str]:
     resp = requests.head(url)
     return resp.headers.get('Content-Type'), _get_filename_from_headers(resp)
 
-@monitor(monitor_slug=INGEST_COUNTRY_PLAN_FILE)
+@monitor(monitor_slug=SentryMonitor.INGEST_COUNTRY_PLAN_FILE)
 class Command(BaseCommand):
     @staticmethod
     def load_file_to_country_plan(country_plan: CountryPlan, url: str, filename: str, field_name: str):

--- a/deployments/management/commands/update_project_status.py
+++ b/deployments/management/commands/update_project_status.py
@@ -9,7 +9,7 @@ from django.db.models import Q
 from sentry_sdk.crons import monitor
 
 from main.frontend import get_project_url
-from main.sentry import UPDATE_PROJECT_STATUS
+from main.sentry import SentryMonitor
 from notifications.notification import send_notification
 from deployments.models import Project, Statuses
 
@@ -21,7 +21,7 @@ PROJECT_STATUS_WILL_COMPLETE_MESSAGE = _(
     ' You can update the end date to further keep the project in <i>Ongoing</i> status.'
 )
 
-@monitor(monitor_slug=UPDATE_PROJECT_STATUS)
+@monitor(monitor_slug=SentryMonitor.UPDATE_PROJECT_STATUS)
 class Command(BaseCommand):
 
     help = 'Update project status using start/end date'

--- a/deployments/management/commands/update_project_status.py
+++ b/deployments/management/commands/update_project_status.py
@@ -6,8 +6,10 @@ from django.utils.translation import gettext
 from django.utils import timezone
 from django.urls import reverse
 from django.db.models import Q
+from sentry_sdk.crons import monitor
 
 from main.frontend import get_project_url
+from main.sentry import UPDATE_PROJECT_STATUS
 from notifications.notification import send_notification
 from deployments.models import Project, Statuses
 
@@ -19,7 +21,7 @@ PROJECT_STATUS_WILL_COMPLETE_MESSAGE = _(
     ' You can update the end date to further keep the project in <i>Ongoing</i> status.'
 )
 
-
+@monitor(monitor_slug=UPDATE_PROJECT_STATUS)
 class Command(BaseCommand):
 
     help = 'Update project status using start/end date'

--- a/deployments/snapshots/snap_tests.py
+++ b/deployments/snapshots/snap_tests.py
@@ -11,12 +11,12 @@ snapshots['TestProjectAPI::test_global_project_api 1'] = {
     'ns_with_ongoing_activities': 16,
     'projects_per_programme_type': [
         {
-            'count': 5,
+            'count': 6,
             'programme_type': 0,
             'programme_type_display': 'Bilateral'
         },
         {
-            'count': 4,
+            'count': 3,
             'programme_type': 1,
             'programme_type_display': 'Multilateral'
         },
@@ -63,16 +63,16 @@ snapshots['TestProjectAPI::test_global_project_api 2'] = [
         'target_total': 0
     },
     {
-        'budget_amount_total': 2310000,
+        'budget_amount_total': 720000,
         'id': 7,
         'iso3': 'kfs',
         'name': 'country-ZwjrVnVzStakFageXSAHAPsUBklxlTimFlGhCKnlmdVlZWmqAC',
         'ongoing_projects': 1,
         'operation_types': [
-            0
+            1
         ],
         'operation_types_display': [
-            'Programme'
+            'Emergency Operation'
         ],
         'projects_per_sector': [
             {
@@ -88,7 +88,7 @@ snapshots['TestProjectAPI::test_global_project_api 2'] = [
         'budget_amount_total': 4740000,
         'id': 9,
         'iso3': 'hWp',
-        'name': 'country-BAdOgXrUUrqOGvAQqwfagTZFpLFoLBQrgXTFJMKyMHQycMgLYP',
+        'name': 'country-FSBAdOgXrUUrqOGvAQqwfagTZFpLFoLBQrgXTFJMKyMHQycMgL',
         'ongoing_projects': 1,
         'operation_types': [
             0

--- a/main/sentry.py
+++ b/main/sentry.py
@@ -1,13 +1,14 @@
 import os
-import enum
-
 import sentry_sdk
-from django.core.exceptions import PermissionDenied
-from celery.exceptions import Retry as CeleryRetry
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
+from celery.exceptions import Retry as CeleryRetry
+
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+from django.core.exceptions import PermissionDenied
 
 # Celery Terminated Exception: The worker processing a job has been terminated by user request.
 from billiard.exceptions import Terminated
@@ -20,30 +21,6 @@ IGNORED_ERRORS = [
 IGNORED_LOGGERS = [
     'django.core.exceptions.ObjectDoesNotExist',
 ]
-
-# Cron jobs
-INDEX_AND_NOTIFY= 'index_and_notify'
-SYNC_MOLNIX = 'sync_molnix'
-INGEST_APPEALS = 'ingest_appeals'
-SYNC_APPEALDOCS = 'sync_appealdocs'
-REVOKE_STAFF_STATUS = 'revoke_staff_status'
-UPDATE_PROJECT_STATUS = 'update_project_status'
-USER_REGISTRATION_REMINDER = 'user_registration_reminder'
-INGEST_COUNTRY_PLAN_FILE  = 'ingest_country_plan_file'
-UPDATE_SURGE_ALERT_STATUS = 'update_surge_alert_status'
-
-# Cron job schedule
-CRON_JOBS_MONITOR_SCHEDULE = (
-    (INDEX_AND_NOTIFY, '*/5 * * * *'),
-    (SYNC_MOLNIX, '*/10 * * * *'),
-    (INGEST_APPEALS, '45 */2 * * *'),
-    (SYNC_APPEALDOCS, '15 * * * *'),
-    (REVOKE_STAFF_STATUS, '51 * * * *'),
-    (UPDATE_PROJECT_STATUS, '1 3 * * *'),
-    (USER_REGISTRATION_REMINDER, '0 9 * * *'),
-    (INGEST_COUNTRY_PLAN_FILE, '1 0 * * *'),
-    (UPDATE_SURGE_ALERT_STATUS, '1 */12 * * *'),
-)
 
 for _logger in IGNORED_LOGGERS:
     ignore_logger(_logger)
@@ -119,3 +96,19 @@ def init_sentry(app_type, tags={}, **config):
         scope.set_tag('app_type', app_type)
         for tag, value in tags.items():
             scope.set_tag(tag, value)
+
+
+class SentryMonitor(models.TextChoices):
+    '''
+    This class is used to create Sentry monitor of cron jobs
+    @Note: Before adding the jobs to this class, make sure to add the job to the `Values.yaml` file
+    '''
+    INDEX_AND_NOTIFY = 'index_and_notify', _('*/5 * * * *')
+    SYNC_MOLNIX = 'sync_molnix', _('*/10 * * * *')
+    INGEST_APPEALS = 'ingest_appeals', _('45 */2 * * *')
+    SYNC_APPEALDOCS = 'sync_appealdocs', _('15 * * * *')
+    REVOKE_STAFF_STATUS = 'revoke_staff_status', _('51 * * * *')
+    UPDATE_PROJECT_STATUS = 'update_project_status', _('1 3 * * *')
+    USER_REGISTRATION_REMINDER = 'user_registration_reminder', _('0 9 * * *')
+    INGEST_COUNTRY_PLAN_FILE = 'ingest_country_plan_file', _('1 0 * * *')
+    UPDATE_SURGE_ALERT_STATUS = 'update_surge_alert_status', _('1 */12 * * *')

--- a/main/sentry.py
+++ b/main/sentry.py
@@ -1,4 +1,5 @@
 import os
+import enum
 
 import sentry_sdk
 from django.core.exceptions import PermissionDenied
@@ -94,3 +95,24 @@ def init_sentry(app_type, tags={}, **config):
         scope.set_tag('app_type', app_type)
         for tag, value in tags.items():
             scope.set_tag(tag, value)
+
+class SentryMonitor(enum.Enum):
+    INDEX_AND_NOTIFY = 'index_and_notify',
+    SYNC_MOLNIX= 'sync_molnix',
+    INGEST_APPEALS = 'ingest_appeals',
+    SYNC_APPEAL_DOCS = 'sync_appealdocs',
+    REVOKE_STAFF_STATUS = 'revoke_staff_status',
+    UPDATE_PROJECT_STATUS = 'update_project_status',
+    USER_REGISTRATION_REMAINDER = 'user_registration_reminder',
+    UPDATE_SURGE_ALERT_STATUS = 'update_surge_alert_status',
+
+    _schedule = {
+        INDEX_AND_NOTIFY: '*/5 * * * *',
+        SYNC_MOLNIX: '*/10 * * * *',
+        INGEST_APPEALS: '45 */2 * * *',
+        SYNC_APPEAL_DOCS: '15 * * * *',
+        REVOKE_STAFF_STATUS: '51 * * * *',
+        UPDATE_PROJECT_STATUS: '1 3 * * *',
+        USER_REGISTRATION_REMAINDER: '0 9 * * *',
+        UPDATE_SURGE_ALERT_STATUS: '1 */12 * * *',
+    }

--- a/main/sentry.py
+++ b/main/sentry.py
@@ -21,6 +21,30 @@ IGNORED_LOGGERS = [
     'django.core.exceptions.ObjectDoesNotExist',
 ]
 
+# Cron jobs
+INDEX_AND_NOTIFY= 'index_and_notify'
+SYNC_MOLNIX = 'sync_molnix'
+INGEST_APPEALS = 'ingest_appeals'
+SYNC_APPEALDOCS = 'sync_appealdocs'
+REVOKE_STAFF_STATUS = 'revoke_staff_status'
+UPDATE_PROJECT_STATUS = 'update_project_status'
+USER_REGISTRATION_REMINDER = 'user_registration_reminder'
+INGEST_COUNTRY_PLAN_FILE  = 'ingest_country_plan_file'
+UPDATE_SURGE_ALERT_STATUS = 'update_surge_alert_status'
+
+# Cron job schedule
+CRON_JOBS_MONITOR_SCHEDULE = (
+    (INDEX_AND_NOTIFY, '*/5 * * * *'),
+    (SYNC_MOLNIX, '*/10 * * * *'),
+    (INGEST_APPEALS, '45 */2 * * *'),
+    (SYNC_APPEALDOCS, '15 * * * *'),
+    (REVOKE_STAFF_STATUS, '51 * * * *'),
+    (UPDATE_PROJECT_STATUS, '1 3 * * *'),
+    (USER_REGISTRATION_REMINDER, '0 9 * * *'),
+    (INGEST_COUNTRY_PLAN_FILE, '1 0 * * *'),
+    (UPDATE_SURGE_ALERT_STATUS, '1 */12 * * *'),
+)
+
 for _logger in IGNORED_LOGGERS:
     ignore_logger(_logger)
 
@@ -95,24 +119,3 @@ def init_sentry(app_type, tags={}, **config):
         scope.set_tag('app_type', app_type)
         for tag, value in tags.items():
             scope.set_tag(tag, value)
-
-class SentryMonitor(enum.Enum):
-    INDEX_AND_NOTIFY = 'index_and_notify',
-    SYNC_MOLNIX= 'sync_molnix',
-    INGEST_APPEALS = 'ingest_appeals',
-    SYNC_APPEAL_DOCS = 'sync_appealdocs',
-    REVOKE_STAFF_STATUS = 'revoke_staff_status',
-    UPDATE_PROJECT_STATUS = 'update_project_status',
-    USER_REGISTRATION_REMAINDER = 'user_registration_reminder',
-    UPDATE_SURGE_ALERT_STATUS = 'update_surge_alert_status',
-
-    _schedule = {
-        INDEX_AND_NOTIFY: '*/5 * * * *',
-        SYNC_MOLNIX: '*/10 * * * *',
-        INGEST_APPEALS: '45 */2 * * *',
-        SYNC_APPEAL_DOCS: '15 * * * *',
-        REVOKE_STAFF_STATUS: '51 * * * *',
-        UPDATE_PROJECT_STATUS: '1 3 * * *',
-        USER_REGISTRATION_REMAINDER: '0 9 * * *',
-        UPDATE_SURGE_ALERT_STATUS: '1 */12 * * *',
-    }

--- a/main/sentry_monitor.py
+++ b/main/sentry_monitor.py
@@ -1,0 +1,45 @@
+import requests
+import logging
+
+from urllib.parse import urlparse
+from django.core.management.base import BaseCommand
+from main.settings import SENTRY_DSN
+from .sentry import SentryMonitor
+
+logger = logging.getLogger(__name__)
+
+class Command(BaseCommand):
+
+    help = "This command is used to create a cron job monitor for sentry"
+
+    def handle(self, *args, **options):
+        if not SENTRY_DSN:
+            logger.error("SENTRY_DSN is not set in the environment variables. Exiting...")
+            return
+        parsed_url = urlparse(SENTRY_DSN)
+        project_id = parsed_url.path.strip("/")[-1]
+        api_key = parsed_url.username
+
+        SENTRY_INGEST = f"https://{parsed_url.hostname}"
+
+        for monitor in SentryMonitor:
+            job = monitor.value[0]
+            schedule = SentryMonitor._schedule[monitor]
+            SENTRY_CRONS = f"{SENTRY_INGEST}/api/{project_id}/cron/{job}/{api_key}/"
+
+            payload = {
+                "monitor_config": {
+                    "schedule": {
+                        "type": "crontab",
+                        "value": schedule
+                    }
+                },
+                "status": "ok"
+            }
+
+            response = requests.post(SENTRY_CRONS, json=payload, headers={"Content-Type": "application/json"})
+            if response.status_code == 201:
+                logger.info(f"Successfully created cron job for {monitor.name}")
+            else:
+                logger.error(f"Failed to create cron job for {monitor.name} with status code {response.status_code}")
+                logger.error(response.json())

--- a/notifications/management/commands/update_surge_alert_status.py
+++ b/notifications/management/commands/update_surge_alert_status.py
@@ -1,18 +1,25 @@
 import logging
-from django.db import models
+from sentry_sdk.crons import monitor
 
 from django.core.management.base import BaseCommand
 from django.utils import timezone
+from django.db import models
+
 from notifications.models import SurgeAlert, SurgeAlertStatus
 from api.models import CronJob, CronJobStatus
+from main.sentry import UPDATE_SURGE_ALERT_STATUS
+
 
 logger = logging.getLogger(__name__)
 
+
+@monitor(monitor_slug=UPDATE_SURGE_ALERT_STATUS)
 class Command(BaseCommand):
     '''
         Updating the Surge Alert Status according:
         If the alert status is marked as stood_down, then the status is Stood Down.
-        If the closing timestamp (closes) is earlier than the current date, the status is displayed as Closed. Otherwise, it is displayed as Open.
+        If the closing timestamp (closes) is earlier than the current date, the status is displayed as Closed.
+        Otherwise, it is displayed as Open.
     '''
     help = 'Update surge alert status'
 
@@ -31,7 +38,7 @@ class Command(BaseCommand):
             )
             CronJob.sync_cron({
                 'name': 'update_surge_alert_status',
-                'message': f'Updated Surge alerts status',
+                'message': 'Updated Surge alerts status',
                 'status': CronJobStatus.SUCCESSFUL,
             })
             logger.info('Updated Surge alerts status')

--- a/notifications/management/commands/update_surge_alert_status.py
+++ b/notifications/management/commands/update_surge_alert_status.py
@@ -7,13 +7,13 @@ from django.db import models
 
 from notifications.models import SurgeAlert, SurgeAlertStatus
 from api.models import CronJob, CronJobStatus
-from main.sentry import UPDATE_SURGE_ALERT_STATUS
+from main.sentry import SentryMonitor
 
 
 logger = logging.getLogger(__name__)
 
 
-@monitor(monitor_slug=UPDATE_SURGE_ALERT_STATUS)
+@monitor(monitor_slug=SentryMonitor.UPDATE_SURGE_ALERT_STATUS)
 class Command(BaseCommand):
     '''
         Updating the Surge Alert Status according:


### PR DESCRIPTION
Addresses 
- https://github.com/IFRCGo/go-api/issues/2010

## Changes
 - Add Command for creating slug for respective Cron jobs
 - Add monitoring slug to the cron jobs: https://docs.sentry.io/product/crons/
 
 
 ### NOTE: We need to initialize the sentry cron configuration using this command
```bash
./manage.py cron_job_monitor
```
> NOTE: Any change in SentryMonitor requires above command for sync

> NOTE: This will push updates to https://sentry.northeurope.cloudapp.azure.com/organizations/ifrc-go/crons/?project=2