### PR TITLE
Fix per-assessment n+1 query issue

### DIFF
--- a/per/drf_views.py
+++ b/per/drf_views.py
@@ -690,7 +690,22 @@ class FormAssessmentViewSet(viewsets.ModelViewSet):
     ordering_fields = "__all__"
 
     def get_queryset(self):
-        return PerAssessment.objects.select_related("overview")
+        return PerAssessment.objects.select_related("overview", "overview__country").prefetch_related(
+            Prefetch(
+                "area_responses",
+                queryset=AreaResponse.objects.select_related("area").prefetch_related(
+                    Prefetch(
+                        "component_response",
+                        queryset=FormComponentResponse.objects.select_related("component", "rating").prefetch_related(
+                            Prefetch(
+                                "question_responses",
+                                queryset=FormComponentQuestionAndAnswer.objects.select_related("question"),
+                            )
+                        ),
+                    )
+                ),
+            )
+        )
 
 
 class PublicFormAssessmentViewSet(viewsets.ReadOnlyModelViewSet):
@@ -698,7 +713,22 @@ class PublicFormAssessmentViewSet(viewsets.ReadOnlyModelViewSet):
     ordering_fields = "__all__"
 
     def get_queryset(self):
-        return PerAssessment.objects.select_related("overview")
+        return PerAssessment.objects.select_related("overview", "overview__country").prefetch_related(
+            Prefetch(
+                "area_responses",
+                queryset=AreaResponse.objects.select_related("area").prefetch_related(
+                    Prefetch(
+                        "component_response",
+                        queryset=FormComponentResponse.objects.select_related("component", "rating").prefetch_related(
+                            Prefetch(
+                                "question_responses",
+                                queryset=FormComponentQuestionAndAnswer.objects.select_related("question"),
+                            )
+                        ),
+                    )
+                ),
+            )
+        )
 
 
 # Consolidated public endpoints (map-data, assessments-processed, dashboard-data)

--- a/per/serializers.py
+++ b/per/serializers.py
@@ -811,6 +811,13 @@ class PerAssessmentSerializer(
 ):
     area_responses = AreaResponseSerializer(many=True, required=False)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        overview_field = self.fields.get("overview")
+        if overview_field is not None and hasattr(overview_field, "queryset"):
+            # Avoid N+1 in overview choice labels, since Overview.__str__ touches country.
+            overview_field.queryset = Overview.objects.select_related("country")
+
     class Meta:
         model = PerAssessment
         fields = "__all__"


### PR DESCRIPTION
Refers to Sentry /organizations/ifrc-go/issues/6969

Dropping from 1169 queries to 11 at around 49ms (instead of 942ms) – the N+1 path is fully addressed.