### PR TITLE
fix(per): block validated OpsLearning fields when not validated (#2293)

### DIFF
--- a/per/serializers.py
+++ b/per/serializers.py
@@ -1107,10 +1107,43 @@ class OpsLearningSerializer(serializers.ModelSerializer):
 
 
 class OpsLearningInSerializer(serializers.ModelSerializer):
+    VALIDATED_M2M_FIELDS = ("organization_validated", "sector_validated", "per_component_validated")
 
     class Meta:
         model = OpsLearning
         fields = "__all__"
+
+    def validate(self, attrs):
+        is_validated = attrs.get("is_validated", getattr(self.instance, "is_validated", False))
+
+        if is_validated:
+            return attrs
+
+        errors = {}
+        learning_validated = attrs.get(
+            "learning_validated",
+            getattr(self.instance, "learning_validated", None) if self.instance else None,
+        )
+        if learning_validated:
+            errors["learning_validated"] = "Cannot set validated fields when is_validated is false."
+
+        record_type = attrs.get("type", getattr(self.instance, "type", None) if self.instance else None)
+        type_validated = attrs.get(
+            "type_validated",
+            getattr(self.instance, "type_validated", None) if self.instance else None,
+        )
+        if record_type is not None and type_validated is not None and type_validated != record_type:
+            errors["type_validated"] = "Cannot set validated fields when is_validated is false."
+
+        for field_name in self.VALIDATED_M2M_FIELDS:
+            if field_name not in attrs:
+                continue
+            if attrs[field_name]:
+                errors[field_name] = "Cannot set validated fields when is_validated is false."
+
+        if errors:
+            raise serializers.ValidationError(errors)
+        return attrs
 
 
 class PublicOpsLearningSerializer(serializers.ModelSerializer):

--- a/per/test_views.py
+++ b/per/test_views.py
@@ -426,3 +426,38 @@ class OpsLearningCoverageTestCase(APITestCase):
 
         self.assertEqual(result_by_appeal[self.appeal1.code]["counts"], 2)
         self.assertEqual(result_by_appeal[self.appeal1.code]["tagging_status"], "in_progress")
+
+
+class OpsLearningValidationTestCase(APITestCase):
+    def setUp(self):
+        super().setUp()
+        management.call_command("make_permissions")
+        self.sector = SectorTagFactory.create()
+
+    def test_rejects_validated_fields_when_not_validated(self):
+        self.authenticate(self.ifrc_user)
+        response = self.client.post(
+            "/api/v2/ops-learning/",
+            {
+                "learning": "Draft lesson",
+                "is_validated": False,
+                "sector_validated": [self.sector.id],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("sector_validated", response.data)
+
+    def test_allows_validated_fields_when_is_validated(self):
+        self.authenticate(self.ifrc_user)
+        response = self.client.post(
+            "/api/v2/ops-learning/",
+            {
+                "learning": "Validated lesson",
+                "learning_validated": "Validated lesson",
+                "is_validated": True,
+                "sector_validated": [self.sector.id],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201)


### PR DESCRIPTION
## Summary
- Validate `OpsLearningInSerializer` so `*_validated` fields cannot be set when `is_validated` is false
- Matches admin form behaviour (non-validated records only expose draft fields)

## Test plan
- [x] API returns 400 when posting `sector_validated` with `is_validated: false`
- [x] API accepts validated fields when `is_validated: true`
- [ ] Full `per` test module in CI when fork workflows are approved

Fixes #2293

Made with [Cursor](https://cursor.com)