### PR TITLE
AppealHistory savepoint via an Admin checkbox

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -24,7 +24,7 @@ from api.management.commands.index_and_notify import Command as Notify
 from lang.admin import TranslationAdmin, TranslationInlineModelAdmin
 from notifications.models import RecordType, SubscriptionType
 
-from .forms import ActionForm
+from .forms import ActionForm, AppealForm
 
 # from reversion.models import Revision
 
@@ -445,6 +445,13 @@ class GeneralDocumentInline(admin.TabularInline, TranslationInlineModelAdmin):
 
 
 class AppealAdmin(CompareVersionAdmin, RegionRestrictedAdmin, TranslationAdmin):
+
+    @admin.display(description="Force history save")
+    def force_history_save(self, obj):
+        return obj._force_history_save
+
+    form = AppealForm
+    force_history_save.boolean = False
     country_in = "country__pk__in"
     region_in = "region__pk__in"
     inlines = [AppealDocumentInline]
@@ -513,6 +520,7 @@ class AppealAdmin(CompareVersionAdmin, RegionRestrictedAdmin, TranslationAdmin):
     def save_model(self, request, obj, form, change):
         if obj.country:
             obj.region = obj.country.region
+        obj._force_history_save = form.cleaned_data.get("force_history_save", False)
         super().save_model(request, obj, form, change)
 
 

--- a/api/forms.py
+++ b/api/forms.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
 from .logger import logger
-from .models import Action, ActionOrg, ActionType
+from .models import Action, ActionOrg, ActionType, Appeal
 
 
 class ActionForm(forms.ModelForm):
@@ -14,6 +14,19 @@ class ActionForm(forms.ModelForm):
 
     class Meta:
         model = Action
+        fields = "__all__"
+
+
+class AppealForm(forms.ModelForm):
+    force_history_save = forms.BooleanField(
+        label="Save changes to history",
+        required=False,
+        initial=False,
+        help_text="Check if changes should be saved to AppealHistory, regardless of the values of the fields.",
+    )
+
+    class Meta:
+        model = Appeal
         fields = "__all__"
 
 

--- a/api/models.py
+++ b/api/models.py
@@ -1205,6 +1205,15 @@ class Appeal(models.Model):
         default=0.00,
         editable=False,
     )
+    _force_history_save = None
+
+    @property
+    def force_history_save(self):
+        return self._force_history_save
+
+    @force_history_save.setter
+    def force_history_save(self, value):
+        self._force_history_save = value
 
     class Meta:
         ordering = (

--- a/api/receivers.py
+++ b/api/receivers.py
@@ -214,7 +214,7 @@ def add_update_appeal_history(sender, instance, created, **kwargs):
         if field.name not in ["id", "appeal", "valid_from", "valid_to", "aid", "amount_funded"]
     ]
     now = timezone.now()
-    changed = False
+    changed = getattr(instance, "force_history_save", False)
 
     if created:  # Appeal Insert
         AppealHistory.objects.create(


### PR DESCRIPTION
Addresses the manual appeal updates on Appeal Admin page (like Myanmar).