### PR TITLE
feat(per): optional grouped CSV layout for ops-learning export (#2274)

### DIFF
--- a/per/custom_renderers.py
+++ b/per/custom_renderers.py
@@ -13,6 +13,9 @@ class NarrowCSVRenderer(PaginatedCSVRenderer):
     Instead of this we would like to show these in different rows.
     Maybe there is an easier way also to achieve this.
     See also: admin.py::export_selected_records()
+
+    Used when exporting ops-learning CSV with ``?format=csv&csv_layout=narrow`` (default).
+    Use ``csv_layout=grouped`` for the standard wide/flattened CSV layout.
     """
 
     def render(self, data, *args, **kwargs):

--- a/per/drf_views.py
+++ b/per/drf_views.py
@@ -1283,6 +1283,11 @@ class OpsLearningViewset(viewsets.ModelViewSet):
     def get_renderers(self):
         serializer = self.get_serializer()
         if isinstance(serializer, OpsLearningCSVSerializer):
+            layout = self.request.GET.get("csv_layout", "narrow").lower()
+            if layout == "grouped":
+                from rest_framework_csv.renderers import PaginatedCSVRenderer
+
+                return [PaginatedCSVRenderer()]
             return [NarrowCSVRenderer()]
         return [renderer() for renderer in tuple(api_settings.DEFAULT_RENDERER_CLASSES)]
 


### PR DESCRIPTION
## Summary
- Ops-learning CSV export accepts `csv_layout` query parameter on `?format=csv` requests
  - `narrow` (default): existing exploded rows via `NarrowCSVRenderer`
  - `grouped`: standard wide CSV via `PaginatedCSVRenderer`
- Documented parameter in `NarrowCSVRenderer` docstring

## Test plan
- [ ] `GET /api/v2/ops-learning/?format=csv` — narrow layout unchanged
- [ ] `GET /api/v2/ops-learning/?format=csv&csv_layout=grouped` — wide/flattened columns
- [ ] Admin export unchanged

Fixes #2274

Made with [Cursor](https://cursor.com)