### PR TITLE
fix(settings): extend admin session cookie lifetime (#2464)

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -30,6 +30,8 @@ env = environ.Env(
     DJANGO_ADDITIONAL_ALLOWED_HOSTS=(list, []),  # Eg: api.go.ifrc.org, goadmin.ifrc.org, dsgocdnapi.azureedge.net
     GO_ENVIRONMENT=(str, "development"),  # staging, production
     SESSION_COOKIE_DOMAIN=str,
+    SESSION_COOKIE_AGE=(int, 60 * 60 * 24 * 28),  # 28 days (Django allows up to ~4 weeks)
+    SESSION_SAVE_EVERY_REQUEST=(bool, True),
     CSRF_COOKIE_DOMAIN=str,
     ADDITIONAL_TRUSTED_ORIGINS=(list, []),
     API_FQDN=str,  # https://goadmin.ifrc.org
@@ -503,6 +505,9 @@ CSRF_TRUSTED_ORIGINS = GO_TRUSTED_ORIGINS
 
 # https://docs.djangoproject.com/en/4.2/ref/settings/#std:setting-SESSION_COOKIE_DOMAIN
 SESSION_COOKIE_DOMAIN = env("SESSION_COOKIE_DOMAIN")
+SESSION_COOKIE_AGE = env("SESSION_COOKIE_AGE")
+# Extend admin session on each request so active users are not prompted to re-login prematurely
+SESSION_SAVE_EVERY_REQUEST = env("SESSION_SAVE_EVERY_REQUEST")
 # https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-cookie-domain
 CSRF_COOKIE_DOMAIN = env("CSRF_COOKIE_DOMAIN")
 


### PR DESCRIPTION
## Summary
- Configure `SESSION_COOKIE_AGE` (default 28 days, env-overridable)
- Enable `SESSION_SAVE_EVERY_REQUEST` so active sessions extend on each request

## Test plan
- [ ] Deploy to staging: confirm admin session persists across browser restarts within cookie age
- [ ] Override `SESSION_COOKIE_AGE` via env if shorter lifetime is required

Fixes #2464

Made with [Cursor](https://cursor.com)