### PR TITLE
Fix typing issue on previous_data (JsonField)

### DIFF
--- a/local_units/serializers.py
+++ b/local_units/serializers.py
@@ -235,6 +235,12 @@ class LocalUnitDetailSerializer(serializers.ModelSerializer):
         return json.loads(unit.location.geojson)
 
 
+"""
+NOTE: This `PrivateLocalUnitDetailSerializer` is used to store the previous_data of local unit
+changing the serializer might effect the data of previous_data
+"""
+
+
 class PrivateLocalUnitDetailSerializer(NestedCreateMixin, NestedUpdateMixin):
     country_details = LocalUnitCountrySerializer(source="country", read_only=True)
     type_details = LocalUnitTypeSerializer(source="type", read_only=True)
@@ -537,23 +543,26 @@ class RejectedReasonSerialzier(serializers.Serializer):
 
 
 class LocalUnitChangeRequestSerializer(serializers.ModelSerializer):
-    local_unit_details = PrivateLocalUnitDetailSerializer(source="local_unit", read_only=True)
     created_by_details = LocalUnitMiniUserSerializer(source="created_by", read_only=True)
     status_details = serializers.CharField(source="get_status_display", read_only=True)
     current_validator_details = serializers.CharField(source="get_current_validator_display", read_only=True)
+    # NOTE: Typing issue on JsonField, So returning as string
+    previous_data_details = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = LocalUnitChangeRequest
         fields = (
             "id",
-            "local_unit_details",
             "status",
             "status_details",
             "current_validator",
             "current_validator_details",
             "created_by_details",
-            "previous_data",
+            "previous_data_details",
         )
+
+    def get_previous_data_details(self, obj):
+        return obj.previous_data
 
 
 class LocalUnitDeprecateSerializer(serializers.ModelSerializer):

--- a/local_units/test_views.py
+++ b/local_units/test_views.py
@@ -87,7 +87,7 @@ class TestLocalUnitsListView(APITestCase):
 
         # Test for validation
         response = self.client.post(url, data=data)
-        self.assert_404(response)
+        self.assert_400(response)
 
         self.client.force_authenticate(self.root_user)
         # test revert deprecate
@@ -622,5 +622,5 @@ class TestLocalUnitCreate(APITestCase):
         # Checking the latest changes
         response = self.client.post(f"/api/v2/local-units/{local_unit_id}/latest-change-request/")
         self.assert_200(response)
-        self.assertEqual(response.data["previous_data"]["local_branch_name"], previous_data["local_branch_name"])
-        self.assertEqual(response.data["previous_data"]["english_branch_name"], previous_data["english_branch_name"])
+        self.assertEqual(response.data["previous_data_details"]["local_branch_name"], previous_data["local_branch_name"])
+        self.assertEqual(response.data["previous_data_details"]["english_branch_name"], previous_data["english_branch_name"])

--- a/local_units/views.py
+++ b/local_units/views.py
@@ -48,7 +48,7 @@ class PrivateLocalUnitViewSet(viewsets.ModelViewSet):
         "country",
         "type",
         "level",
-    ).exclude(is_deprecated=True)
+    )
     filterset_class = LocalUnitFilters
     search_fields = (
         "local_branch_name",


### PR DESCRIPTION
Addresses
- typing issue for the Jsonfield
- Passing as a String

## Changes
- Change the type of previous_data field to string
- Remove deprecated filter on queryset 


## Checklist
Things that should succeed before merging.

- [ ] Updated/ran unit tests
- [ ] Updated CHANGELOG.md

## Release

If there is a version update, make sure to tag the repository with the latest version.