### PR TITLE
Set Readonly fields on LocalUnit admin panel

### DIFF
--- a/local_units/admin.py
+++ b/local_units/admin.py
@@ -52,6 +52,10 @@ class LocalUnitAdmin(CompareVersionAdmin, admin.OSMGeoAdmin):
         "level",
         "health",
     )
+    readonly_fields = (
+        "validated",
+        "is_locked",
+    )
     list_filter = (
         AutocompleteFilterFactory("Country", "country"),
         AutocompleteFilterFactory("Type", "type"),


### PR DESCRIPTION
Addresses
- https://github.com/IFRCGo/go-api/issues/2327
- Readonly fields for `validated` and `is_locked` fields

## Changes
- Set validated and is_locked field to Readonly fields

## Checklist
Things that should succeed before merging.

- [ ] Updated/ran unit tests
- [ ] Updated CHANGELOG.md

## Release

If there is a version update, make sure to tag the repository with the latest version.