### PR TITLE
Fix: Forward scheme header to Django behind Traefik/nginx

### DIFF
--- a/main/nginx.conf
+++ b/main/nginx.conf
@@ -1,3 +1,13 @@
+proxy_headers_hash_max_size 1024;
+proxy_headers_hash_bucket_size 128;
+
+map $http_x_forwarded_proto $django_forwarded_proto {
+    # Traefik -> X-Forwarded-Proto
+    default $http_x_forwarded_proto;
+    # nginx ingress -> X-Forwarded-Scheme
+    ""      $http_x_forwarded_scheme;
+}
+
 server {
     listen 80;
     server_name $NGINX_SERVER_NAME;
@@ -20,7 +30,12 @@ server {
     }
 
     location / {
-        include proxy_params;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # Preserve the original HTTPS scheme from the ingress.
+        proxy_set_header X-Forwarded-Proto $django_forwarded_proto;
+
         proxy_pass http://unix:/home/ifrc/django_app.sock;
     }
 }


### PR DESCRIPTION
## Problem
Staging returned http:// URLs instead of https:// in API responses
(e.g. EAP/DREF template URLs). Django's SECURE_PROXY_SSL_HEADER only
reads X-Forwarded-Proto, but the old config used `include proxy_params;`
which never forwarded that header to gunicorn. Depending on which
ingress sits in front (Traefik sends X-Forwarded-Proto, nginx-ingress
sends X-Forwarded-Scheme), Django never saw the request as HTTPS.

## Solution
Add an nginx map that normalizes whichever header arrives
(X-Forwarded-Proto or X-Forwarded-Scheme) into a single value, and
explicitly set X-Forwarded-Proto on it before proxying to gunicorn.
Works correctly regardless of which proxy terminates TLS upstream.


## Checklist
Things that should succeed before merging.

- [ ] Updated/ran unit tests
- [ ] Updated CHANGELOG.md

## Release

If there is a version update, make sure to tag the repository with the latest version.
