### PR TITLE
Add ModelSerializer for primary sector

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -13,7 +13,7 @@ from rest_framework import serializers
 # from api.utils import pdf_exporter
 from api.tasks import generate_url
 from api.utils import CountryValidator, RegionValidator
-from deployments.models import EmergencyProject, Personnel, PersonnelDeployment
+from deployments.models import EmergencyProject, Personnel, PersonnelDeployment, Sector
 from dref.models import Dref, DrefFinalReport, DrefOperationalUpdate
 from lang.models import String
 from lang.serializers import ModelSerializer
@@ -2455,11 +2455,10 @@ class SearchSerializer(serializers.Serializer):
     reports = SearchReportSerializer(many=True, required=False, allow_null=True)
 
 
-class ProjectPrimarySectorsSerializer(serializers.Serializer):
-    key = serializers.IntegerField()
-    label = serializers.CharField()
-    color = serializers.CharField()
-    is_deprecated = serializers.BooleanField()
+class ProjectPrimarySectorsSerializer(ModelSerializer):
+    class Meta:
+        model = Sector
+        fields = "__all__"
 
 
 class ProjectSecondarySectorsSerializer(serializers.Serializer):

--- a/api/views.py
+++ b/api/views.py
@@ -587,10 +587,8 @@ class ProjectPrimarySectors(APIView):
         responses=ProjectPrimarySectorsSerializer(many=True),
     )
     def get(cls, request):
-        keys_labels = [
-            {"key": s.id, "label": s.title, "color": s.color, "is_deprecated": s.is_deprecated} for s in Sector.objects.all()
-        ]
-        return Response(ProjectPrimarySectorsSerializer(keys_labels, many=True).data)
+        queryset = Sector.objects.filter(is_deprecated=False).all()
+        return Response(ProjectPrimarySectorsSerializer(queryset, many=True).data)
 
 
 class ProjectSecondarySectors(APIView):


### PR DESCRIPTION
## Changes
- Use modelserializer for sector as it's registered for translation 

# Commands to run

1. Trigger model fields translation
```
from lang.tasks import ModelTranslator
from deployments.models import *
# Define a list of models to translate
models_to_translate = [
    Sector
]

# Display character counts for the specified models
ModelTranslator.show_characters_counts(only_models=models_to_translate)

# Run the translation process for the specified models
ModelTranslator().run(only_models=models_to_translate)

```

## Checklist
Things that should succeed before merging.

- [ ] Updated/ran unit tests
- [ ] Updated CHANGELOG.md

## Release

If there is a version update, make sure to tag the repository with the latest version.
