### PR TITLE
fix version conflicts with chartpress - pin requests and docker versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,9 @@ jobs:
     displayName: "Checkout go-api"
     path: go-api
 
+  - bash: pip install requests==2.31.0 docker==6.1.3
+    displayName: "Install pinned versions of requests and docker"
+
   - bash: pip install -v chartpress
     displayName: "Install Chartpress"
 


### PR DESCRIPTION
Trying to fix recent errors with the build.

Getting an error like `docker.errors.DockerException: Error while fetching server API version: Not supported URL scheme http+docker` which seems to be related to https://github.com/docker/docker-py/issues/3256

The linked issues seem to indicate that pinning requests to `2.31.0` and `docker` to `<7.0.0` should get rid of that error.

cc @sunu @szabozoltan69 