### PR TITLE
Add filter by per in per-document-upload

### DIFF
--- a/per/migrations/0100_auto_20240130_0851.py
+++ b/per/migrations/0100_auto_20240130_0851.py
@@ -43,7 +43,7 @@ class Migration(migrations.Migration):
             )
             if form_question_group.exists():
                 form_question_group_first = form_question_group.first()
-                question.question_group = form_question_group
+                question.question_group = form_question_group_first
                 question.save(update_fields=['question_group'])
                 question_count += 1
 

--- a/per/serializers.py
+++ b/per/serializers.py
@@ -1025,16 +1025,19 @@ class PerDocumentUploadSerializer(serializers.ModelSerializer):
 
     def validate(self, data):
         country = data['country']
-        user_document_count = PerDocumentUpload.objects.filter(
-            country=country,
-            created_by=self.context["request"].user
-        ).count()
-        if user_document_count > self.MAX_NUMBER_OF_DOCUMENTS:
-            raise serializers.ValidationError(
-                {
-                    "file": gettext("Can add utmost %s documents" % self.MAX_NUMBER_OF_DOCUMENTS)
-                }
-            )
+        per = data.get('per')
+        if per:
+            user_document_count = PerDocumentUpload.objects.filter(
+                country=country,
+                created_by=self.context["request"].user,
+                per=per
+            ).count()
+            if user_document_count > self.MAX_NUMBER_OF_DOCUMENTS:
+                raise serializers.ValidationError(
+                    {
+                        "file": gettext("Can add utmost %s documents" % self.MAX_NUMBER_OF_DOCUMENTS)
+                    }
+                )
         return data
 
     def validate_per(self, per):


### PR DESCRIPTION
Addresses
- https://github.com/IFRCGo/go-api/issues/2093

## Changes
- Add per document upload limit to 10 per PER cycle for a country

## Checklist
Things that should succeed before merging.

- [ ] Updated/ran unit tests
- [ ] Updated CHANGELOG.md

## Release

If there is a version update, make sure to tag the repository with the latest version.