### PR TITLE
Remove filter on latest change request api

### DIFF
--- a/local_units/serializers.py
+++ b/local_units/serializers.py
@@ -547,7 +547,7 @@ class LocalUnitChangeRequestSerializer(serializers.ModelSerializer):
     status_details = serializers.CharField(source="get_status_display", read_only=True)
     current_validator_details = serializers.CharField(source="get_current_validator_display", read_only=True)
     # NOTE: Typing issue on JsonField, So returning as string
-    previous_data_details = serializers.SerializerMethodField(read_only=True)
+    previous_data_details = serializers.SerializerMethodField(read_only=True, required=False)
 
     class Meta:
         model = LocalUnitChangeRequest

--- a/local_units/serializers.py
+++ b/local_units/serializers.py
@@ -547,7 +547,7 @@ class LocalUnitChangeRequestSerializer(serializers.ModelSerializer):
     status_details = serializers.CharField(source="get_status_display", read_only=True)
     current_validator_details = serializers.CharField(source="get_current_validator_display", read_only=True)
     # NOTE: Typing issue on JsonField, So returning as string
-    previous_data_details = serializers.SerializerMethodField(read_only=True, required=False)
+    previous_data_details = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = LocalUnitChangeRequest

--- a/local_units/test_views.py
+++ b/local_units/test_views.py
@@ -633,6 +633,9 @@ class TestLocalUnitCreate(APITestCase):
         response = self.client.post(f"/api/v2/local-units/{local_unit_id}/validate/")
         self.assert_200(response)
 
+        # saving the previous data
+        previous_data = response.data
+
         # Changing the local unit
         data["local_branch_name"] = "Updated local branch name"
         data["english_branch_name"] = "Updated english branch name"
@@ -643,8 +646,8 @@ class TestLocalUnitCreate(APITestCase):
         # Checking the latest changes
         response = self.client.post(f"/api/v2/local-units/{local_unit_id}/latest-change-request/")
         self.assert_200(response)
-        self.assertEqual(response.data["previous_data_details"]["local_branch_name"], data["local_branch_name"])
-        self.assertEqual(response.data["previous_data_details"]["english_branch_name"], data["english_branch_name"])
+        self.assertEqual(response.data["previous_data_details"]["local_branch_name"], previous_data["local_branch_name"])
+        self.assertEqual(response.data["previous_data_details"]["english_branch_name"], previous_data["english_branch_name"])
 
     def test_validate_local_unit(self):
         type = LocalUnitType.objects.create(code=0, name="Code 0")

--- a/local_units/test_views.py
+++ b/local_units/test_views.py
@@ -385,7 +385,6 @@ class TestLocalUnitCreate(APITestCase):
         # Checking the request changes for the local unit is created or not
         request_change = LocalUnitChangeRequest.objects.all()
         self.assertEqual(request_change.count(), 1)
-        self.assertEqual(request_change.first().previous_data["id"], response.data["id"])
 
     def test_create_update_local_unit_health(self):
         region = Region.objects.create(name=2)
@@ -634,9 +633,6 @@ class TestLocalUnitCreate(APITestCase):
         response = self.client.post(f"/api/v2/local-units/{local_unit_id}/validate/")
         self.assert_200(response)
 
-        # saving the previous data
-        previous_data = response.data
-
         # Changing the local unit
         data["local_branch_name"] = "Updated local branch name"
         data["english_branch_name"] = "Updated english branch name"
@@ -647,8 +643,8 @@ class TestLocalUnitCreate(APITestCase):
         # Checking the latest changes
         response = self.client.post(f"/api/v2/local-units/{local_unit_id}/latest-change-request/")
         self.assert_200(response)
-        self.assertEqual(response.data["previous_data_details"]["local_branch_name"], previous_data["local_branch_name"])
-        self.assertEqual(response.data["previous_data_details"]["english_branch_name"], previous_data["english_branch_name"])
+        self.assertEqual(response.data["previous_data_details"]["local_branch_name"], data["local_branch_name"])
+        self.assertEqual(response.data["previous_data_details"]["english_branch_name"], data["english_branch_name"])
 
     def test_validate_local_unit(self):
         type = LocalUnitType.objects.create(code=0, name="Code 0")

--- a/local_units/views.py
+++ b/local_units/views.py
@@ -81,6 +81,8 @@ class PrivateLocalUnitViewSet(viewsets.ModelViewSet):
     def update(self, request, *args, **kwargs):
         local_unit = self.get_object()
 
+        previous_data = PrivateLocalUnitDetailSerializer(local_unit, context={"request": request}).data
+
         # NOTE: Checking if the local unit is locked.
         # TODO: This should be moved to a permission class and validators can update the local unit
         if local_unit.is_locked:
