### PR TITLE
Feature/s3 storage

### DIFF
--- a/.github/workflows/build-publish-docker-helm.yml
+++ b/.github/workflows/build-publish-docker-helm.yml
@@ -42,7 +42,7 @@ jobs:
     - name: 🐳 Helm dependency
       working-directory: deploy/helm/ifrcgo-helm
       run: |
-        yq --indent 0 '.dependencies | map(["helm", "repo", "add", .name, .repository] | join(" ")) | .[]' ./helm/Chart.lock  | sh --
+        yq --indent 0 '.dependencies | map(["helm", "repo", "add", .name, .repository] | join(" ")) | .[]' ./Chart.lock | sh --
         helm dependency build ./
 
     - name: Tag docker image in Helm Chart values.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,16 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
 
+      - name: 🐳 Helm dependency
+        working-directory: deploy/helm/ifrcgo-helm
+        run: |
+          yq --indent 0 '.dependencies | map(["helm", "repo", "add", .name, .repository] | join(" ")) | .[]' ./Chart.lock | sh --
+          helm dependency build ./
+
       - name: 🐳 Helm lint
-        run: helm lint deploy/helm/ifrcgo-helm --values ./deploy/helm/ifrcgo-helm/values-staging.yaml
+        working-directory: deploy/helm/ifrcgo-helm
+        run: helm lint ./ --values ./values-staging.yaml
 
       - name: 🐳 Helm template
-        run: helm template deploy/helm/ifrcgo-helm --values ./deploy/helm/ifrcgo-helm/values-staging.yaml
+        working-directory: deploy/helm/ifrcgo-helm
+        run: helm template ./ --values ./values-staging.yaml

--- a/api/admin.py
+++ b/api/admin.py
@@ -1044,5 +1044,5 @@ admin.site.register(models.UserRegion, UserRegionAdmin)
 admin.site.register(models.CountryOfFieldReportToReview, CountryOfFieldReportToReviewAdmin)
 # admin.site.register(Revision, RevisionAdmin)
 
-admin.site.site_url = "https://" + settings.FRONTEND_URL
+admin.site.site_url = settings.GO_WEB_URL
 admin.widgets.RelatedFieldWidgetWrapper.template_name = "related_widget_wrapper.html"

--- a/api/management/commands/cron_job_monitor.py
+++ b/api/management/commands/cron_job_monitor.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
         project_id = parsed_url.path.strip("/")
         api_key = parsed_url.username
 
-        SENTRY_INGEST = f"https://{parsed_url.hostname}"
+        SENTRY_INGEST = f"{parsed_url.scheme}://{parsed_url.hostname}"
 
         for cronjob in SentryMonitor.choices:
             job, schedule = cronjob

--- a/api/management/commands/index_and_notify.py
+++ b/api/management/commands/index_and_notify.py
@@ -264,8 +264,8 @@ class Command(BaseCommand):
             RecordType.SURGE_DEPLOYMENT_MESSAGES: "deployments/personneldeployment",
             RecordType.SURGE_ALERT: "notifications/surgealert",
         }[rtype]
