### PR TITLE
[Experimental Typing] Override enum type name for openapi

### DIFF
--- a/main/enums.py
+++ b/main/enums.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from rest_framework import serializers
 
 from dref import enums as dref_enums
@@ -44,6 +45,8 @@ global_enum_registers = generate_global_enum_register()
 
 def generate_enum_global_serializer(name):
     def _get_enum_key_value_serializer(enum, enum_name):
+        _enum_name = enum_name.replace('EnumSerializer', 'EnumKey')
+        settings.SPECTACULAR_SETTINGS['ENUM_NAME_OVERRIDES'][_enum_name] = enum
         return type(
             enum_name,
             (serializers.Serializer,),

--- a/main/settings.py
+++ b/main/settings.py
@@ -593,7 +593,8 @@ SPECTACULAR_SETTINGS = {
     'DESCRIPTION': 'Please see the <a href="https://go-wiki.ifrc.org/en/go-api/api-overview" target="_blank">GO Wiki</a> for an overview of API usage, or the interactive <a href="/api-docs/swagger-ui/" target="_blank">Swagger page</a>.',
     'VERSION': '1.0.0',
     'SERVE_INCLUDE_SCHEMA': False,
-     'ENUM_ADD_EXPLICIT_BLANK_NULL_CHOICE': False,
+    'ENUM_ADD_EXPLICIT_BLANK_NULL_CHOICE': False,
+    'ENUM_NAME_OVERRIDES': {},
     # 'POSTPROCESSING_HOOKS': []
 }
 


### PR DESCRIPTION
Addresses random enum type name in openapi schema

## Changes

* Use global enum registry to set manual enum names