### PR TITLE
Fix status code on latest change request

### DIFF
--- a/local_units/test_views.py
+++ b/local_units/test_views.py
@@ -647,7 +647,7 @@ class TestLocalUnitCreate(APITestCase):
         self.assert_200(response)
 
         # Checking the latest changes
-        response = self.client.post(f"/api/v2/local-units/{local_unit_id}/latest-change-request/")
+        response = self.client.get(f"/api/v2/local-units/{local_unit_id}/latest-change-request/")
         self.assert_200(response)
         self.assertEqual(response.data["previous_data_details"]["local_branch_name"], previous_data["local_branch_name"])
         self.assertEqual(response.data["previous_data_details"]["english_branch_name"], previous_data["english_branch_name"])

--- a/local_units/views.py
+++ b/local_units/views.py
@@ -133,7 +133,10 @@ class PrivateLocalUnitViewSet(viewsets.ModelViewSet):
         ).last()
 
         if not change_request_instance:
-            return bad_request("No change request found to validate")
+            return response.Response(
+                {"message": "No change request found to validate"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         # Checking the validator type
         validator = Validator.LOCAL
@@ -191,7 +194,10 @@ class PrivateLocalUnitViewSet(viewsets.ModelViewSet):
         ).last()
 
         if not change_request_instance:
-            return bad_request("No change request found to revert")
+            return response.Response(
+                {"message": "No change request found to revert"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         change_request_instance.status = LocalUnitChangeRequest.Status.REVERT
         change_request_instance.rejected_reason = reason
@@ -237,7 +243,7 @@ class PrivateLocalUnitViewSet(viewsets.ModelViewSet):
     @action(
         detail=True,
         url_path="latest-change-request",
-        methods=["post"],
+        methods=["get"],
         serializer_class=LocalUnitChangeRequestSerializer,
         permission_classes=[permissions.IsAuthenticated, IsAuthenticatedForLocalUnit, DenyGuestUserPermission],
     )
@@ -249,7 +255,10 @@ class PrivateLocalUnitViewSet(viewsets.ModelViewSet):
         ).last()
 
         if not change_request:
-            return bad_request("Last change request not found")
+            return response.Response(
+                {"message": "Last change request not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         serializer = LocalUnitChangeRequestSerializer(change_request, context={"request": request})
         return response.Response(serializer.data)


### PR DESCRIPTION
Addresses
- Change status code  400 to 404 in latest change request

## Changes
- Change request type to get and status code from 400 to 404

## Checklist
Things that should succeed before merging.

- [ ] Updated/ran unit tests
- [ ] Updated CHANGELOG.md

## Release

If there is a version update, make sure to tag the repository with the latest version.