### PR TITLE
Fix event-pk query n+1 selects

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -843,8 +843,8 @@ class FieldReportContactSerializer(ModelSerializer):
 
 
 class MiniFieldReportSerializer(ModelSerializer):
-    contacts = FieldReportContactSerializer(many=True)
-    countries = MiniCountrySerializer(many=True)
+    contacts = FieldReportContactSerializer(many=True, read_only=True)
+    countries = MiniCountrySerializer(many=True, read_only=True)
     epi_figures_source_display = serializers.CharField(source="get_epi_figures_source_display", read_only=True)
     visibility_display = serializers.CharField(source="get_visibility_display", read_only=True)
 

--- a/deployments/drf_views.py
+++ b/deployments/drf_views.py
@@ -424,7 +424,15 @@ class ProjectViewset(
         Project.objects.select_related(
             "user", "modified_by", "project_country", "reporting_ns", "dtype", "regional_project", "primary_sector"
         )
-        .prefetch_related("project_districts", "event", "annual_splits", "secondary_sectors", "project_admin2")
+        .prefetch_related(
+            "project_districts",
+            "event",
+            "event__appeals",
+            "event__countries_for_preview",
+            "annual_splits",
+            "secondary_sectors",
+            "project_admin2",
+        )
         .order_by("-modified_at")
         .all()
     )

--- a/deployments/drf_views.py
+++ b/deployments/drf_views.py
@@ -840,7 +840,17 @@ class EmergencyProjectViewSet(
 ):
     queryset = (
         EmergencyProject.objects.select_related("created_by", "reporting_ns", "event", "country", "deployed_eru", "modified_by")
-        .prefetch_related("districts", "activities", "admin2")
+        .prefetch_related(
+            "districts",
+            "admin2",
+            "event__appeals",
+            "event__countries_for_preview",
+            "activities",
+            "activities__sector",
+            "activities__action",
+            "activities__action__supplies",
+            "activities__points",
+        )
         .order_by("-modified_at")
         .all()
     )


### PR DESCRIPTION
Refers to Sentry issue organizations/ifrc-go/issues/2073