### PR TITLE
Alert-system: Map to internal cluster eoapi url

### DIFF
--- a/alert_system/etl/base/extraction.py
+++ b/alert_system/etl/base/extraction.py
@@ -229,11 +229,10 @@ class BaseExtractionClass(ABC):
             logger.warning(f"Failed to fetch events: {e}")
             raise
 
-        first_event_item = next(event_items, None)
-        if not first_event_item:
-            msg = f"No event items found for extraction_run_id={extraction_run_id}"
-            logger.warning(msg)
-            raise ValueError(msg)
+        event_items = list(event_items)
+        if not event_items:
+            logger.warning(f"No event items found for extraction_run_id={extraction_run_id}")
+            return
 
         for event_item in event_items:
             self.process_event_item(event_item=event_item, extraction_run_id=extraction_run_id, is_past_event=is_past_event)

--- a/alert_system/helpers.py
+++ b/alert_system/helpers.py
@@ -10,8 +10,8 @@ def _remap_stac_url(url: str) -> str:
     """
     Rewrite a STAC URL to point at the internal cluster service.
     """
-    external_base = getattr(settings, "EOAPI_STAC_EXTERNAL_URL", None)
-    internal_base = getattr(settings, "EOAPI_STAC_INTERNAL_URL", None)
+    external_base = settings.EOAPI_STAC_EXTERNAL_URL
+    internal_base = settings.EOAPI_STAC_INTERNAL_URL
     if not external_base or not internal_base:
         return url
 
@@ -23,7 +23,7 @@ def _remap_stac_url(url: str) -> str:
         return url
 
     path = parsed.path
-    if ext.path and path.startswith(ext.path):
+    if ext.path and (path == ext.path or path.startswith(ext.path + "/")):
         path = path[len(ext.path) :]
 
     return urlunsplit((internal.scheme, internal.netloc, internal.path + path, parsed.query, parsed.fragment))

--- a/alert_system/helpers.py
+++ b/alert_system/helpers.py
@@ -1,7 +1,32 @@
 # Helper functions to build search params.
 from typing import Dict, Generator, Optional
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
+from django.conf import settings
+
+
+def _remap_stac_url(url: str) -> str:
+    """
+    Rewrite a STAC URL to point at the internal cluster service.
+    """
+    external_base = getattr(settings, "EOAPI_STAC_EXTERNAL_URL", None)
+    internal_base = getattr(settings, "EOAPI_STAC_INTERNAL_URL", None)
+    if not external_base or not internal_base:
+        return url
+
+    ext = urlsplit(external_base.rstrip("/"))
+    internal = urlsplit(internal_base.rstrip("/"))
+    parsed = urlsplit(url)
+
+    if parsed.netloc not in (ext.netloc, internal.netloc):
+        return url
+
+    path = parsed.path
+    if ext.path and path.startswith(ext.path):
+        path = path[len(ext.path) :]
+
+    return urlunsplit((internal.scheme, internal.netloc, internal.path + path, parsed.query, parsed.fragment))
 
 
 def build_search_params(
@@ -57,7 +82,7 @@ def build_stac_search(
 
 
 def fetch_stac_data(url: str, payload: dict | None = None, timeout: int | None = 60):
-    response = httpx.get(url=url, params=payload, timeout=timeout)
+    response = httpx.get(url=_remap_stac_url(url), params=payload, timeout=timeout)
     response.raise_for_status()
     return response.json()
 

--- a/deploy/helm/ifrcgo-helm/templates/config/configmap.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/config/configmap.yaml
@@ -48,6 +48,9 @@ data:
   SENTRY_DSN: {{ .Values.env.SENTRY_DSN | quote }}
   OIDC_ENABLE: {{ .Values.env.OIDC_ENABLE | quote }}
 
+  EOAPI_STAC_EXTERNAL_URL: {{ .Values.env.EOAPI_STAC_EXTERNAL_URL | quote }}
+  EOAPI_STAC_INTERNAL_URL: {{ .Values.env.EOAPI_STAC_INTERNAL_URL | quote }}
+
   # Additional configs
   {{- range $name, $value := .Values.envAdditional }}
   {{ $name }}: {{ $value | quote }}

--- a/main/settings.py
+++ b/main/settings.py
@@ -153,6 +153,9 @@ env = environ.Env(
     # PowerBI
     POWERBI_WORKSPACE_ID=(str, None),
     POWERBI_DATASET_IDS=(str, None),
+    # Alert system - remap external STAC related-item URLs to internal cluster URLs
+    EOAPI_STAC_EXTERNAL_URL=(str, None),  # e.g. https://montandon-eoapi.ifrc.org/stac
+    EOAPI_STAC_INTERNAL_URL=(str, None),  # e.g. http://montandon-eoapi-stac.montandon-eoapi.svc.cluster.local:8080
 )
 
 
@@ -175,6 +178,9 @@ def parse_domain(*env_keys: str) -> str:
         logger.warning(f"Provided {env_key}: {raw_domain} is missing schema.. Adding https -> {domain}")
     return domain.strip("/")
 
+
+EOAPI_STAC_EXTERNAL_URL = env("EOAPI_STAC_EXTERNAL_URL")
+EOAPI_STAC_INTERNAL_URL = env("EOAPI_STAC_INTERNAL_URL")
 
 GO_API_URL = parse_domain("API_FQDN")
 GO_WEB_URL = parse_domain("FRONTEND_URL")


### PR DESCRIPTION
## Changes

* Map external urls for related events to internal cluster eoapi url.
* Avoid raise on empty data.

## Things to remember

We need to set two env for this change.
for these values, take reference from montandon configurations
```
EOAPI_STAC_INTERNAL_URL=
EOAPI_STAC_EXTERNAL_URL=
```

## Checklist

- [x] Updated/ran unit tests
- [x] Updated CHANGELOG.md

## NOTE
- This is a breaking change in staging environment.
