### PR TITLE
TinyMCE cleanup - no selector is needed in settings

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -23,7 +23,7 @@ from api.management.commands.index_and_notify import Command as Notify
 from lang.admin import TranslationAdmin, TranslationInlineModelAdmin
 from notifications.models import RecordType, SubscriptionType
 
-from .forms import ActionForm, DescriptionPlain, SocietyNameOverviewPlain, SummaryPlain
+from .forms import ActionForm
 
 # from reversion.models import Revision
 
@@ -183,12 +183,10 @@ class SituationReportInline(admin.TabularInline):
 
 class EventFeaturedDocumentInline(admin.TabularInline):
     model = models.EventFeaturedDocument
-    form = DescriptionPlain
 
 
 class EventLinkInline(admin.TabularInline, TranslationInlineModelAdmin):
     model = models.EventLink
-    form = DescriptionPlain
 
 
 class EventAdmin(CompareVersionAdmin, RegionRestrictedAdmin, TranslationAdmin):
@@ -319,7 +317,6 @@ class FieldReportAdmin(CompareVersionAdmin, RegionRestrictedAdmin, TranslationAd
         "countries",
         "districts",
     )
-    form = SummaryPlain
 
     readonly_fields = ("report_date", "created_at", "updated_at")
     list_filter = [MembershipFilter]
@@ -652,7 +649,6 @@ class CountryAdmin(geoadmin.OSMGeoAdmin, CompareVersionAdmin, RegionRestrictedAd
         CountryICRCPresenceInline,
     ]
     exclude = ("key_priorities",)
-    form = SocietyNameOverviewPlain
 
 
 class RegionAdmin(geoadmin.OSMGeoAdmin, CompareVersionAdmin, RegionRestrictedAdmin, TranslationAdmin):

--- a/api/forms.py
+++ b/api/forms.py
@@ -11,38 +11,3 @@ class ActionForm(forms.ModelForm):
     class Meta:
         model = Action
         fields = "__all__"
-
-
-class SocietyNameOverviewPlain(forms.ModelForm):
-    class Meta:
-        widgets = {
-            "society_name_en": forms.Textarea(attrs={"class": "plain-textarea"}),
-            "society_name_es": forms.Textarea(attrs={"class": "plain-textarea"}),
-            "society_name_fr": forms.Textarea(attrs={"class": "plain-textarea"}),
-            "society_name_ar": forms.Textarea(attrs={"class": "plain-textarea"}),
-            "overview_en": forms.Textarea(attrs={"class": "plain-textarea"}),
-            "overview_es": forms.Textarea(attrs={"class": "plain-textarea"}),
-            "overview_fr": forms.Textarea(attrs={"class": "plain-textarea"}),
-            "overview_ar": forms.Textarea(attrs={"class": "plain-textarea"}),
-        }
-
-
-class SummaryPlain(forms.ModelForm):
-    class Meta:
-        widgets = {
-            "summary_en": forms.Textarea(attrs={"class": "plain-textarea"}),
-            "summary_es": forms.Textarea(attrs={"class": "plain-textarea"}),
-            "summary_fr": forms.Textarea(attrs={"class": "plain-textarea"}),
-            "summary_ar": forms.Textarea(attrs={"class": "plain-textarea"}),
-        }
-
-
-class DescriptionPlain(forms.ModelForm):
-    class Meta:
-        widgets = {
-            "description": forms.Textarea(attrs={"class": "plain-textarea"}),
-            "description_en": forms.Textarea(attrs={"class": "plain-textarea"}),
-            "description_es": forms.Textarea(attrs={"class": "plain-textarea"}),
-            "description_fr": forms.Textarea(attrs={"class": "plain-textarea"}),
-            "description_ar": forms.Textarea(attrs={"class": "plain-textarea"}),
-        }

--- a/main/settings.py
+++ b/main/settings.py
@@ -331,9 +331,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-# selector – exclude Geometry fields (bbox) and some plain textareas (see forms.py)
 TINYMCE_DEFAULT_CONFIG = {
-    "selector": "textarea.vLargeTextField",
     "entity_encoding": "raw",
     "height": 360,
     "width": 1120,


### PR DESCRIPTION
Cleaning up unnecessary finetuning via css selector.