### PR TITLE
Add filter for appeal_type in EventFilter.

### DIFF
--- a/api/filter_set.py
+++ b/api/filter_set.py
@@ -8,6 +8,7 @@ from api.models import (
     Appeal,
     AppealDocument,
     AppealHistory,
+    AppealType,
     Country,
     CountryKeyDocument,
     CountryKeyFigure,
@@ -156,6 +157,12 @@ class Admin2Filter(filters.FilterSet):
 
 class EventFilter(filters.FilterSet):
     dtype = filters.NumberFilter(field_name="dtype", lookup_expr="exact")
+    appeal_type = filters.MultipleChoiceFilter(
+        choices=AppealType.choices,
+        field_name="appeals__atype",
+        widget=filters.widgets.CSVWidget,
+        lookup_expr="in",
+    )
     is_featured = filters.BooleanFilter(field_name="is_featured")
     is_featured_region = filters.BooleanFilter(field_name="is_featured_region")
     countries__in = ListFilter(field_name="countries__id")

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -788,6 +788,7 @@ class CountryKeyDocumentSerializer(ModelSerializer):
 
 class RelatedAppealSerializer(ModelSerializer):
     status_display = serializers.CharField(source="get_status_display", read_only=True)
+    atype_display = serializers.CharField(source="get_atype_display", read_only=True)
 
     class Meta:
         model = Appeal
@@ -800,6 +801,8 @@ class RelatedAppealSerializer(ModelSerializer):
             "status",
             "status_display",
             "start_date",
+            "atype",
+            "atype_display",
             "id",
         )
 


### PR DESCRIPTION
## Changes
  - Add filter appeal_type in event api to assist Montandon ETL.

## Checklist
Things that should succeed before merging.

- [ ] Updated/ran unit tests
- [ ] Updated CHANGELOG.md

## Release

If there is a version update, make sure to tag the repository with the latest version.