### PR TITLE
Build and push docker images and helm charts on every push to develop

### DIFF
--- a/.github/workflows/build-publish-docker-helm.yaml
+++ b/.github/workflows/build-publish-docker-helm.yaml
@@ -9,6 +9,9 @@ on:
     tags:
     - "**"
 
+permissions:
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-publish-docker-helm.yaml
+++ b/.github/workflows/build-publish-docker-helm.yaml
@@ -1,0 +1,54 @@
+name: Builds and pushes Docker Images and Helm charts to Github Registry
+
+on:
+  # Build and push Docker image and Helm charts on every push to develop branch
+  # and on every tag push
+  push:
+    branches:
+    - develop
+    tags:
+    - "**"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Install chart publishing dependencies (chartpress, helm)
+      run: |
+        pip install chartpress
+        pip list
+
+        helm version
+
+    - name: Build and push Docker image. Update the image tag, chart version etc as needed
+      run: |
+        cd deploy/helm
+        # hack to push the image to ghcr.io. We will update chartpress.yaml when we move to separate deploy repo
+        python -c "import re; data=open('chartpress.yaml').read(); open('chartpress.yaml', 'w').write(re.sub(r'ifrcgoacr.azurecr.io/ifrcgo-', 'ghcr.io/IFRCGo/go-', data))"
+        chartpress --push
+
+    - name: Get the version
+      id: get_version
+      run: echo ::set-output name=VERSION::$(cat deploy/helm/ifrcgo-helm/Chart.yaml | grep version | awk '{print $2}')
+
+    - name: Package Helm Chart
+      run: |
+        helm package deploy/helm/ifrcgo-helm -d .helm-charts
+
+    - name: Push Helm Chart
+      run: |
+        helm push .helm-charts/ifrcgo-helm-${{ steps.get_version.outputs.VERSION }}.tgz oci://ghcr.io/IFRCGo/go-api


### PR DESCRIPTION
The CI will build appropriately tagged docker images and helm charts for every push to develop and for every tag. We will used these published images and charts to deploy go-api once we move deployment to a separate repo.

The docker images and Helm charts are published to GHCR.

refs https://github.com/IFRCGo/go-api/issues/1885

cc @batpad @szabozoltan69 