### PR TITLE
Run helm charts on local cluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,19 @@ jobs:
 
       - name: 🤞 Run Test 🧪
         run: docker compose run --rm serve pytest --reuse-db --durations=10
+
+  validate_helm:
+    name: 🚴 Validate Helm 🚴
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: 🐳 Helm lint
+        run: helm lint deploy/helm/ifrcgo-helm --values ./deploy/helm/ifrcgo-helm/values-staging.yaml
+
+      - name: 🐳 Helm template
+        run: helm template deploy/helm/ifrcgo-helm --values ./deploy/helm/ifrcgo-helm/values-staging.yaml

--- a/deploy/helm/ifrcgo-helm/templates/api/ingress.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/api/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "360s"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "360s"
 spec:
+  {{- if .Values.api.tls.enabled }}
   tls:
     - hosts:
       - {{ .Values.api.domain }}
@@ -19,6 +20,7 @@ spec:
       - {{ .Values.api.additionalDomain }}
       secretName: {{ template "ifrcgo-helm.fullname" . }}-secret-api-additional-domain-cert
     {{- end }}
+  {{- end }}
 
   rules:
   - host: {{ .Values.api.domain }}

--- a/deploy/helm/ifrcgo-helm/templates/api/secrets.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/api/secrets.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.api.tls.enabled }}
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,6 +8,7 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ .Values.secrets.API_TLS_CRT | quote}}
   tls.key: {{ .Values.secrets.API_TLS_KEY | quote}}
+
 
 ---
 
@@ -18,4 +21,6 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ .Values.secrets.API_ADDITIONAL_DOMAIN_TLS_CRT | quote}}
   tls.key: {{ .Values.secrets.API_ADDITIONAL_DOMAIN_TLS_KEY | quote}}
+{{- end }}
+
 {{- end }}

--- a/deploy/helm/ifrcgo-helm/templates/config/configmap.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/config/configmap.yaml
@@ -10,9 +10,9 @@ data:
   CELERY_REDIS_URL: "redis://{{ template "ifrcgo-helm.fullname" . }}-redis:6379/0"
   CACHE_REDIS_URL: "redis://{{ template "ifrcgo-helm.fullname" . }}-redis:6379/1"
   CACHE_MIDDLEWARE_SECONDS: {{ .Values.env.CACHE_MIDDLEWARE_SECONDS | quote }}
-  DJANGO_DB_NAME: postgres
   DJANGO_DEBUG: {{ .Values.env.DJANGO_DEBUG | quote }}
   ELASTIC_SEARCH_HOST: "elasticsearch://{{ template "ifrcgo-helm.fullname" . }}-elasticsearch:9200" #FIXME: double check format
+  ELASTIC_SEARCH_INDEX: {{ .Values.env.ELASTIC_SEARCH_INDEX | quote }}
   DOCKER_HOST_IP: {{ .Values.env.DOCKER_HOST_IP | quote }}
   DJANGO_ADDITIONAL_ALLOWED_HOSTS: {{ .Values.env.DJANGO_ADDITIONAL_ALLOWED_HOSTS | quote }}
   GO_ENVIRONMENT: {{ .Values.env.GO_ENVIRONMENT | quote }}

--- a/deploy/helm/ifrcgo-helm/templates/elasticsearch/pvc.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/elasticsearch/pvc.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.elasticsearch.enabled }}
+
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -14,3 +16,5 @@ spec:
       storage: {{ .Values.elasticsearch.storageSize }}
   storageClassName: managed-csi
   volumeName:  {{ template "ifrcgo-helm.fullname" . }}-elasticsearch-pv
+
+{{- end }}

--- a/deploy/helm/ifrcgo-helm/templates/letsencrypt-issuer.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/letsencrypt-issuer.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.api.tls.enabled }}
+
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -23,3 +25,5 @@ spec:
         - http01:
             ingress:
                 class: nginx
+
+{{- end }}

--- a/deploy/helm/ifrcgo-helm/values.yaml
+++ b/deploy/helm/ifrcgo-helm/values.yaml
@@ -29,6 +29,7 @@ env:
   HPC_CREDENTIAL: ''
   APPLICATION_INSIGHTS_INSTRUMENTATION_KEY: ''
   ELASTIC_SEARCH_HOST: ''
+  ELASTIC_SEARCH_INDEX: 'new_index'
   GO_FTPHOST: ''
   GO_FTPUSER: ''
   GO_FTPPASS: ''
@@ -70,6 +71,8 @@ secrets:
 
 api:
   domain: "go-staging.ifrc.org"
+  tls:
+    enabled: true
   additionalDomain: ""
   enabled: true
   replicaCount: 1


### PR DESCRIPTION
Addresses "Run helm charts on local cluster"

## Changes

- Customize helm using values.yaml
  - Skip elasticsearch resources
  - Skip manual TLS certificates
  - Allow custom ELASTIC_SEARCH_INDEX value
- Add basic helm lint/template check 

## TODO
- Push docker image and helm chart to separate package for `project/x` branches (which will be used by alpha instances)