### PR TITLE
Remove additionalDomain that's no longer being used

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       environment:
         # For Terraform
         - TF_VAR_domain=${API_FQDN}
-        - TF_VAR_additionalDomain=${API_ADDITIONAL_FQDN}
         - TF_VAR_username=${USER}
         - TF_VAR_environment=${environment}
         - TF_VAR_subscriptionId=${subscriptionId}

--- a/deploy/helm/ifrcgo-helm/templates/api/ingress.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/api/ingress.yaml
@@ -14,11 +14,6 @@ spec:
     - hosts:
       - {{ .Values.api.domain }}
       secretName: {{ template "ifrcgo-helm.fullname" . }}-secret-api-cert
-    {{- if .Values.api.additionalDomain }}
-    - hosts:
-      - {{ .Values.api.additionalDomain }}
-      secretName: {{ template "ifrcgo-helm.fullname" . }}-secret-api-additional-domain-cert
-    {{- end }}
 
   rules:
   - host: {{ .Values.api.domain }}
@@ -31,16 +26,4 @@ spec:
             name: {{ template "ifrcgo-helm.fullname" . }}-api
             port:
               number: 80
-  {{- if .Values.api.additionalDomain }}
-  - host: {{ .Values.api.additionalDomain }}
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ template "ifrcgo-helm.fullname" . }}-api
-            port:
-              number: 80
-  {{- end }}
 {{- end }}

--- a/deploy/helm/ifrcgo-helm/templates/api/secrets.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/api/secrets.yaml
@@ -6,16 +6,3 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ .Values.secrets.API_TLS_CRT | quote}}
   tls.key: {{ .Values.secrets.API_TLS_KEY | quote}}
-
----
-
-{{- if .Values.api.additionalDomain }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ template "ifrcgo-helm.fullname" . }}-secret-api-additional-domain-cert
-type: kubernetes.io/tls
-data:
-  tls.crt: {{ .Values.secrets.API_ADDITIONAL_DOMAIN_TLS_CRT | quote}}
-  tls.key: {{ .Values.secrets.API_ADDITIONAL_DOMAIN_TLS_KEY | quote}}
-{{- end }}

--- a/deploy/helm/ifrcgo-helm/values-production.yaml
+++ b/deploy/helm/ifrcgo-helm/values-production.yaml
@@ -20,7 +20,6 @@ env:
 
 api:
   domain: goadmin.ifrc.org
-  additionalDomain: api.go.ifrc.org
   replicaCount: 2
   resources:
     requests:

--- a/deploy/helm/ifrcgo-helm/values-staging.yaml
+++ b/deploy/helm/ifrcgo-helm/values-staging.yaml
@@ -20,7 +20,6 @@ env:
 
 api:
   domain: goadmin-stage.ifrc.org
-  additionalDomain: ""
   replicaCount: 1
   resources:
     requests:

--- a/deploy/helm/ifrcgo-helm/values.yaml
+++ b/deploy/helm/ifrcgo-helm/values.yaml
@@ -65,7 +65,6 @@ secrets:
 
 api:
   domain: "go-staging.ifrc.org"
-  additionalDomain: ""
   enabled: true
   replicaCount: 1
   containerPort: 80

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -3,7 +3,6 @@ module "resources" {
   environment = var.environment
   subscriptionId = var.subscriptionId
   domain = var.domain
-  additionalDomain = var.additionalDomain
   DJANGO_SECRET_KEY = var.DJANGO_SECRET_KEY
   DJANGO_DB_NAME = var.DJANGO_DB_NAME
   DJANGO_DB_USER = var.DJANGO_DB_USER

--- a/deploy/terraform/resources/variables.tf
+++ b/deploy/terraform/resources/variables.tf
@@ -15,11 +15,6 @@ variable "domain" {
   type = string
 }
 
-variable "additionalDomain" {
-  type = string
-  default = ""
-}
-
 variable "DJANGO_SECRET_KEY" {
   type = string
 }

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -15,11 +15,6 @@ variable "domain" {
   type = string
 }
 
-variable "additionalDomain" {
-  type = string
-  default = ""
-}
-
 variable "DJANGO_SECRET_KEY" {
   type = string
 }

--- a/main/k8s_runserver.sh
+++ b/main/k8s_runserver.sh
@@ -10,7 +10,7 @@ python manage.py collectstatic --noinput -l
 
 # Add server name(s) to django settings and nginx - later maybe only nginx would be enough, and ALLOWED_HOSTS could be "*"
 if [ "$GO_ENVIRONMENT"x = productionx ]; then
-    sed -i 's/\$NGINX_SERVER_NAME/'$API_FQDN' api.go.ifrc.org/g' /etc/nginx/sites-available/nginx.conf
+    sed -i 's/\$NGINX_SERVER_NAME/'$API_FQDN'/g' /etc/nginx/sites-available/nginx.conf
     sed -i 's/CHANGE_ME_BEFORE_START/prod/' /etc/nginx/sites-available/nginx.conf
 else
     sed -i 's/\$NGINX_SERVER_NAME/'$API_FQDN'/g' /etc/nginx/sites-available/nginx.conf

--- a/main/runserver.sh
+++ b/main/runserver.sh
@@ -10,7 +10,7 @@ python manage.py collectstatic --noinput -l
 
 # Add server name(s) to django settings and nginx - later maybe only nginx would be enough, and ALLOWED_HOSTS could be "*"
 if [ "$GO_ENVIRONMENT"x = productionx ]; then
-    sed -i 's/\$NGINX_SERVER_NAME/'$API_FQDN' api.go.ifrc.org/g' /etc/nginx/sites-available/nginx.conf
+    sed -i 's/\$NGINX_SERVER_NAME/'$API_FQDN'/g' /etc/nginx/sites-available/nginx.conf
     sed -i 's/CHANGE_ME_BEFORE_START/prod/' /etc/nginx/sites-available/nginx.conf
 else
     sed -i 's/\$NGINX_SERVER_NAME/'$API_FQDN'/g' /etc/nginx/sites-available/nginx.conf


### PR DESCRIPTION
Removes the additionalDomain setting and k8s resources associated with it. Also removes hardcoded references to `api.go.ifrc.org`

cc @batpad @szabozoltan69 