### PR TITLE
Fix sources count on operational learning

### DIFF
--- a/per/drf_views.py
+++ b/per/drf_views.py
@@ -20,7 +20,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
-from api.models import Appeal, Country, Region
+from api.models import Country, Region
 from deployments.models import SectorTag
 from main.permissions import DenyGuestUserMutationPermission, DenyGuestUserPermission
 from main.utils import SpreadSheetContentNegotiation
@@ -950,7 +950,7 @@ class OpsLearningViewset(viewsets.ModelViewSet):
             operations_included=Count("appeal_code", distinct=True),
             learning_extracts=Count("id", distinct=True),
             sector_covered=Count("sector_validated", distinct=True),
-            source_used=Count("appeal_code__appealdocument", distinct=True),
+            source_used=Count("appeal_document_id", distinct=True),
         )
 
         learning_by_sector_qs = (
@@ -961,13 +961,13 @@ class OpsLearningViewset(viewsets.ModelViewSet):
 
         # NOTE: Queryset is unbounded, we may need to add some start_date filter.
         sources_overtime_qs = (
-            Appeal.objects.filter(opslearning__in=queryset)
+            queryset.filter(appeal_document_id__isnull=False)
             .annotate(
-                type=F("atype"),
-                date=F("start_date"),
-                count=Count("appealdocument", distinct=True),
+                atype=F("appeal_code__atype"),
+                date=F("appeal_code__start_date"),
+                count=Count("appeal_document_id", distinct=True),
             )
-            .values("type", "date", "count")
+            .values("atype", "date", "count")
         )
 
         learning_by_region_qs = (

--- a/per/serializers.py
+++ b/per/serializers.py
@@ -1275,13 +1275,13 @@ class LearningBySectorSerializer(serializers.Serializer):
 
 
 class LearningSourcesOvertimeSerializer(serializers.Serializer):
-    type = serializers.IntegerField(required=True)
-    type_display = serializers.SerializerMethodField(read_only=True)
+    atype = serializers.IntegerField(required=True)
+    atype_display = serializers.SerializerMethodField(read_only=True)
     date = serializers.DateTimeField(required=True)
     count = serializers.IntegerField(required=True)
 
-    def get_type_display(self, obj):
-        type = obj.get("type")
+    def get_atype_display(self, obj):
+        type = obj.get("atype")
         return AppealType(type).label
 
 

--- a/per/test_views.py
+++ b/per/test_views.py
@@ -250,16 +250,22 @@ class OpsLearningStatsTestCase(APITestCase):
             region=self.region, country=self.country, code="APP002", atype=1, start_date="2023-02-01"
         )
 
-        AppealDocumentFactory.create(appeal=self.appeal1)
-        AppealDocumentFactory.create(appeal=self.appeal2)
+        appeal_document_1 = AppealDocumentFactory.create(appeal=self.appeal1)
+        appeal_document_2 = AppealDocumentFactory.create(appeal=self.appeal2)
 
-        self.ops_learning1 = OpsLearningFactory.create(is_validated=True, appeal_code=self.appeal1)
+        self.ops_learning1 = OpsLearningFactory.create(
+            is_validated=True, appeal_code=self.appeal1, appeal_document_id=appeal_document_1.id
+        )
         self.ops_learning1.sector_validated.set([self.sector1])
 
-        self.ops_learning2 = OpsLearningFactory.create(is_validated=True, appeal_code=self.appeal2)
+        self.ops_learning2 = OpsLearningFactory.create(
+            is_validated=True, appeal_code=self.appeal2, appeal_document_id=appeal_document_2.id
+        )
         self.ops_learning2.sector_validated.set([self.sector2])
 
-        self.ops_learning3 = OpsLearningFactory.create(is_validated=False, appeal_code=self.appeal2)
+        self.ops_learning3 = OpsLearningFactory.create(
+            is_validated=False, appeal_code=self.appeal2, appeal_document_id=appeal_document_2.id
+        )
         self.ops_learning3.sector_validated.set([self.sector2])
 
     def test_ops_learning_stats(self):


### PR DESCRIPTION
Addresses
- Change sources count logic on ops learning stats

## Changes
- Count only appeal document used to create operational learning rather than all sources attached to appeal 

## Checklist
Things that should succeed before merging.

- [ ] Updated/ran unit tests
- [ ] Updated CHANGELOG.md

## Release

If there is a version update, make sure to tag the repository with the latest version.