### PR TITLE
Fix Fdrs sentry issue on cronjob

### DIFF
--- a/databank/management/commands/sources/FDRS.py
+++ b/databank/management/commands/sources/FDRS.py
@@ -123,7 +123,9 @@ def load(country, overview, fdrs_data):
     if country.iso is None or fdrs_data is None:
         return
 
-    fdrs_data_fetched_year = max(int(item["year"]) for item in fdrs_data.values())
+    fdrs_data_fetched_year = max(
+        int(item["year"]) for item in fdrs_data.values() if item is not None and item.get("year") is not None
+    )
 
     for fdrs_indicator, field in FDRS_INDICATORS_FIELD_MAP:
         value = fdrs_data.get(f"{country.iso.upper()}-{fdrs_indicator}")


### PR DESCRIPTION
Addresses 
- FDRS Sentry  issue

```
fdrs_data_fetched_year = max(int(item["year"]) for item in fdrs_data.values())
TypeError: 'NoneType' object is not subscriptable
```
## Changes
- Checking Empty value

## Checklist
Things that should succeed before merging.

- [ ] Updated/ran unit tests
- [ ] Updated CHANGELOG.md

## Release

If there is a version update, make sure to tag the repository with the latest version.