@@ -95,7 +97,7 @@ class PrivateLocalUnitViewSet(viewsets.ModelViewSet):
         # Creating a new change request for the local unit
         LocalUnitChangeRequest.objects.create(
             local_unit=local_unit,
-            previous_data=serializer.data,
+            previous_data=previous_data,
             status=LocalUnitChangeRequest.Status.PENDING,
             triggered_by=request.user,
         )
@@ -121,10 +123,7 @@ class PrivateLocalUnitViewSet(viewsets.ModelViewSet):
         if not change_request_instance:
             return bad_request("No change request found to validate")
 
-        full_serializer = PrivateLocalUnitDetailSerializer(local_unit, context={"request": request})
-
         # Checking the validator type
-
         validator = LocalUnitChangeRequest.Validator.LOCAL
         if request.user.is_superuser or request.user.has_perm("local_units.local_unit_global_validator"):
             validator = LocalUnitChangeRequest.Validator.GLOBAL
@@ -140,7 +139,6 @@ class PrivateLocalUnitViewSet(viewsets.ModelViewSet):
                 validator = LocalUnitChangeRequest.Validator.REGIONAL
 
         change_request_instance.current_validator = validator
-        change_request_instance.previous_data = full_serializer.data
         change_request_instance.status = LocalUnitChangeRequest.Status.APPROVED
         change_request_instance.updated_by = request.user
         change_request_instance.updated_at = timezone.now()
@@ -189,14 +187,18 @@ class PrivateLocalUnitViewSet(viewsets.ModelViewSet):
         change_request_instance.rejected_data = full_serializer.data
         change_request_instance.save(update_fields=["status", "rejected_reason", "updated_at", "updated_by", "rejected_data"])
 
-        # Reverting the last change request related to this local unit
-        last_change_request = LocalUnitChangeRequest.objects.filter(
-            local_unit=local_unit,
-            status=LocalUnitChangeRequest.Status.APPROVED,
-        ).last()
-
-        if not last_change_request:
-            return bad_request("No change request found to revert")
+        # NOTE: Handling the first change request
+        if change_request_instance.previous_data == {}:
+            total_change_request_count = LocalUnitChangeRequest.objects.filter(local_unit=local_unit).count()
+            assert (
+                total_change_request_count == 1
+            ), f"There should be one change request and it is the first one {total_change_request_count}"
+            local_unit.is_deprecated = True
+            local_unit.deprecated_reason = reason
+            local_unit.save(
+                update_fields=["is_deprecated", "deprecated_reason"],
+            )
+            return response.Response(PrivateLocalUnitDetailSerializer(local_unit, context={"request": request}).data)
 
         # NOTE: Unlocking the reverted local unit
         local_unit.is_locked = False
@@ -205,7 +207,7 @@ class PrivateLocalUnitViewSet(viewsets.ModelViewSet):
         # reverting the previous data of change request to local unit by passing through serializer
         serializer = PrivateLocalUnitDetailSerializer(
             local_unit,
-            data=last_change_request.previous_data,
+            data=change_request_instance.previous_data,
             context={"request": request},
             partial=True,
         )

--- a/local_units/views.py
+++ b/local_units/views.py
@@ -165,7 +165,7 @@ class PrivateLocalUnitViewSet(viewsets.ModelViewSet):
         if local_unit.validated:
             return bad_request("Local unit is already validated and cannot be reverted")
 
-        full_serializer = PrivateLocalUnitDetailSerializer(local_unit, context={"request": request})
+        rejected_data = PrivateLocalUnitDetailSerializer(local_unit, context={"request": request}).data
 
         serializer = RejectedReasonSerialzier(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -184,7 +184,7 @@ class PrivateLocalUnitViewSet(viewsets.ModelViewSet):
         change_request_instance.rejected_reason = reason
         change_request_instance.updated_by = request.user
         change_request_instance.updated_at = timezone.now()
-        change_request_instance.rejected_data = full_serializer.data
+        change_request_instance.rejected_data = rejected_data
         change_request_instance.save(update_fields=["status", "rejected_reason", "updated_at", "updated_by", "rejected_data"])
 
         # NOTE: Handling the first change request

--- a/local_units/views.py
+++ b/local_units/views.py
@@ -142,7 +142,7 @@ class PrivateLocalUnitViewSet(viewsets.ModelViewSet):
         change_request_instance.status = LocalUnitChangeRequest.Status.APPROVED
         change_request_instance.updated_by = request.user
         change_request_instance.updated_at = timezone.now()
-        change_request_instance.save(update_fields=["status", "updated_by", "updated_at", "current_validator", "previous_data"])
+        change_request_instance.save(update_fields=["status", "updated_by", "updated_at", "current_validator"])
 
         # Validate the local unit
         local_unit.validated = True


### PR DESCRIPTION
Addresses
- Remove filter on latest change request

## Changes
- removing filter
- adding previous data while validating the request change


## Checklist
Things that should succeed before merging.

- [ ] Updated/ran unit tests
- [ ] Updated CHANGELOG.md

## Release

If there is a version update, make sure to tag the repository with the latest version.