-        return "https://%s/admin/%s/%s/change" % (
-            settings.BASE_URL,
+        return "%s/admin/%s/%s/change" % (
+            settings.GO_API_URL,
             admin_page,
             record.id,
         )
@@ -960,8 +960,8 @@ class Command(BaseCommand):
                 (
                     "Ingest issue(s) occured, one of them is "
                     + ingestor_name
-                    + ", via CronJob log record id: https://"
-                    + settings.BASE_URL
+                    + ", via CronJob log record id: "
+                    + settings.GO_API_URL
                     + "/admin/api/cronjob/"
                     + str(ingest_issue_id)
                     + ". Please fix it ASAP."

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -2436,9 +2436,9 @@ class ExportSerializer(serializers.ModelSerializer):
             title = "Export"
         user = self.context["request"].user
         if export_type == Export.ExportType.PER:
-            validated_data["url"] = f"https://{settings.FRONTEND_URL}/countries/{country_id}/{export_type}/{export_id}/export/"
+            validated_data["url"] = f"{settings.GO_WEB_INTERNAL_URL}/countries/{country_id}/{export_type}/{export_id}/export/"
         else:
-            validated_data["url"] = f"https://{settings.FRONTEND_URL}/{export_type}/{export_id}/export/"
+            validated_data["url"] = f"{settings.GO_WEB_INTERNAL_URL}/{export_type}/{export_id}/export/"
 
         # Adding is_pga to the url
         is_pga = validated_data.pop("is_pga")

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -25,7 +25,7 @@ def build_storage_state(tmp_dir, user, token):
     state = {
         "origins": [
             {
-                "origin": "https://" + settings.FRONTEND_URL + "/",
+                "origin": settings.GO_WEB_INTERNAL_URL + "/",
                 "localStorage": [
                     {
                         "name": "user",

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -137,7 +137,7 @@ def generate_url(url, export_id, user, title):
             )
     except Exception:
         logger.error(
-            "Failed to export PDF",
+            f"Failed to export PDF: {export.export_type}",
             exc_info=True,
             extra=logger_context(dict(export_id=export.pk)),
         )

--- a/api/templates/admin/base_site.html
+++ b/api/templates/admin/base_site.html
@@ -8,7 +8,7 @@
 
 <h1 id="site-name">
     <a href="{% url 'admin:index' %}">
-        <img height="40" src="/static/images/logo/go-logo-2020-6cdc2b0c.svg">
+        <img height="40" src="{% static "images/logo/go-logo-2020-6cdc2b0c.svg" %}" />
     </a>
     {% if HAVING_INGEST_ISSUE and request.user.is_superuser %}
         <span title="Ingest issue – please check erroneous api/CronJob item">

--- a/api/views.py
+++ b/api/views.py
@@ -958,9 +958,9 @@ class ResendValidation(APIView):
 
                 # Construct and re-send the email
                 email_context = {
-                    "confirmation_link": "https://%s/verify_email/?token=%s&user=%s"
+                    "confirmation_link": "%s/verify_email/?token=%s&user=%s"
                     % (
-                        settings.BASE_URL,  # on PROD it should point to goadmin...
+                        settings.GO_API_URL,  # on PROD it should point to goadmin...
                         pending_user.token,
                         username,
                     )

--- a/deploy/helm/ifrcgo-helm/.gitignore
+++ b/deploy/helm/ifrcgo-helm/.gitignore
@@ -1,2 +1,3 @@
 .helm-charts
 values-local.yaml
+charts

--- a/deploy/helm/ifrcgo-helm/Chart.lock
+++ b/deploy/helm/ifrcgo-helm/Chart.lock
@@ -9,4 +9,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 15.0.3
 digest: sha256:a4d204e014228cb7670468d6ec03f567918084eb4bc2f7429b2ec6531bdc2681
-generated: "2025-02-18T16:16:13.450899724+05:45"
+generated: "2025-02-18T16:46:12.682756654+05:45"

--- a/deploy/helm/ifrcgo-helm/Chart.yaml
+++ b/deploy/helm/ifrcgo-helm/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 description: "Helm Chart to deploy the IFRC GO Infrastructure"
 name: ifrcgo-helm
 version: 0.0.2-SET-BY-CICD

--- a/deploy/helm/ifrcgo-helm/Chart.yaml
+++ b/deploy/helm/ifrcgo-helm/Chart.yaml
@@ -15,3 +15,7 @@ dependencies:
     version: 16.4.9
     condition: postgresql.enabled
     repository: https://charts.bitnami.com/bitnami
+  - name: minio
+    version: 15.0.3
+    condition: minio.enabled
+    repository: https://charts.bitnami.com/bitnami

--- a/deploy/helm/ifrcgo-helm/Chart.yaml
+++ b/deploy/helm/ifrcgo-helm/Chart.yaml
@@ -5,3 +5,9 @@ version: 0.0.2-SET-BY-CICD
 
 sources:
   - https://github.com/IFRCGo/go-api
+
+dependencies:
+  - name: redis
+    version: "20.7.1"
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled

--- a/deploy/helm/ifrcgo-helm/Chart.yaml
+++ b/deploy/helm/ifrcgo-helm/Chart.yaml
@@ -11,3 +11,7 @@ dependencies:
     version: "20.7.1"
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
+  - name: postgresql
+    version: 16.4.9
+    condition: postgresql.enabled
+    repository: https://charts.bitnami.com/bitnami

--- a/deploy/helm/ifrcgo-helm/requirements.lock
+++ b/deploy/helm/ifrcgo-helm/requirements.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 20.7.1
-digest: sha256:1852c9489ae647e0394ccb39fa70787bb29ebbdbe24b89b914ce01a2adc6ff29
-generated: "2025-02-18T16:08:53.322089326+05:45"
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 16.4.9
+digest: sha256:ccb7b5c911cae85ec6358f0cf09db34c2fa53a0ebb11fa8ba0426ba991e89c18
+generated: "2025-02-18T16:12:59.123394069+05:45"

--- a/deploy/helm/ifrcgo-helm/requirements.lock
+++ b/deploy/helm/ifrcgo-helm/requirements.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 16.4.9
-digest: sha256:ccb7b5c911cae85ec6358f0cf09db34c2fa53a0ebb11fa8ba0426ba991e89c18
-generated: "2025-02-18T16:12:59.123394069+05:45"
+- name: minio
+  repository: https://charts.bitnami.com/bitnami
+  version: 15.0.3
+digest: sha256:a4d204e014228cb7670468d6ec03f567918084eb4bc2f7429b2ec6531bdc2681
+generated: "2025-02-18T16:16:13.450899724+05:45"

--- a/deploy/helm/ifrcgo-helm/requirements.lock
+++ b/deploy/helm/ifrcgo-helm/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 20.7.1
+digest: sha256:1852c9489ae647e0394ccb39fa70787bb29ebbdbe24b89b914ce01a2adc6ff29
+generated: "2025-02-18T16:08:53.322089326+05:45"

--- a/deploy/helm/ifrcgo-helm/templates/config/configmap.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/config/configmap.yaml
@@ -7,8 +7,15 @@ metadata:
     environment: {{ .Values.environment }}
     release: {{ .Release.Name }}
 data:
-  CELERY_REDIS_URL: "redis://{{ template "ifrcgo-helm.fullname" . }}-redis:6379/0"
-  CACHE_REDIS_URL: "redis://{{ template "ifrcgo-helm.fullname" . }}-redis:6379/1"
+  # Redis
+  {{- if .Values.redis.enabled }}
+  CELERY_REDIS_URL: "redis://{{ printf "%s-master" (include "common.names.fullname" .Subcharts.redis) }}:6379/0"
+  CACHE_REDIS_URL: "redis://{{ printf "%s-master" (include "common.names.fullname" .Subcharts.redis) }}:6379/1"
+  {{- else }}
+  CELERY_REDIS_URL: {{ required "env.CELERY_REDIS_URL" .Values.env.CELERY_REDIS_URL | quote }}
+  CACHE_REDIS_URL: {{ required "env.CACHE_REDIS_URL" .Values.env.CACHE_REDIS_URL | quote }}
+  {{- end }}
+
   CACHE_MIDDLEWARE_SECONDS: {{ .Values.env.CACHE_MIDDLEWARE_SECONDS | quote }}
   DJANGO_DEBUG: {{ .Values.env.DJANGO_DEBUG | quote }}
   ELASTIC_SEARCH_HOST: {{ default (printf "elasticsearch://%s-elasticsearch:9200" (include "ifrcgo-helm.fullname" .)) .Values.env.ELASTIC_SEARCH_HOST | quote }}

--- a/deploy/helm/ifrcgo-helm/templates/config/secret.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/config/secret.yaml
@@ -9,11 +9,22 @@ metadata:
 type: Opaque
 stringData:
   DJANGO_SECRET_KEY: "{{ .Values.env.DJANGO_SECRET_KEY }}"
-  DJANGO_DB_NAME: "{{ .Values.env.DJANGO_DB_NAME }}"
-  DJANGO_DB_USER: "{{ .Values.env.DJANGO_DB_USER }}"
-  DJANGO_DB_PASS: "{{ .Values.env.DJANGO_DB_PASS }}"
-  DJANGO_DB_HOST: "{{ .Values.env.DJANGO_DB_HOST }}"
-  DJANGO_DB_PORT: "{{ .Values.env.DJANGO_DB_PORT }}"
+
+  # Database
+  {{- if .Values.postgresql.enabled }}
+  DJANGO_DB_HOST: {{ include "postgresql.v1.primary.fullname" .Subcharts.postgresql }}
+  DJANGO_DB_PORT: {{ include "postgresql.v1.service.port" .Subcharts.postgresql | quote }}
+  DJANGO_DB_NAME: {{ .Values.postgresql.auth.database | quote }}
+  DJANGO_DB_USER: {{ default "postgres" .Values.postgresql.auth.username | quote }}
+  DJANGO_DB_PASS: {{ default .Values.postgresql.auth.postgresPassword .Values.postgresql.auth.password | quote }}
+  {{- else }}
+  DJANGO_DB_NAME: {{ .Values.env.DJANGO_DB_NAME | quote }}
+  DJANGO_DB_USER: {{ .Values.env.DJANGO_DB_USER | quote }}
+  DJANGO_DB_PASS: {{ .Values.env.DJANGO_DB_PASS | quote }}
+  DJANGO_DB_HOST: {{ .Values.env.DJANGO_DB_HOST | quote }}
+  DJANGO_DB_PORT: {{ .Values.env.DJANGO_DB_PORT | quote }}
+  {{- end }}
+
   AZURE_STORAGE_ACCOUNT: "{{ .Values.env.AZURE_STORAGE_ACCOUNT }}"
   AZURE_STORAGE_KEY: "{{ .Values.env.AZURE_STORAGE_KEY }}"
   EMAIL_API_ENDPOINT: "{{ .Values.env.EMAIL_API_ENDPOINT }}"

--- a/deploy/helm/ifrcgo-helm/templates/config/secret.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/config/secret.yaml
@@ -25,6 +25,17 @@ stringData:
   DJANGO_DB_PORT: {{ .Values.env.DJANGO_DB_PORT | quote }}
   {{- end }}
 
+  # Minio
+  {{- if .Values.minio.enabled }}
+  AWS_S3_ENABLED: "true"
+  AWS_S3_ENDPOINT_URL: "https://{{ .Values.minio.apiIngress.hostname }}/"
+  AWS_S3_ACCESS_KEY_ID: {{ required ".Values.minio.auth.rootUser" .Values.minio.auth.rootUser }}
+  AWS_S3_SECRET_ACCESS_KEY: {{ required ".Values.minio.auth.rootPassword" .Values.minio.auth.rootPassword }}
+  AWS_S3_REGION_NAME: "us-east-1"
+  AWS_S3_MEDIA_BUCKET_NAME: "go-data"
+  AWS_S3_STATIC_BUCKET_NAME: "go-static"
+  {{- end }}
+
   AZURE_STORAGE_ACCOUNT: "{{ .Values.env.AZURE_STORAGE_ACCOUNT }}"
   AZURE_STORAGE_KEY: "{{ .Values.env.AZURE_STORAGE_KEY }}"
   EMAIL_API_ENDPOINT: "{{ .Values.env.EMAIL_API_ENDPOINT }}"

--- a/deploy/helm/ifrcgo-helm/values.yaml
+++ b/deploy/helm/ifrcgo-helm/values.yaml
@@ -102,6 +102,15 @@ redis:
         cpu: "1"
         memory: 2Gi
 
+postgresql:
+  enabled: false  # XXX: Used for alpha instances running outside Azure
+  fullnameOverride: "go-pg"
+  architecture: standalone
+  primary:
+    persistence:
+      enabled: true
+      size: 8Gi
+
 api:
   domain: "go-staging.ifrc.org"
   tls:

--- a/deploy/helm/ifrcgo-helm/values.yaml
+++ b/deploy/helm/ifrcgo-helm/values.yaml
@@ -84,6 +84,24 @@ secretsAdditional:
   # Additional secrets
   # EXAMPLE: MY_SECRET: "my-secret-value"
 
+redis:
+  enabled: true
+  architecture: standalone
+  fullnameOverride: go-redis
+  auth:
+    enabled: false
+  master:
+    persistence:
+      enabled: true
+      size: 1Gi
+    resources:
+      requests:
+        cpu: "0.5"
+        memory: 1Gi
+      limits:
+        cpu: "1"
+        memory: 2Gi
+
 api:
   domain: "go-staging.ifrc.org"
   tls:
@@ -103,16 +121,6 @@ api:
     limits:
       cpu: "2"
       memory: 4Gi
-
-redis:
-  enabled: true
-  resources:
-    requests:
-      cpu: "0.5"
-      memory: 1Gi
-    limits:
-      cpu: "1"
-      memory: 2Gi
 
 celery:
   enabled: true

--- a/deploy/helm/ifrcgo-helm/values.yaml
+++ b/deploy/helm/ifrcgo-helm/values.yaml
@@ -102,6 +102,37 @@ redis:
         cpu: "1"
         memory: 2Gi
 
+# https://artifacthub.io/packages/helm/bitnami/minio
+# extraEnvVars: https://github.com/bitnami/containers/blob/main/bitnami/minio/README.md#environment-variables
+minio:
+  enabled: false  # XXX: Used for alpha instances running outside Azure
+  disableWebUI: true
+  mode: standalone
+  fullnameOverride: go-minio
+  global:
+    defaultStorageClass:
+  apiIngress:
+    enabled: true
+    ingressClassName:
+    hostname:
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+  auth:
+    forceNewKeys: True
+    rootUser: go
+    rootPassword:
+  persistence:
+    enabled: true
+    size: 1Gi
+  defaultBuckets: go-data,go-static
+  provisioning:
+    enabled: true
+    resourcesPreset: "nano"
+    cleanupAfterFinished:
+      enabled: true
+    extraCommands:
+      - "mc anonymous set download provisioning/go-static"
+
 postgresql:
   enabled: false  # XXX: Used for alpha instances running outside Azure
   fullnameOverride: "go-pg"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,10 @@ x-server: &base_server_setup
     # Other development defaults configs
     DJANGO_DEBUG: ${DJANGO_DEBUG:-true}
     GO_ENVIRONMENT: ${GO_ENVIRONMENT:-development}
-    API_FQDN: ${API_FQDN:-localhost:8000}
-    FRONTEND_URL: ${FRONTEND_URL:-localhost:3000}
+    API_FQDN: ${API_FQDN:-http://localhost:8000}
+    FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
+    GO_WEB_INTERNAL_URL: ${GO_WEB_INTERNAL_URL:-http://host.docker.internal:3000}
+    DJANGO_ADDITIONAL_ALLOWED_HOSTS: ${DJANGO_ADDITIONAL_ALLOWED_HOSTS:-host.docker.internal}
     DEBUG_EMAIL: ${DEBUG_EMAIL:-true}
     MOLNIX_API_BASE: ${MOLNIX_API_BASE:-https://api.ifrc-staging.rpm.molnix.com/api/}
     ERP_API_ENDPOINT: ${ERP_API_ENDPOINT:-https://ifrctintapim001.azure-api.net/GoAPI/ExtractGoEmergency}

--- a/main/settings.py
+++ b/main/settings.py
@@ -54,7 +54,7 @@ env = environ.Env(
     AWS_S3_REGION_NAME=str,
     AWS_S3_MEDIA_BUCKET_NAME=str,
     AWS_S3_STATIC_BUCKET_NAME=str,
-    # -- Filesystem (default) XXX: Don't use for production
+    # -- Filesystem (default) XXX: Don't use in production
     DJANGO_MEDIA_ROOT=(str, os.path.join(BASE_DIR, "media")),
     DJANGO_STATIC_ROOT=(str, os.path.join(BASE_DIR, "static")),
     # Email
@@ -155,10 +155,7 @@ def find_env_with_value(*keys: str) -> None | str:
 
 
 def parse_domain(*env_keys: str) -> str:
-    """
-    NOTE: This is used for to avoid breaking due to existing config value
-    Update this using django validation
-    """
+    # FIXME: This is for backward compatibility for the existing config value
     env_key = find_env_with_value(*env_keys)
     raw_domain = env(env_key)
     domain = raw_domain
@@ -170,10 +167,10 @@ def parse_domain(*env_keys: str) -> str:
 
 GO_API_URL = parse_domain("API_FQDN")
 GO_WEB_URL = parse_domain("FRONTEND_URL")
-# NOTE: Used in local development to get to the frontend service from within go-api container
-#  GO_WEB_URL will be used if GO_WEB_INTERNAL_URL is not provided
+# NOTE: Used in local development to point to the frontend service from within go-api container
+#  Default to GO_WEB_URL if GO_WEB_INTERNAL_URL is not provided
 GO_WEB_INTERNAL_URL = parse_domain("GO_WEB_INTERNAL_URL", "FRONTEND_URL")
-FRONTEND_URL = urlparse(GO_WEB_URL).hostname  # XXX: Deprecated. Slowly remove this from codebase
+FRONTEND_URL = urlparse(GO_WEB_URL).hostname  # FIXME: Deprecated. Slowly remove this from codebase
 
 INTERNAL_IPS = ["127.0.0.1"]
 if env("DOCKER_HOST_IP"):
@@ -498,7 +495,7 @@ if env("AZURE_STORAGE_ENABLED"):
                 "azure_container": "api",
             },
         },
-        # TODO: Use this instead of nginx for staticfiles
+        # FIXME: Use this instead of nginx for staticfiles
         # "staticfiles": {
         #     "BACKEND": "storages.backends.azure_storage.AzureStorage",
         #     "OPTIONS": {

--- a/main/settings.py
+++ b/main/settings.py
@@ -46,6 +46,14 @@ env = environ.Env(
     AZURE_STORAGE_KEY=(str, None),
     AZURE_STORAGE_TOKEN_CREDENTIAL=(str, None),
     AZURE_STORAGE_MANAGED_IDENTITY=(bool, False),
+    # -- S3 storage
+    AWS_S3_ENABLED=(bool, False),
+    AWS_S3_ENDPOINT_URL=(str, None),
+    AWS_S3_ACCESS_KEY_ID=str,
+    AWS_S3_SECRET_ACCESS_KEY=str,
+    AWS_S3_REGION_NAME=str,
+    AWS_S3_MEDIA_BUCKET_NAME=str,
+    AWS_S3_STATIC_BUCKET_NAME=str,
     # -- Filesystem (default) XXX: Don't use for production
     DJANGO_MEDIA_ROOT=(str, os.path.join(BASE_DIR, "media")),
     DJANGO_STATIC_ROOT=(str, os.path.join(BASE_DIR, "static")),
@@ -500,6 +508,38 @@ if env("AZURE_STORAGE_ENABLED"):
         #     },
         # },
     }
+
+# NOTE: This is used for instances outside azure environment
+elif env("AWS_S3_ENABLED"):
+    AWS_S3_CONFIG_OPTIONS = {
+        "endpoint_url": env("AWS_S3_ENDPOINT_URL"),
+        "access_key": env("AWS_S3_ACCESS_KEY_ID"),
+        "secret_key": env("AWS_S3_SECRET_ACCESS_KEY"),
+        "region_name": env("AWS_S3_REGION_NAME"),
+    }
+
+    STORAGES = {
+        "default": {
+            "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+            "OPTIONS": {
+                **AWS_S3_CONFIG_OPTIONS,
+                "bucket_name": env("AWS_S3_MEDIA_BUCKET_NAME"),
+                "location": "media/",
+                "file_overwrite": False,
+            },
+        },
+        "staticfiles": {
+            "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+            "OPTIONS": {
+                **AWS_S3_CONFIG_OPTIONS,
+                "bucket_name": env("AWS_S3_STATIC_BUCKET_NAME"),
+                "querystring_auth": False,
+                "location": "static/",
+                "file_overwrite": True,
+            },
+        },
+    }
+
 else:
     # Filesystem
     MEDIA_ROOT = env("DJANGO_MEDIA_ROOT")

--- a/main/settings.py
+++ b/main/settings.py
@@ -82,6 +82,7 @@ env = environ.Env(
     FDRS_CREDENTIAL=(str, None),
     HPC_CREDENTIAL=(str, None),
     APPLICATION_INSIGHTS_INSTRUMENTATION_KEY=(str, None),
+    DEBUG_PLAYWRIGHT=(bool, False),
     # Pytest (Only required when running tests)
     PYTEST_XDIST_WORKER=(str, None),
     # Elastic-Cache
@@ -180,6 +181,7 @@ ALLOWED_HOSTS = [
 
 SECRET_KEY = env("DJANGO_SECRET_KEY")
 DEBUG = env("DJANGO_DEBUG")
+DEBUG_PLAYWRIGHT = env("DEBUG_PLAYWRIGHT")
 GO_ENVIRONMENT = env("GO_ENVIRONMENT")
 
 # See if we are inside a test environment

--- a/main/settings.py
+++ b/main/settings.py
@@ -30,8 +30,8 @@ env = environ.Env(
     DJANGO_ADDITIONAL_ALLOWED_HOSTS=(list, []),  # Eg: api.go.ifrc.org, goadmin.ifrc.org, dsgocdnapi.azureedge.net
     GO_ENVIRONMENT=(str, "development"),  # staging, production
     #
-    FRONTEND_URL=str,
     API_FQDN=str,  # https://goadmin.ifrc.org
+    FRONTEND_URL=str,  # https://go.ifrc.org
     # Database
     DJANGO_DB_NAME=str,
     DJANGO_DB_USER=str,
@@ -145,6 +145,9 @@ def parse_domain(env_key: str) -> str:
 
 
 GO_API_URL = parse_domain("API_FQDN")
+GO_WEB_URL = parse_domain("FRONTEND_URL")
+FRONTEND_URL = urlparse(GO_WEB_URL).hostname  # XXX: Deprecated. Slowly remove this from codebase
+
 INTERNAL_IPS = ["127.0.0.1"]
 if env("DOCKER_HOST_IP"):
     INTERNAL_IPS.append(env("DOCKER_HOST_IP"))
@@ -627,8 +630,6 @@ GO_FTPUSER = env("GO_FTPUSER")
 GO_FTPPASS = env("GO_FTPPASS")
 GO_DBPASS = env("GO_DBPASS")
 
-# MISC
-FRONTEND_URL = env("FRONTEND_URL")
 
 # COUNTRY PAGE
 NS_CONTACT_USERNAME = env("NS_CONTACT_USERNAME")

--- a/poetry.lock
+++ b/poetry.lock
@@ -155,6 +155,43 @@ files = [
 ]
 
 [[package]]
+name = "azure-core"
+version = "1.32.0"
+description = "Microsoft Azure Core Library for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "azure_core-1.32.0-py3-none-any.whl", hash = "sha256:eac191a0efb23bfa83fddf321b27b122b4ec847befa3091fa736a5c32c50d7b4"},
+    {file = "azure_core-1.32.0.tar.gz", hash = "sha256:22b3c35d6b2dae14990f6c1be2912bf23ffe50b220e708a28ab1bb92b1c730e5"},
+]
+
+[package.dependencies]
+requests = ">=2.21.0"
+six = ">=1.11.0"
+typing-extensions = ">=4.6.0"
+
+[package.extras]
+aio = ["aiohttp (>=3.0)"]
+
+[[package]]
+name = "azure-identity"
+version = "1.20.0"
+description = "Microsoft Azure Identity Library for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "azure_identity-1.20.0-py3-none-any.whl", hash = "sha256:5f23fc4889a66330e840bd78830287e14f3761820fe3c5f77ac875edcb9ec998"},
+    {file = "azure_identity-1.20.0.tar.gz", hash = "sha256:40597210d56c83e15031b0fe2ea3b26420189e1e7f3e20bdbb292315da1ba014"},
+]
+
+[package.dependencies]
+azure-core = ">=1.31.0"
+cryptography = ">=2.5"
+msal = ">=1.30.0"
+msal-extensions = ">=1.2.0"
+typing-extensions = ">=4.0.0"
+
+[[package]]
 name = "azure-nspkg"
 version = "3.0.2"
 description = "Microsoft Azure Namespace Package [Internal]"
@@ -1190,6 +1227,7 @@ files = [
 ]
 
 [package.dependencies]
+azure-storage-blob = {version = ">=1.3.1,<12.0.0", optional = true, markers = "extra == \"azure\""}
 Django = ">=2.2"
 
 [package.extras]
@@ -2198,6 +2236,40 @@ dev = ["check-manifest"]
 test = ["coveralls", "hypothesis", "pydocstyle", "pytest-cov"]
 
 [[package]]
+name = "msal"
+version = "1.31.1"
+description = "The Microsoft Authentication Library (MSAL) for Python library enables your app to access the Microsoft Cloud by supporting authentication of users with Microsoft Azure Active Directory accounts (AAD) and Microsoft Accounts (MSA) using industry standard OAuth2 and OpenID Connect."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "msal-1.31.1-py3-none-any.whl", hash = "sha256:29d9882de247e96db01386496d59f29035e5e841bcac892e6d7bf4390bf6bd17"},
+    {file = "msal-1.31.1.tar.gz", hash = "sha256:11b5e6a3f802ffd3a72107203e20c4eac6ef53401961b880af2835b723d80578"},
+]
+
+[package.dependencies]
+cryptography = ">=2.5,<46"
+PyJWT = {version = ">=1.0.0,<3", extras = ["crypto"]}
+requests = ">=2.0.0,<3"
+
+[package.extras]
+broker = ["pymsalruntime (>=0.14,<0.18)", "pymsalruntime (>=0.17,<0.18)"]
+
+[[package]]
+name = "msal-extensions"
+version = "1.2.0"
+description = "Microsoft Authentication Library extensions (MSAL EX) provides a persistence API that can save your data on disk, encrypted on Windows, macOS and Linux. Concurrent data access will be coordinated by a file lock mechanism."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "msal_extensions-1.2.0-py3-none-any.whl", hash = "sha256:cf5ba83a2113fa6dc011a254a72f1c223c88d7dfad74cc30617c4679a417704d"},
+    {file = "msal_extensions-1.2.0.tar.gz", hash = "sha256:6f41b320bfd2933d631a215c91ca0dd3e67d84bd1a2f50ce917d5874ec646bef"},
+]
+
+[package.dependencies]
+msal = ">=1.29,<2"
+portalocker = ">=1.4,<3"
+
+[[package]]
 name = "numpy"
 version = "1.26.4"
 description = "Fundamental package for array computing in Python"
@@ -2595,6 +2667,25 @@ files = [
     {file = "polib-1.1.0-py2.py3-none-any.whl", hash = "sha256:93b730477c16380c9a96726c54016822ff81acfa553977fdd131f2b90ba858d7"},
     {file = "polib-1.1.0.tar.gz", hash = "sha256:fad87d13696127ffb27ea0882d6182f1a9cf8a5e2b37a587751166c51e5a332a"},
 ]
+
+[[package]]
+name = "portalocker"
+version = "2.10.1"
+description = "Wraps the portalocker recipe for easy usage"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "portalocker-2.10.1-py3-none-any.whl", hash = "sha256:53a5984ebc86a025552264b459b46a2086e269b21823cb572f8f28ee759e45bf"},
+    {file = "portalocker-2.10.1.tar.gz", hash = "sha256:ef1bf844e878ab08aee7e40184156e1151f228f103aa5c6bd0724cc330960f8f"},
+]
+
+[package.dependencies]
+pywin32 = {version = ">=226", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+docs = ["sphinx (>=1.7.1)"]
+redis = ["redis"]
+tests = ["pytest (>=5.4.1)", "pytest-cov (>=2.8.1)", "pytest-mypy (>=0.8.0)", "pytest-timeout (>=2.1.0)", "redis", "sphinx (>=6.0.0)", "types-redis"]
 
 [[package]]
 name = "promise"
@@ -3108,6 +3199,9 @@ files = [
     {file = "pyjwt-2.9.0.tar.gz", hash = "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c"},
 ]
 
+[package.dependencies]
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
+
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
 dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
@@ -3453,6 +3547,33 @@ python-versions = "*"
 files = [
     {file = "pytz-2019.1-py2.py3-none-any.whl", hash = "sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda"},
     {file = "pytz-2019.1.tar.gz", hash = "sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"},
+]
+
+[[package]]
+name = "pywin32"
+version = "308"
+description = "Python for Window Extensions"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pywin32-308-cp310-cp310-win32.whl", hash = "sha256:796ff4426437896550d2981b9c2ac0ffd75238ad9ea2d3bfa67a1abd546d262e"},
+    {file = "pywin32-308-cp310-cp310-win_amd64.whl", hash = "sha256:4fc888c59b3c0bef905ce7eb7e2106a07712015ea1c8234b703a088d46110e8e"},
+    {file = "pywin32-308-cp310-cp310-win_arm64.whl", hash = "sha256:a5ab5381813b40f264fa3495b98af850098f814a25a63589a8e9eb12560f450c"},
+    {file = "pywin32-308-cp311-cp311-win32.whl", hash = "sha256:5d8c8015b24a7d6855b1550d8e660d8daa09983c80e5daf89a273e5c6fb5095a"},
+    {file = "pywin32-308-cp311-cp311-win_amd64.whl", hash = "sha256:575621b90f0dc2695fec346b2d6302faebd4f0f45c05ea29404cefe35d89442b"},
+    {file = "pywin32-308-cp311-cp311-win_arm64.whl", hash = "sha256:100a5442b7332070983c4cd03f2e906a5648a5104b8a7f50175f7906efd16bb6"},
+    {file = "pywin32-308-cp312-cp312-win32.whl", hash = "sha256:587f3e19696f4bf96fde9d8a57cec74a57021ad5f204c9e627e15c33ff568897"},
+    {file = "pywin32-308-cp312-cp312-win_amd64.whl", hash = "sha256:00b3e11ef09ede56c6a43c71f2d31857cf7c54b0ab6e78ac659497abd2834f47"},
+    {file = "pywin32-308-cp312-cp312-win_arm64.whl", hash = "sha256:9b4de86c8d909aed15b7011182c8cab38c8850de36e6afb1f0db22b8959e3091"},
+    {file = "pywin32-308-cp313-cp313-win32.whl", hash = "sha256:1c44539a37a5b7b21d02ab34e6a4d314e0788f1690d65b48e9b0b89f31abbbed"},
+    {file = "pywin32-308-cp313-cp313-win_amd64.whl", hash = "sha256:fd380990e792eaf6827fcb7e187b2b4b1cede0585e3d0c9e84201ec27b9905e4"},
+    {file = "pywin32-308-cp313-cp313-win_arm64.whl", hash = "sha256:ef313c46d4c18dfb82a2431e3051ac8f112ccee1a34f29c263c583c568db63cd"},
+    {file = "pywin32-308-cp37-cp37m-win32.whl", hash = "sha256:1f696ab352a2ddd63bd07430080dd598e6369152ea13a25ebcdd2f503a38f1ff"},
+    {file = "pywin32-308-cp37-cp37m-win_amd64.whl", hash = "sha256:13dcb914ed4347019fbec6697a01a0aec61019c1046c2b905410d197856326a6"},
+    {file = "pywin32-308-cp38-cp38-win32.whl", hash = "sha256:5794e764ebcabf4ff08c555b31bd348c9025929371763b2183172ff4708152f0"},
+    {file = "pywin32-308-cp38-cp38-win_amd64.whl", hash = "sha256:3b92622e29d651c6b783e368ba7d6722b1634b8e70bd376fd7610fe1992e19de"},
+    {file = "pywin32-308-cp39-cp39-win32.whl", hash = "sha256:7873ca4dc60ab3287919881a7d4f88baee4a6e639aa6962de25a98ba6b193341"},
+    {file = "pywin32-308-cp39-cp39-win_amd64.whl", hash = "sha256:71b3322d949b4cc20776436a9c9ba0eeedcbc9c650daa536df63f0ff111bb920"},
 ]
 
 [[package]]
@@ -4380,4 +4501,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "37c91e4e89aefb6510e90679a03c13aad13768fb89962a602f29312a4bfff58e"
+content-hash = "80527c9b7d116e6c22ad4737c1fda95bebf49d0deca884a195db9e4bfccaa7b8"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4501,4 +4501,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "80527c9b7d116e6c22ad4737c1fda95bebf49d0deca884a195db9e4bfccaa7b8"
+content-hash = "9ff1ef3b0a1403e97dab266291ec7875f7b65361dc78c21f02bfcb7e6c95ec49"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ django-modeltranslation = "==0.17.5"
 django-read-only = "==1.12.0"
 django-reversion-compare = "==0.16.2"
 django-reversion = "==5.0.12"
-django-storages = { version = "==1.11.1", extras = ["azure"] }
+django-storages = { version = "==1.11.1", extras = ["s3", "azure"] }
 django-tinymce = "==4.1.0"
 django-oauth-toolkit = "3.0.1"
 djangorestframework-csv = "==2.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ django-modeltranslation = "==0.17.5"
 django-read-only = "==1.12.0"
 django-reversion-compare = "==0.16.2"
 django-reversion = "==5.0.12"
-django-storages = "==1.11.1"
+django-storages = { version = "==1.11.1", extras = ["azure"] }
 django-tinymce = "==4.1.0"
 django-oauth-toolkit = "3.0.1"
 djangorestframework-csv = "==2.1.1"
@@ -88,7 +88,7 @@ drf-spectacular = "*"
 pyjwt = "*"
 shapely = "*"
 colorlog = "*"
-
+azure-identity = "*"  # Required by django-storages[azure] if used
 mapbox-tilesets = "*"
 ipython = "*"
 tiktoken = "*"

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -8,9 +8,9 @@ from notifications.notification import send_notification
 @shared_task
 def send_notification_create(token, username, is_staff, email):
     email_context = {
-        "confirmation_link": "https://%s/verify_email/?token=%s&user=%s"
+        "confirmation_link": "%s/verify_email/?token=%s&user=%s"
         % (
-            settings.BASE_URL,  # on PROD it should point to goadmin...
+            settings.GO_API_URL,  # on PROD it should point to goadmin...
             token,
             username,
         )

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -68,9 +68,9 @@ class VerifyEmail(APIView):
             for admin in admins:
                 token = pending_user.admin_token_1
                 email_context = {
-                    "validation_link": "https://%s/validate_user/?token=%s&user=%s"
+                    "validation_link": "%s/validate_user/?token=%s&user=%s"
                     % (
-                        settings.BASE_URL,  # on PROD it should point to goadmin...
+                        settings.GO_API_URL,  # on PROD it should point to goadmin...
                         token,
                         user,
                     ),


### PR DESCRIPTION
Addresses **PDF Export support for local and Alpha environments**

## Changes

* Allow using locally running go-web-app for PDF export
* Add support for S3 storage (using self-host Bitnami [minio](https://min.io/) sub-chart) to serve static/media files in Alpha environments where Azure blob storage is not available.
  * Eg: Export DREF using https://alpha-4.ifrc-go.dev.datafriendlyspace.org/account/my-forms/dref
* Add basic Bitnami Postgres sub-chart inside cluster for Alpha environments.
* Add config to remove hardcoded `https` in the system (http is required for local development) - WIP

## 🚨 Breaking change 🚨 
- We need to explicitly enable Azure blob in go-deploy using ENV `AZURE_STORAGE_ENABLED=true`