### PR TITLE
 Run helm charts on local cluster

### DIFF
--- a/.github/workflows/build-publish-docker-helm.yml
+++ b/.github/workflows/build-publish-docker-helm.yml
@@ -7,6 +7,7 @@ on:
     branches:
     - develop
     - master
+    - project/*
     tags:
     - "**"
 
@@ -51,7 +52,12 @@ jobs:
         source venv/bin/activate
         cd deploy/helm
         # hack to push the image to ghcr.io. We will update chartpress.yaml when we move to separate deploy repo
-        python -c "import re; data=open('chartpress.yaml').read(); open('chartpress.yaml', 'w').write(re.sub(r'ifrcgoacr.azurecr.io/ifrcgo-', 'ghcr.io/ifrcgo/go-', data))"
+        if [[ "$GITHUB_REF_NAME" == "project/"* ]]; then
+          # NOTE: Using seperate package registry for alpha
+          python -c "import re; data=open('chartpress.yaml').read(); open('chartpress.yaml', 'w').write(re.sub(r'ifrcgoacr.azurecr.io/ifrcgo-', 'ghcr.io/ifrcgo/alpha-go-', data))"
+        else
+          python -c "import re; data=open('chartpress.yaml').read(); open('chartpress.yaml', 'w').write(re.sub(r'ifrcgoacr.azurecr.io/ifrcgo-', 'ghcr.io/ifrcgo/go-', data))"
+        fi
         chartpress --push
 
     - name: Get the version
@@ -60,8 +66,16 @@ jobs:
 
     - name: Package Helm Chart
       run: |
+        if [[ "$GITHUB_REF_NAME" == "project/"* ]]; then
+          # NOTE: Using seperate package registry for alpha
+          sed -i 's/^name: \(.*\)/name: alpha-\1/' deploy/helm/ifrcgo-helm/Chart.yaml
+        fi
         helm package deploy/helm/ifrcgo-helm -d .helm-charts
 
     - name: Push Helm Chart
       run: |
-        helm push .helm-charts/ifrcgo-helm-${{ steps.get_version.outputs.VERSION }}.tgz oci://ghcr.io/ifrcgo/go-api
+        if [[ "$GITHUB_REF_NAME" == "project/"* ]]; then
+          helm push ".helm-charts/alpha-ifrcgo-helm-${{ steps.get_version.outputs.VERSION }}.tgz" oci://ghcr.io/ifrcgo/go-api
+        else
+          helm push ".helm-charts/ifrcgo-helm-${{ steps.get_version.outputs.VERSION }}.tgz" oci://ghcr.io/ifrcgo/go-api
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,19 @@ jobs:
 
       - name: 🤞 Run Test 🧪
         run: docker compose run --rm serve pytest --reuse-db --durations=10
+
+  validate_helm:
+    name: 🚴 Validate Helm 🚴
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: 🐳 Helm lint
+        run: helm lint deploy/helm/ifrcgo-helm --values ./deploy/helm/ifrcgo-helm/values-staging.yaml
+
+      - name: 🐳 Helm template
+        run: helm template deploy/helm/ifrcgo-helm --values ./deploy/helm/ifrcgo-helm/values-staging.yaml

--- a/deploy/helm/ifrcgo-helm/templates/api/ingress.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/api/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "360s"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "360s"
 spec:
+  {{- if .Values.api.tls.enabled }}
   tls:
     - hosts:
       - {{ .Values.api.domain }}
@@ -19,6 +20,7 @@ spec:
       - {{ .Values.api.additionalDomain }}
       secretName: {{ template "ifrcgo-helm.fullname" . }}-secret-api-additional-domain-cert
     {{- end }}
+  {{- end }}
 
   rules:
   - host: {{ .Values.api.domain }}

--- a/deploy/helm/ifrcgo-helm/templates/api/secrets.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/api/secrets.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.api.tls.enabled }}
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,6 +8,7 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ .Values.secrets.API_TLS_CRT | quote}}
   tls.key: {{ .Values.secrets.API_TLS_KEY | quote}}
+
 
 ---
 
@@ -18,4 +21,6 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ .Values.secrets.API_ADDITIONAL_DOMAIN_TLS_CRT | quote}}
   tls.key: {{ .Values.secrets.API_ADDITIONAL_DOMAIN_TLS_KEY | quote}}
+{{- end }}
+
 {{- end }}

--- a/deploy/helm/ifrcgo-helm/templates/config/configmap.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/config/configmap.yaml
@@ -10,9 +10,9 @@ data:
   CELERY_REDIS_URL: "redis://{{ template "ifrcgo-helm.fullname" . }}-redis:6379/0"
   CACHE_REDIS_URL: "redis://{{ template "ifrcgo-helm.fullname" . }}-redis:6379/1"
   CACHE_MIDDLEWARE_SECONDS: {{ .Values.env.CACHE_MIDDLEWARE_SECONDS | quote }}
-  DJANGO_DB_NAME: postgres
   DJANGO_DEBUG: {{ .Values.env.DJANGO_DEBUG | quote }}
   ELASTIC_SEARCH_HOST: "elasticsearch://{{ template "ifrcgo-helm.fullname" . }}-elasticsearch:9200" #FIXME: double check format
+  ELASTIC_SEARCH_INDEX: {{ .Values.env.ELASTIC_SEARCH_INDEX | quote }}
   DOCKER_HOST_IP: {{ .Values.env.DOCKER_HOST_IP | quote }}
   DJANGO_ADDITIONAL_ALLOWED_HOSTS: {{ .Values.env.DJANGO_ADDITIONAL_ALLOWED_HOSTS | quote }}
   GO_ENVIRONMENT: {{ .Values.env.GO_ENVIRONMENT | quote }}

--- a/deploy/helm/ifrcgo-helm/templates/elasticsearch/pvc.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/elasticsearch/pvc.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.elasticsearch.enabled }}
+
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -14,3 +16,5 @@ spec:
       storage: {{ .Values.elasticsearch.storageSize }}
   storageClassName: managed-csi
   volumeName:  {{ template "ifrcgo-helm.fullname" . }}-elasticsearch-pv
+
+{{- end }}

--- a/deploy/helm/ifrcgo-helm/templates/letsencrypt-issuer.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/letsencrypt-issuer.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.api.tls.enabled }}
+
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -23,3 +25,5 @@ spec:
         - http01:
             ingress:
                 class: nginx
+
+{{- end }}

--- a/deploy/helm/ifrcgo-helm/values.yaml
+++ b/deploy/helm/ifrcgo-helm/values.yaml
@@ -29,6 +29,7 @@ env:
   HPC_CREDENTIAL: ''
   APPLICATION_INSIGHTS_INSTRUMENTATION_KEY: ''
   ELASTIC_SEARCH_HOST: ''
+  ELASTIC_SEARCH_INDEX: 'new_index'
   GO_FTPHOST: ''
   GO_FTPUSER: ''
   GO_FTPPASS: ''
@@ -70,6 +71,8 @@ secrets:
 
 api:
   domain: "go-staging.ifrc.org"
+  tls:
+    enabled: true
   additionalDomain: ""
   enabled: true
   replicaCount: 1


### PR DESCRIPTION
Addresses "Run helm charts on local cluster"

## Changes

- Customize helm using values.yaml
  - Skip Elasticsearch resources
  - Skip manual TLS certificates
  - Allow custom ELASTIC_SEARCH_INDEX value
- Add basic helm lint/template check 
- Push docker image and helm chart to separate package for `project/x` branches
  - Which will be used by alpha instances
  - Can be easily cleaned-up in future without effecting the staging/prod packages
  - Image: https://github.com/orgs/IFRCGo/packages/container/package/alpha-go-api
  - Charts: https://github.com/IFRCGo/go-api/pkgs/container/go-api%2Falpha-ifrcgo-helm
  
  
## More context
We are trying to run the go-api using local cluster (real one using talos :D ) for all the alpha instances instead of using VM with docker-compose. With this, we will be able to test and maintain helm charts respective to applications level changes.
https://alpha-x.ifrc-go.dev.datafriendlyspace.org/