### PR TITLE
Fix: Regenerate field report number if event and country changes

### DIFF
--- a/api/drf_views.py
+++ b/api/drf_views.py
@@ -971,9 +971,16 @@ class FieldReportViewset(ReadOnlyVisibilityViewsetMixin, viewsets.ModelViewSet):
         start_date = serializer.validated_data.get("start_date")
         title = serializer.validated_data.get("title")
         is_covid_report = serializer.validated_data.get("is_covid_report")
+        id = serializer.validated_data.get("id")
 
         summary = generate_field_report_title(
-            country=countries[0], dtype=dtype, event=event, start_date=start_date, title=title, is_covid_report=is_covid_report
+            country=countries[0],
+            dtype=dtype,
+            event=event,
+            start_date=start_date,
+            title=title,
+            is_covid_report=is_covid_report,
+            id=id,
         )
         return Response(
             FieldReportGeneratedTitleSerializer(

--- a/api/models.py
+++ b/api/models.py
@@ -1703,9 +1703,9 @@ class FieldReport(models.Model):
 
         if self.fr_num is None and self.event and self.id:
             current_fr_number = (
-                FieldReport.objects.filter(event=self.event, countries__iso3=country_iso3).aggregate(
-                    max_fr_num=models.Max("fr_num")
-                )["max_fr_num"]
+                FieldReport.objects.filter(event=self.event, countries__iso3=country_iso3)
+                .exclude(id=self.id)
+                .aggregate(max_fr_num=models.Max("fr_num"))["max_fr_num"]
                 or 0
             )
             field_report_number = current_fr_number + 1

--- a/api/receivers.py
+++ b/api/receivers.py
@@ -299,4 +299,5 @@ def update_fieldreport_summary(sender, instance, action, **kwargs):
     Update the FieldReport summary when the countries are changed.
     """
     if action in ["post_add", "post_remove"]:
+        instance.fr_num = None
         instance.save()

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -2100,6 +2100,9 @@ class FieldReportSerializer(
         return field_report
 
     def update(self, instance, validated_data):
+        # NOTE: Set fr_num to None if event is changed
+        if validated_data.get("event") != instance.event:
+            instance.fr_num = None
         validated_data["user"] = self.context["request"].user
         return super().update(instance, validated_data)
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -2111,10 +2111,12 @@ class FieldReportGenerateTitleSerializer(serializers.ModelSerializer):
     dtype = serializers.PrimaryKeyRelatedField(queryset=DisasterType.objects.all())
     event = serializers.PrimaryKeyRelatedField(queryset=Event.objects.all(), required=False)
     title = serializers.CharField(required=True)
+    id = serializers.IntegerField(required=False)
 
     class Meta:
         model = FieldReport
         fields = (
+            "id",
             "countries",
             "dtype",
             "title",

--- a/api/utils.py
+++ b/api/utils.py
@@ -5,6 +5,7 @@ from typing import Optional
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.translation import gettext
 
@@ -112,6 +113,7 @@ def generate_field_report_title(
     start_date: Optional[timezone.datetime],
     title: str,
     is_covid_report: bool = False,
+    id: Optional[int] = None,
 ):
     """
     Generates the summary based on the country, dtype, event, start_date, title and is_covid_report
@@ -129,6 +131,12 @@ def generate_field_report_title(
         or 0
     )
     fr_num = current_fr_number + 1
+
+    # NOTE: Checking if event or country is changed while Updating
+    if id:
+        fr = get_object_or_404(FieldReport, id=id)
+        if fr.event == event and fr.countries.first() == country:
+            fr_num = current_fr_number
 
     suffix = ""
     if fr_num > 1 and event:


### PR DESCRIPTION
Addresses
- Setting the value of fr_num to None if event is changed
- Passing field report number id while updating  the field report

## Changes
- updating the fr number if event is changed 
- Setting fr_num to None if countries and event changed from serializer and While calling signal.

## Checklist
Things that should succeed before merging.

- [ ] Updated/ran unit tests
- [ ] Updated CHANGELOG.md

## Release

If there is a version update, make sure to tag the repository with the latest version.