### PR TITLE
Disable --single-process for playwright

### DIFF
--- a/api/tasks.py
+++ b/api/tasks.py
@@ -85,7 +85,9 @@ def generate_url(url, export_id, user, title):
                 browser = p.chromium.launch(
                     headless=True,
                     args=[
-                        "--single-process",
+                        # https://github.com/microsoft/playwright-python/issues/1453
+                        # Usually required when running AWS lambda
+                        # "--single-process",
                         "--no-zygote",
                         "--no-sandbox",
                         "--disable-setuid-sandbox",


### PR DESCRIPTION
Chromium Browser crashes with single process

Addresses
- https://github.com/IFRCGo/go-web-app/issues/1236

## Changes

* Disable --single-process