### PR TITLE
Change field name in option api

### DIFF
--- a/local_units/serializers.py
+++ b/local_units/serializers.py
@@ -519,7 +519,7 @@ class LocalUnitOptionsSerializer(serializers.Serializer):
     blood_services = BloodServiceSerializer(many=True)
     professional_training_facilities = ProfessionalTrainingFacilitySerializer(many=True)
     general_medical_services = GeneralMedicalServiceSerializer(many=True)
-    specialized_medical_services = SpecializedMedicalServiceSerializer(many=True)
+    specialized_medical_beyond_primary_level = SpecializedMedicalServiceSerializer(many=True)
 
 
 class MiniDelegationOfficeSerializer(serializers.ModelSerializer):

--- a/local_units/test_views.py
+++ b/local_units/test_views.py
@@ -89,7 +89,7 @@ class TestLocalUnitsListView(APITestCase):
 
         # Test for validation
         response = self.client.post(url, data=data)
-        self.assert_400(response)
+        self.assert_404(response)
 
         self.client.force_authenticate(self.root_user)
         # test revert deprecate

--- a/local_units/views.py
+++ b/local_units/views.py
@@ -49,7 +49,7 @@ class PrivateLocalUnitViewSet(viewsets.ModelViewSet):
         "country",
         "type",
         "level",
-    )
+    ).exclude(is_deprecated=True)
     filterset_class = LocalUnitFilters
     search_fields = (
         "local_branch_name",
@@ -315,7 +315,7 @@ class LocalUnitOptionsView(views.APIView):
                     blood_services=BloodService.objects.all(),
                     professional_training_facilities=ProfessionalTrainingFacility.objects.all(),
                     general_medical_services=GeneralMedicalService.objects.all(),
-                    specialized_medical_services=SpecializedMedicalService.objects.all(),
+                    specialized_medical_beyond_primary_level=SpecializedMedicalService.objects.all(),
                 ),
                 context={"request": request},
             ).data


### PR DESCRIPTION
Addresses
- Change field name `specialized_medical_services` to `specialized_medical_beyond_primary_level` in Option API

## Changes
- add filter on queryset is deprecated True


## Checklist
Things that should succeed before merging.

- [ ] Updated/ran unit tests
- [ ] Updated CHANGELOG.md

## Release

If there is a version update, make sure to tag the repository with the latest version.